### PR TITLE
fix: Update code to make it work on Samsung Tizen 3.5

### DIFF
--- a/src/core/text-rendering/renderers/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/renderers/CanvasTextRenderer.ts
@@ -84,12 +84,18 @@ export interface CanvasTextRendererState extends TextRendererState {
 }
 
 export class CanvasTextRenderer extends TextRenderer<CanvasTextRendererState> {
+  /*
   protected canvas: OffscreenCanvas;
   protected context: OffscreenCanvasRenderingContext2D;
+*/
+  protected canvas: HTMLCanvasElement;
+  protected context: CanvasRenderingContext2D;
 
   constructor(stage: Stage) {
     super(stage);
-    this.canvas = new OffscreenCanvas(0, 0);
+    //this.canvas = new OffscreenCanvas(0, 0);.
+    const canvas = document.createElement('canvas');
+    this.canvas = canvas;
     const context = this.canvas.getContext('2d');
     assertTruthy(context);
     this.context = context;
@@ -273,11 +279,13 @@ export class CanvasTextRenderer extends TextRenderer<CanvasTextRendererState> {
       };
       const renderInfoCalculateTime = performance.now();
       state.renderInfo = state.lightning2TextRenderer.calculateRenderInfo();
+      /*
       console.log(
         'Render info calculated in',
         performance.now() - renderInfoCalculateTime,
         'ms',
       );
+      */
       state.textH = state.renderInfo.lineHeight * state.renderInfo.lines.length;
       state.textW = state.renderInfo.width;
 
@@ -432,7 +440,7 @@ export class CanvasTextRenderer extends TextRenderer<CanvasTextRendererState> {
       }
       pageInfo.valid = true;
     }
-    console.log('pageDrawTime', performance.now() - pageDrawTime, 'ms');
+    //console.log('pageDrawTime', performance.now() - pageDrawTime, 'ms');
 
     // Report final status
     this.setStatus(state, 'loaded');

--- a/src/core/text-rendering/renderers/LightningTextTextureRenderer.ts
+++ b/src/core/text-rendering/renderers/LightningTextTextureRenderer.ts
@@ -126,15 +126,12 @@ export interface RenderInfo {
 }
 
 export class LightningTextTextureRenderer {
-  private _canvas: OffscreenCanvas;
-  private _context: OffscreenCanvasRenderingContext2D;
+  private _canvas: HTMLCanvasElement;
+  private _context: CanvasRenderingContext2D;
   private _settings: Settings;
   private renderInfo: RenderInfo | undefined;
 
-  constructor(
-    canvas: OffscreenCanvas,
-    context: OffscreenCanvasRenderingContext2D,
-  ) {
+  constructor(canvas: HTMLCanvasElement, context: CanvasRenderingContext2D) {
     this._canvas = canvas;
     this._context = context;
     this._settings = this.mergeDefaults({});

--- a/src/main-api/RendererMain.ts
+++ b/src/main-api/RendererMain.ts
@@ -151,11 +151,13 @@ export class RendererMain {
   private nodes: Map<number, INode> = new Map();
   private nextTextureId = 1;
 
+  /*
   private textureRegistry = new FinalizationRegistry(
     (textureDescId: number) => {
       this.driver.releaseTexture(textureDescId);
     },
   );
+  */
 
   /**
    * Constructs a new Renderer instance
@@ -389,7 +391,7 @@ export class RendererMain {
         id,
       },
     };
-    this.textureRegistry.register(desc, id);
+    //this.textureRegistry.register(desc, id);
     return desc;
   }
 


### PR DESCRIPTION
- Removes the use of FinalizationRegistry
- Use a real canvas instead of OffscreenCanvas

Note: Need disable `build.minify` in `vite.config.js`