### PR TITLE
Implement automatic `$` prefixed shader props

### DIFF
--- a/examples/index.ts
+++ b/examples/index.ts
@@ -31,9 +31,13 @@ import type { ExampleSettings } from './common/ExampleSettings.js';
 
 (async () => {
   // URL params
+  // - driver: main | threadx (default: threadx)
+  // - test: <test name> (default: test)
+  // - showOverlay: true | false (default: true)
   const urlParams = new URLSearchParams(window.location.search);
   let driverName = urlParams.get('driver');
   const test = urlParams.get('test') || 'test';
+  const showOverlay = urlParams.get('overlay') !== 'false';
 
   if (driverName !== 'main' && driverName !== 'threadx') {
     driverName = 'threadx';
@@ -72,20 +76,22 @@ import type { ExampleSettings } from './common/ExampleSettings.js';
 
   assertTruthy(canvas instanceof HTMLCanvasElement);
 
-  const overlayText = renderer.createTextNode({
-    color: 0xff0000ff,
-    text: `Test: ${test} | Driver: ${driverName}`,
-    zIndex: 99999,
-    parent: renderer.root,
-    fontSize: 50,
-  });
-  overlayText.once(
-    'textLoaded',
-    (target: any, { width, height }: Dimensions) => {
-      overlayText.x = appDimensions.width - width - 20;
-      overlayText.y = appDimensions.height - height - 20;
-    },
-  );
+  if (showOverlay) {
+    const overlayText = renderer.createTextNode({
+      color: 0xff0000ff,
+      text: `Test: ${test} | Driver: ${driverName}`,
+      zIndex: 99999,
+      parent: renderer.root,
+      fontSize: 50,
+    });
+    overlayText.once(
+      'textLoaded',
+      (target: any, { width, height }: Dimensions) => {
+        overlayText.x = appDimensions.width - width - 20;
+        overlayText.y = appDimensions.height - height - 20;
+      },
+    );
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const module = await import(`./tests/${test}.ts`);

--- a/src/core/renderers/CoreShader.ts
+++ b/src/core/renderers/CoreShader.ts
@@ -31,8 +31,11 @@ export abstract class CoreShader {
     return {};
   }
 
-  abstract bindRenderOp(renderOp: CoreRenderOp): void;
-  abstract bindProps(props: Record<string, unknown>): void;
+  abstract bindRenderOp(
+    renderOp: CoreRenderOp,
+    props: Record<string, unknown> | null,
+  ): void;
+  protected abstract bindProps(props: Record<string, unknown>): void;
   abstract attach(): void;
   abstract detach(): void;
 }

--- a/src/core/renderers/webgl/WebGlCoreRenderOp.ts
+++ b/src/core/renderers/webgl/WebGlCoreRenderOp.ts
@@ -73,8 +73,7 @@ export class WebGlCoreRenderOp extends CoreRenderOp {
 
     const { shManager } = options;
     shManager.useShader(shader);
-    shader.bindRenderOp(this);
-    shader.bindProps(shaderProps);
+    shader.bindRenderOp(this, shaderProps);
 
     // TODO: Reduce calculations required
     const quadIdx = (this.bufferIdx / 24) * 6 * 2;

--- a/src/core/renderers/webgl/shaders/SdfShader.ts
+++ b/src/core/renderers/webgl/shaders/SdfShader.ts
@@ -82,7 +82,7 @@ export class SdfShader extends WebGlCoreShader {
     gl.bindTexture(gl.TEXTURE_2D, textures[0]!.ctxTexture);
   }
 
-  override bindProps(props: SdfShaderProps): void {
+  protected override bindProps(props: SdfShaderProps): void {
     const resolvedProps = SdfShader.resolveDefaults(props);
     for (const key in resolvedProps) {
       if (key === 'offset') {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -160,10 +160,10 @@ export function mergeColorAlpha(rgba: number, alpha: number): number {
  * NOTE: This method returns a PREMULTIPLIED alpha color which is generally only useful
  * in the context of the internal rendering process. Use {@link mergeColorAlpha} if you
  * need to blend an alpha value into a color in the context of the Renderer's
- * public API.
+ * main API.
  *
  * @internalRemarks
- * Do not expose this method in the public API because Renderer users should instead use
+ * Do not expose this method in the main API because Renderer users should instead use
  * {@link mergeColorAlpha} to manipulate the alpha value of a color.
  *
  * @internal
@@ -188,4 +188,15 @@ export function mergeColorAlphaPremultiplied(
   }
 
   return ((r << 24) | (g << 16) | (b << 8) | a) >>> 0;
+}
+
+/**
+ * Returns true if the given object has the given "own" property.
+ *
+ * @param obj
+ * @param prop
+ * @returns
+ */
+export function hasOwn(obj: object, prop: string | number | symbol): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, prop);
 }


### PR DESCRIPTION
The `u_dimensions` uniform used by both RoundedRectangleShader and DynamicShader are automatically filled in per quad that is rendered. The way it was done originally makes it difficult for the renderer to tell generally if two consecutive quads that use the same shaders can be batched into the same render operation.

With `$` prefixed automatic shader props, Shaders opt-into using them and simply set their defaults to a compatible type (for `$dimensions` it is simply a Rect). The renderer, during addQuad() will fill our the correct values for automatic shader props prior to rendering.

Shaders now can implement a `canBatchShaderProps()` method to compare two sets of shader props to see if it can be batched into the same render opertion. The default behavior is to return false. Some Shaders like the DynamicShader may opt not to implement this at all if the overhead of comparing the two sets of shader props is too high.

**This is a pre-requisite for Clipping in order to smooth out the logic needed to decide when to spawn a new render op**