### PR TITLE
RendererMain: Expose renderer settings

### DIFF
--- a/src/main-api/RendererMain.ts
+++ b/src/main-api/RendererMain.ts
@@ -147,7 +147,7 @@ export class RendererMain {
   readonly root: INode | null = null;
   readonly driver: IRenderDriver;
   private canvas: HTMLCanvasElement;
-  private settings: Required<RendererMainSettings>;
+  readonly settings: Readonly<Required<RendererMainSettings>>;
   private nodes: Map<number, INode> = new Map();
   private nextTextureId = 1;
 


### PR DESCRIPTION
Expose the `settings` object from the RendererMain instance for easy access