### PR TITLE
Replace FinalizationRegistry based Texture Usage GC with Manual Strategy

### DIFF
--- a/examples/common/Character.ts
+++ b/examples/common/Character.ts
@@ -18,10 +18,11 @@
  */
 
 import type {
+  SpecificTextureRef,
   INode,
   INodeWritableProps,
   RendererMain,
-  TextureDesc,
+  TextureRef,
 } from '@lightningjs/renderer';
 import { assertTruthy } from '@lightningjs/renderer/utils';
 
@@ -30,12 +31,12 @@ export class Character {
   curIntervalAnimation: ReturnType<typeof setTimeout> | null = null;
   direction!: 'left' | 'right'; // Set in setState
   state!: 'idle' | 'walk' | 'run' | 'jump'; // Set in setState
-  leftFrames: TextureDesc[] = [];
+  leftFrames: TextureRef[] = [];
 
   constructor(
     private props: Partial<INodeWritableProps>,
     private renderer: RendererMain,
-    private rightFrames: TextureDesc<'SubTexture'>[],
+    private rightFrames: SpecificTextureRef<'SubTexture'>[],
   ) {
     this.node = renderer.createNode({
       x: props.x,
@@ -47,7 +48,7 @@ export class Character {
       zIndex: props.zIndex,
     });
     this.leftFrames = rightFrames.map((frame) => {
-      return renderer.makeTexture('SubTexture', frame.props, {
+      return renderer.createTexture('SubTexture', frame.props, {
         flipX: true,
       });
     });

--- a/examples/common/ExampleSettings.ts
+++ b/examples/common/ExampleSettings.ts
@@ -3,7 +3,6 @@ import type { Dimensions, RendererMain } from '@lightningjs/renderer';
 export interface ExampleSettings {
   testName: string;
   renderer: RendererMain;
-  appDimensions: Dimensions;
   driverName: 'main' | 'threadx';
   canvas: HTMLCanvasElement;
 }

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -34,13 +34,17 @@ import type { ExampleSettings } from './common/ExampleSettings.js';
   // - driver: main | threadx (default: threadx)
   // - test: <test name> (default: test)
   // - showOverlay: true | false (default: true)
+  // - finalizationRegistry: true | false (default: false)
+  //   - Use FinalizationRegistryTextureUsageTracker instead of
+  //     ManualCountTextureUsageTracker
   const urlParams = new URLSearchParams(window.location.search);
   let driverName = urlParams.get('driver');
   const test = urlParams.get('test') || 'test';
   const showOverlay = urlParams.get('overlay') !== 'false';
+  const finalizationRegistry = urlParams.get('finalizationRegistry') === 'true';
 
   if (driverName !== 'main' && driverName !== 'threadx') {
-    driverName = 'threadx';
+    driverName = 'main';
   }
 
   let driver: IRenderDriver | null = null;
@@ -65,6 +69,8 @@ import type { ExampleSettings } from './common/ExampleSettings.js';
       devicePhysicalPixelRatio: 1,
       clearColor: 0x00000000,
       coreExtensionModule: coreExtensionModuleUrl,
+      experimental_FinalizationRegistryTextureUsageTracker:
+        finalizationRegistry,
     },
     'app',
     driver,

--- a/examples/tests/alpha-blending.ts
+++ b/examples/tests/alpha-blending.ts
@@ -37,7 +37,6 @@ interface LocalStorageData {
 export default async function ({
   testName,
   renderer,
-  appDimensions,
   canvas,
 }: ExampleSettings) {
   const savedState = loadStorage<LocalStorageData>(testName);
@@ -55,10 +54,10 @@ export default async function ({
   // the right half of the canvas
   // We will test WebGL -> WebGL alpha over this background
   const rightBackground = renderer.createNode({
-    x: appDimensions.width / 2,
+    x: renderer.settings.appWidth / 2,
     y: 0,
-    width: appDimensions.width / 2,
-    height: appDimensions.height,
+    width: renderer.settings.appWidth / 2,
+    height: renderer.settings.appHeight,
     color: rightSideBg === 'red' ? 0xff0000ff : 0x00ff00ff,
     parent: renderer.root,
     zIndex: 0,
@@ -76,7 +75,7 @@ export default async function ({
     fontSize: HEADER_FONT_SIZE,
     color: 0xffffffff,
     contain: 'width',
-    width: appDimensions.width / 2,
+    width: renderer.settings.appWidth / 2,
     y: PADDING,
     textAlign: 'center',
     parent: renderer.root,
@@ -88,8 +87,8 @@ export default async function ({
     fontSize: HEADER_FONT_SIZE,
     color: 0xffffffff,
     contain: 'width',
-    width: appDimensions.width / 2,
-    x: appDimensions.width / 2,
+    width: renderer.settings.appWidth / 2,
+    x: renderer.settings.appWidth / 2,
     y: PADDING,
     textAlign: 'center',
     parent: renderer.root,
@@ -100,7 +99,7 @@ export default async function ({
     fontSize: 30,
     color: 0xffffffff,
     x: PADDING,
-    y: appDimensions.height - 30 - PADDING,
+    y: renderer.settings.appHeight - 30 - PADDING,
     parent: renderer.root,
   });
 

--- a/examples/tests/animation.ts
+++ b/examples/tests/animation.ts
@@ -19,7 +19,7 @@
 
 import type { ExampleSettings } from '../common/ExampleSettings.js';
 
-export default async function ({ renderer, appDimensions }: ExampleSettings) {
+export default async function ({ renderer }: ExampleSettings) {
   const randomColor = () => {
     const alpha = Math.floor(Math.random() * 256);
     const red = Math.floor(Math.random() * 256);
@@ -57,7 +57,7 @@ export default async function ({ renderer, appDimensions }: ExampleSettings) {
     create(i)
       .animate(
         {
-          x: appDimensions.width + 100,
+          x: renderer.settings.appWidth + 100,
         },
         {
           duration: 4400,
@@ -97,7 +97,7 @@ export default async function ({ renderer, appDimensions }: ExampleSettings) {
     create(2 + i)
       .animate(
         {
-          x: appDimensions.width + 100,
+          x: renderer.settings.appWidth + 100,
         },
         {
           duration: 3400,

--- a/examples/tests/clipping.ts
+++ b/examples/tests/clipping.ts
@@ -24,14 +24,10 @@ import { PageContainer } from '../common/PageContainer.js';
 const SQUARE_SIZE = 200;
 const PADDING = 20;
 
-export default async function ({
-  testName,
-  renderer,
-  appDimensions,
-}: ExampleSettings) {
+export default async function ({ testName, renderer }: ExampleSettings) {
   const pageContainer = new PageContainer(renderer, {
-    width: appDimensions.width,
-    height: appDimensions.height,
+    width: renderer.settings.appWidth,
+    height: renderer.settings.appHeight,
     parent: renderer.root,
     title: 'Clipping Tests',
     testName,

--- a/examples/tests/dynamic-shader.ts
+++ b/examples/tests/dynamic-shader.ts
@@ -26,7 +26,7 @@ export default async function ({ renderer }: ExampleSettings) {
     y: 100,
     width: 250,
     height: 500,
-    shader: renderer.makeShader('DynamicShader', {
+    shader: renderer.createShader('DynamicShader', {
       effects: [
         {
           type: 'radius',
@@ -72,7 +72,7 @@ export default async function ({ renderer }: ExampleSettings) {
     width: 250,
     height: 500,
     color: 0x00ff00ff,
-    shader: renderer.makeShader('DynamicShader', {
+    shader: renderer.createShader('DynamicShader', {
       effects: [
         {
           type: 'borderTop',
@@ -98,7 +98,7 @@ export default async function ({ renderer }: ExampleSettings) {
     y: 100,
     width: 250,
     height: 500,
-    shader: renderer.makeShader('DynamicShader', {
+    shader: renderer.createShader('DynamicShader', {
       effects: [
         {
           type: 'linearGradient',
@@ -128,7 +128,7 @@ export default async function ({ renderer }: ExampleSettings) {
     width: 250,
     height: 500,
     color: 0x0000ffff,
-    shader: renderer.makeShader('DynamicShader', {
+    shader: renderer.createShader('DynamicShader', {
       effects: [
         {
           type: 'borderRight',
@@ -155,7 +155,7 @@ export default async function ({ renderer }: ExampleSettings) {
     width: 250,
     height: 500,
     color: 0xff0000ff,
-    shader: renderer.makeShader('DynamicShader', {
+    shader: renderer.createShader('DynamicShader', {
       effects: [
         {
           type: 'radius',
@@ -181,7 +181,7 @@ export default async function ({ renderer }: ExampleSettings) {
     width: 750,
     height: 250,
     color: 0xff0000ff,
-    shader: renderer.makeShader('DynamicShader', {
+    shader: renderer.createShader('DynamicShader', {
       effects: [
         {
           type: 'radius',

--- a/examples/tests/dynamic-shader.ts
+++ b/examples/tests/dynamic-shader.ts
@@ -205,7 +205,7 @@ export default async function ({ renderer }: ExampleSettings) {
     y: 700,
     width: 750,
     height: 250,
-    shader: renderer.makeShader('DynamicShader', {
+    shader: renderer.createShader('DynamicShader', {
       effects: [
         {
           type: 'radialGradient',

--- a/examples/tests/mount-pivot.ts
+++ b/examples/tests/mount-pivot.ts
@@ -74,7 +74,7 @@ export default async function ({ renderer }: ExampleSettings) {
     colorBottom: randomColor() * 0xffffffaa,
     colorTop: randomColor() * 0xffffffaa,
     parent: renderer.root,
-    shader: renderer.makeShader('RoundedRectangle', {
+    shader: renderer.createShader('RoundedRectangle', {
       radius: rnd(10, 50),
     }),
     mountX,
@@ -90,7 +90,7 @@ export default async function ({ renderer }: ExampleSettings) {
     height: 20,
     color: 0xffffffff,
     parent: node,
-    shader: renderer.makeShader('RoundedRectangle', {
+    shader: renderer.createShader('RoundedRectangle', {
       radius: 10,
     }),
     scale: 1,

--- a/examples/tests/robot.ts
+++ b/examples/tests/robot.ts
@@ -27,7 +27,7 @@ import robotImg from '../assets/robot/robot.png';
 import shadowImg from '../assets/robot/robot-shadow.png';
 import type { ExampleSettings } from '../common/ExampleSettings.js';
 
-export default async function ({ renderer, appDimensions }: ExampleSettings) {
+export default async function ({ renderer }: ExampleSettings) {
   const elevatorBg = renderer.createNode({
     x: 368,
     y: 228,
@@ -71,8 +71,8 @@ export default async function ({ renderer, appDimensions }: ExampleSettings) {
   const environment = renderer.createNode({
     x: 0,
     y: 0,
-    width: appDimensions.width,
-    height: appDimensions.height,
+    width: renderer.settings.appWidth,
+    height: renderer.settings.appHeight,
     zIndex: 3,
     src: environmentImg,
     parent: renderer.root,
@@ -167,7 +167,7 @@ export default async function ({ renderer, appDimensions }: ExampleSettings) {
     shadow.animate({ alpha: 1 }, { duration: 500 }).start();
     await shadow.animate({}, { duration: 2000 }).start().waitUntilStopped();
     await robot
-      .animate({ x: appDimensions.width }, { duration: 5000 })
+      .animate({ x: renderer.settings.appWidth }, { duration: 5000 })
       .start()
       .waitUntilStopped();
     await closeTopDoors(1000);

--- a/examples/tests/rotation.ts
+++ b/examples/tests/rotation.ts
@@ -42,7 +42,7 @@ export default async function ({ renderer }: ExampleSettings) {
       colorBottom: randomColor(),
       colorTop: randomColor(),
       parent: renderer.root,
-      shader: renderer.makeShader('RoundedRectangle', {
+      shader: renderer.createShader('RoundedRectangle', {
         radius: rnd(10, 50),
       }),
       scale: 1,

--- a/examples/tests/scale.ts
+++ b/examples/tests/scale.ts
@@ -42,7 +42,7 @@ export default async function ({ renderer }: ExampleSettings) {
       colorBottom: randomColor(),
       colorTop: randomColor(),
       parent: renderer.root,
-      shader: renderer.makeShader('RoundedRectangle', {
+      shader: renderer.createShader('RoundedRectangle', {
         radius: rnd(10, 50),
       }),
       scale: 1,
@@ -56,7 +56,7 @@ export default async function ({ renderer }: ExampleSettings) {
       height: 20,
       color: 0xffffff55,
       parent: node,
-      // shader: renderer.makeShader('RoundedRectangle', {
+      // shader: renderer.createShader('RoundedRectangle', {
       //   radius: 5,
       // }),
       scale: 1,
@@ -69,7 +69,7 @@ export default async function ({ renderer }: ExampleSettings) {
       height: 16,
       color: 0x000000ff,
       parent: pivotPoint,
-      // shader: renderer.makeShader('RoundedRectangle', {
+      // shader: renderer.createShader('RoundedRectangle', {
       //   radius: 3,
       // }),
     });

--- a/examples/tests/test.ts
+++ b/examples/tests/test.ts
@@ -24,7 +24,7 @@ import spritemap from '../assets/spritemap.png';
 import { Character } from '../common/Character.js';
 import type { ExampleSettings } from '../common/ExampleSettings.js';
 
-export default async function ({ renderer, appDimensions }: ExampleSettings) {
+export default async function ({ renderer }: ExampleSettings) {
   const redRect = renderer.createNode({
     x: 0,
     y: 0,
@@ -73,11 +73,11 @@ export default async function ({ renderer, appDimensions }: ExampleSettings) {
     x: 395,
     y: 0,
     width: 210,
-    height: appDimensions.height,
+    height: renderer.settings.appHeight,
     color: 0xffffffff,
     texture: renderer.createTexture('NoiseTexture', {
       width: 210,
-      height: appDimensions.height,
+      height: renderer.settings.appHeight,
     }),
     parent: renderer.root,
   });
@@ -131,7 +131,7 @@ export default async function ({ renderer, appDimensions }: ExampleSettings) {
 
   const rockoRect = renderer.createNode({
     x: -181,
-    y: appDimensions.height - 218,
+    y: renderer.settings.appHeight - 218,
     width: 181,
     height: 218,
     src: rocko,
@@ -173,7 +173,7 @@ export default async function ({ renderer, appDimensions }: ExampleSettings) {
       'NoiseTexture',
       {
         width: 210,
-        height: appDimensions.height,
+        height: renderer.settings.appHeight,
         cacheId: Math.floor(Math.random() * 100000),
       },
       {
@@ -226,7 +226,7 @@ export default async function ({ renderer, appDimensions }: ExampleSettings) {
       rockoAnimation = rockoRect
         .animate(
           {
-            x: appDimensions.width,
+            x: renderer.settings.appWidth,
             // y: 100,
           },
           {
@@ -238,7 +238,7 @@ export default async function ({ renderer, appDimensions }: ExampleSettings) {
 
       console.log('resetting rocko');
       rockoRect.x = -rockoRect.width;
-      rockoRect.y = appDimensions.height - 218;
+      rockoRect.y = renderer.settings.appHeight - 218;
       rockoRect.flush();
     }
   }, 1000);
@@ -428,8 +428,8 @@ export default async function ({ renderer, appDimensions }: ExampleSettings) {
   });
 
   const noChangeText = renderer.createTextNode({
-    x: appDimensions.width - 300,
-    y: appDimensions.height - 200,
+    x: renderer.settings.appWidth - 300,
+    y: renderer.settings.appHeight - 200,
     width: 300,
     height: 200,
     color: 0xffffffff,

--- a/examples/tests/test.ts
+++ b/examples/tests/test.ts
@@ -31,7 +31,7 @@ export default async function ({ renderer, appDimensions }: ExampleSettings) {
     width: 100,
     height: 100,
     color: 0xff0000ff,
-    shader: renderer.makeShader('RoundedRectangle', {
+    shader: renderer.createShader('RoundedRectangle', {
       radius: 50,
     }),
     parent: renderer.root,
@@ -75,7 +75,7 @@ export default async function ({ renderer, appDimensions }: ExampleSettings) {
     width: 210,
     height: appDimensions.height,
     color: 0xffffffff,
-    texture: renderer.makeTexture('NoiseTexture', {
+    texture: renderer.createTexture('NoiseTexture', {
       width: 210,
       height: appDimensions.height,
     }),
@@ -92,7 +92,7 @@ export default async function ({ renderer, appDimensions }: ExampleSettings) {
     width: 1315,
     height: 50,
     color: 0xaabb66ff,
-    texture: renderer.makeTexture('NoiseTexture', {
+    texture: renderer.createTexture('NoiseTexture', {
       width: 1315,
       height: 50,
     }),
@@ -106,7 +106,7 @@ export default async function ({ renderer, appDimensions }: ExampleSettings) {
     height: 30,
     color: 0xaaedffaa,
     parent: relativePositioningPlatform,
-    texture: renderer.makeTexture('NoiseTexture', {
+    texture: renderer.createTexture('NoiseTexture', {
       width: 1315 - 20,
       height: 30,
     }),
@@ -119,7 +119,7 @@ export default async function ({ renderer, appDimensions }: ExampleSettings) {
     height: 10,
     color: 0xff00ffff,
     parent: relativePositioningChild,
-    texture: renderer.makeTexture('NoiseTexture', {
+    texture: renderer.createTexture('NoiseTexture', {
       width: 1315 - 20 - 20,
       height: 50,
     }),
@@ -168,19 +168,19 @@ export default async function ({ renderer, appDimensions }: ExampleSettings) {
     zIndex: 3,
   });
 
-  // setInterval(() => {
-  //   shaft.texture = renderer.makeTexture(
-  //     'NoiseTexture',
-  //     {
-  //       width: 210,
-  //       height: appDimensions.height,
-  //       cacheId: Math.floor(Math.random() * 100000),
-  //     },
-  //     {
-  //       preload: true,
-  //     },
-  //   );
-  // }, 10);
+  setInterval(() => {
+    shaft.texture = renderer.createTexture(
+      'NoiseTexture',
+      {
+        width: 210,
+        height: appDimensions.height,
+        cacheId: Math.floor(Math.random() * 100000),
+      },
+      {
+        preload: true,
+      },
+    );
+  }, 10);
 
   // setTimeout required for ThreadX right now because the emit() that sends
   // the animation to the renderer worker doesn't work until the Node is fully
@@ -339,14 +339,14 @@ export default async function ({ renderer, appDimensions }: ExampleSettings) {
    * Begin: Sprite Map Demo
    */
 
-  const spriteMapTexture = renderer.makeTexture('ImageTexture', {
+  const spriteMapTexture = renderer.createTexture('ImageTexture', {
     src: spritemap,
   });
 
   const frames = Array.from(Array(8).keys()).map((i) => {
     const x = (i % 8) * 100;
     const y = Math.floor(i / 8) * 150;
-    return renderer.makeTexture('SubTexture', {
+    return renderer.createTexture('SubTexture', {
       texture: spriteMapTexture,
       x,
       y,

--- a/examples/tests/test.ts
+++ b/examples/tests/test.ts
@@ -180,7 +180,7 @@ export default async function ({ renderer }: ExampleSettings) {
         preload: true,
       },
     );
-  }, 10);
+  }, 1000);
 
   // setTimeout required for ThreadX right now because the emit() that sends
   // the animation to the renderer worker doesn't work until the Node is fully

--- a/examples/tests/text-events.ts
+++ b/examples/tests/text-events.ts
@@ -32,11 +32,7 @@ const FONT_SIZE = 60;
 const BUTTON_PADDING = 10;
 const BEGIN_Y = HEADER_SIZE;
 
-export default async function ({
-  renderer,
-  appDimensions,
-  driverName,
-}: ExampleSettings) {
+export default async function ({ renderer, driverName }: ExampleSettings) {
   const header = renderer.createTextNode({
     text: `Text Event Test (${driverName})`,
     fontSize: HEADER_SIZE,
@@ -50,7 +46,7 @@ export default async function ({
     fontSize: 45,
     parent: renderer.root,
     x: 100,
-    y: (appDimensions.height * 1) / 4 - 45 / 2,
+    y: (renderer.settings.appHeight * 1) / 4 - 45 / 2,
   });
 
   const marqueeSdf = new BoxedText(
@@ -67,8 +63,9 @@ export default async function ({
   );
 
   marqueeSdf.on('afterLayout', () => {
-    marqueeSdf.x = appDimensions.width / 2 - marqueeSdf.node.width / 2;
-    marqueeSdf.y = (appDimensions.height * 1) / 4 - marqueeSdf.node.height / 2;
+    marqueeSdf.x = renderer.settings.appWidth / 2 - marqueeSdf.node.width / 2;
+    marqueeSdf.y =
+      (renderer.settings.appHeight * 1) / 4 - marqueeSdf.node.height / 2;
   });
 
   const canvasLabel = renderer.createTextNode({
@@ -76,7 +73,7 @@ export default async function ({
     fontSize: 45,
     parent: renderer.root,
     x: 100,
-    y: (appDimensions.height * 3) / 4 - 45 / 2,
+    y: (renderer.settings.appHeight * 3) / 4 - 45 / 2,
   });
 
   const marqueeCanvas = new BoxedText(
@@ -93,9 +90,10 @@ export default async function ({
   );
 
   marqueeCanvas.on('afterLayout', () => {
-    marqueeCanvas.x = appDimensions.width / 2 - marqueeCanvas.node.width / 2;
+    marqueeCanvas.x =
+      renderer.settings.appWidth / 2 - marqueeCanvas.node.width / 2;
     marqueeCanvas.y =
-      (appDimensions.height * 3) / 4 - marqueeCanvas.node.height / 2;
+      (renderer.settings.appHeight * 3) / 4 - marqueeCanvas.node.height / 2;
   });
 
   const marqueeText = `The following is a test of the textLoaded event...

--- a/examples/tests/text-events.ts
+++ b/examples/tests/text-events.ts
@@ -199,7 +199,7 @@ class BoxedText extends EventEmitter implements BoxedTextProps {
       y: props.y,
       colorTop: props.boxColor1,
       colorBottom: props.boxColor2,
-      shader: renderer.makeShader('RoundedRectangle', {
+      shader: renderer.createShader('RoundedRectangle', {
         radius: 10,
       }),
       parent: props.parent,

--- a/examples/tests/text.ts
+++ b/examples/tests/text.ts
@@ -19,7 +19,6 @@
 
 import {
   type ITextNodeWritableProps,
-  type RendererMain,
   type TextRendererMap,
   type TrFontFaceMap,
 } from '@lightningjs/renderer';
@@ -34,8 +33,6 @@ import {
 const FONT_FAMILY = 'Ubuntu';
 const HEADER_SIZE = 45;
 const FONT_SIZE = 40;
-const BUTTON_PADDING = 10;
-const BEGIN_Y = HEADER_SIZE;
 
 const initialMutableProps: Partial<ITextNodeWritableProps> = {
   x: 0,
@@ -67,11 +64,7 @@ interface LocalStorageData {
 
 const colors = Object.values(Colors);
 
-export default async function ({
-  testName,
-  renderer,
-  appDimensions,
-}: ExampleSettings) {
+export default async function ({ testName, renderer }: ExampleSettings) {
   const savedState = loadStorage<LocalStorageData>(testName);
 
   let curMode = savedState?.curMode || 0;
@@ -93,8 +86,8 @@ export default async function ({
     ...(savedState?.mutableProps || initialMutableProps),
     fontFamily: FONT_FAMILY,
     contain: 'both',
-    width: appDimensions.width,
-    height: appDimensions.height,
+    width: renderer.settings.appWidth,
+    height: renderer.settings.appHeight,
     text,
   };
 
@@ -130,7 +123,7 @@ export default async function ({
   statusNode.on(
     'textLoaded',
     (target: any, dimensions: { width: number; height: number }) => {
-      statusNode.x = appDimensions.width - dimensions.width;
+      statusNode.x = renderer.settings.appWidth - dimensions.width;
     },
   );
 

--- a/examples/tests/texture-memory-stress.ts
+++ b/examples/tests/texture-memory-stress.ts
@@ -1,0 +1,75 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ExampleSettings } from '../common/ExampleSettings.js';
+
+export default async function ({ renderer, appDimensions }: ExampleSettings) {
+  const screen = renderer.createNode({
+    x: 0,
+    y: 0,
+    width: appDimensions.width,
+    height: appDimensions.height,
+    parent: renderer.root,
+    color: 0xff00ffff,
+  });
+
+  renderer.createTextNode({
+    x: 0,
+    y: 0,
+    text: 'Texture Memory Stress Test',
+    parent: screen,
+    fontFamily: 'Ubuntu',
+    fontSize: 60,
+  });
+
+  renderer.createTextNode({
+    x: 0,
+    y: 100,
+    width: appDimensions.width,
+    contain: 'width',
+    text: `This test will create and display a random texture every 10ms.
+
+To test that the textures are being properly disposed of, you can use the Chrome Task Manager to monitor the GPU's memory usage:
+
+1. Click Window > Task Manager
+2. Locate the "GPU Process"
+3. Observe the "Memory Footprint" column
+4. The value should remain relatively constant, with occasional spikes as new textures are created and disposed of.
+
+By default, the ManualCountTextureUsageTracker is used to track texture usage. To test the experimental FinalizationRegistryTextureUsageTracker instead, set the URL param "finalizationRegistry=true".
+    `,
+    parent: screen,
+    fontFamily: 'Ubuntu',
+    fontSize: 40,
+  });
+
+  // Create a new random texture every 10ms
+  setInterval(() => {
+    screen.texture = renderer.createTexture(
+      'NoiseTexture',
+      {
+        width: 500,
+        height: 500,
+        cacheId: Math.floor(Math.random() * 100000),
+      },
+      {
+        preload: true,
+      },
+    );
+  }, 10);
+}

--- a/examples/tests/texture-memory-stress.ts
+++ b/examples/tests/texture-memory-stress.ts
@@ -16,14 +16,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { RendererMainSettings } from '../../dist/exports/main-api.js';
 import type { ExampleSettings } from '../common/ExampleSettings.js';
 
-export default async function ({ renderer, appDimensions }: ExampleSettings) {
+export function customSettings(
+  urlParams: URLSearchParams,
+): Partial<RendererMainSettings> {
+  const finalizationRegistry = urlParams.get('finalizationRegistry') === 'true';
+  return {
+    textureCleanupOptions: {
+      textureCleanupAgeThreadholdMs: 6000,
+      textureCleanupIntervalMs: 1000,
+    },
+    experimental_FinalizationRegistryTextureUsageTracker: finalizationRegistry,
+  };
+}
+
+export default async function ({ renderer }: ExampleSettings) {
   const screen = renderer.createNode({
     x: 0,
     y: 0,
-    width: appDimensions.width,
-    height: appDimensions.height,
+    width: renderer.settings.appWidth,
+    height: renderer.settings.appHeight,
     parent: renderer.root,
     color: 0xff00ffff,
   });
@@ -40,7 +54,7 @@ export default async function ({ renderer, appDimensions }: ExampleSettings) {
   renderer.createTextNode({
     x: 0,
     y: 100,
-    width: appDimensions.width,
+    width: renderer.settings.appWidth,
     contain: 'width',
     text: `This test will create and display a random texture every 10ms.
 
@@ -49,9 +63,10 @@ To test that the textures are being properly disposed of, you can use the Chrome
 1. Click Window > Task Manager
 2. Locate the "GPU Process"
 3. Observe the "Memory Footprint" column
-4. The value should remain relatively constant, with occasional spikes as new textures are created and disposed of.
+4. The value should eventually drop significantly toward a minimum and/or reach a
+threadhold.
 
-By default, the ManualCountTextureUsageTracker is used to track texture usage. To test the experimental FinalizationRegistryTextureUsageTracker instead, set the URL param "finalizationRegistry=true".
+By default, the ManualCountTextureUsageTracker is used to track texture usage. Also test the experimental FinalizationRegistryTextureUsageTracker instead, by setting the URL param "finalizationRegistry=true".
     `,
     parent: screen,
     fontFamily: 'Ubuntu',

--- a/examples/tests/textures.ts
+++ b/examples/tests/textures.ts
@@ -97,7 +97,7 @@ export default async function ({
   curX = appDimensions.width / 2;
   curY = BEGIN_Y;
 
-  const noiseTexture = renderer.makeTexture('NoiseTexture', {
+  const noiseTexture = renderer.createTexture('NoiseTexture', {
     width: 100,
     height: 100,
   });
@@ -122,14 +122,14 @@ export default async function ({
   await execLoadingTest(noise2, 100, 100);
 
   // Test: SubTexture Load
-  const spriteMapTexture = renderer.makeTexture('ImageTexture', {
+  const spriteMapTexture = renderer.createTexture('ImageTexture', {
     src: spritemap,
   });
 
   const frames = Array.from(Array(32).keys()).map((i) => {
     const x = (i % 8) * 100;
     const y = Math.floor(i / 8) * 150;
-    return renderer.makeTexture('SubTexture', {
+    return renderer.createTexture('SubTexture', {
       texture: spriteMapTexture,
       x,
       y,
@@ -158,14 +158,14 @@ export default async function ({
   await execLoadingTest(subTextureNode2, 100, 150);
 
   // Test: SubTetxure Failure
-  const failureTexture = renderer.makeTexture('ImageTexture', {
+  const failureTexture = renderer.createTexture('ImageTexture', {
     src: 'does-not-exist.png',
   });
 
   const failureFrames = Array.from(Array(32).keys()).map((i) => {
     const x = (i % 8) * 120;
     const y = Math.floor(i / 8) * 120;
-    return renderer.makeTexture('SubTexture', {
+    return renderer.createTexture('SubTexture', {
       texture: failureTexture,
       x,
       y,

--- a/examples/tests/textures.ts
+++ b/examples/tests/textures.ts
@@ -23,11 +23,7 @@ import elevatorImg from '../assets/elevator.png';
 import spritemap from '../assets/spritemap.png';
 import type { ExampleSettings } from '../common/ExampleSettings.js';
 
-export default async function ({
-  renderer,
-  appDimensions,
-  driverName,
-}: ExampleSettings) {
+export default async function ({ renderer, driverName }: ExampleSettings) {
   const FONT_SIZE = 45;
   const BEGIN_Y = FONT_SIZE;
 
@@ -94,7 +90,7 @@ export default async function ({
 
   // Test: NoiseTexture
 
-  curX = appDimensions.width / 2;
+  curX = renderer.settings.appWidth / 2;
   curY = BEGIN_Y;
 
   const noiseTexture = renderer.createTexture('NoiseTexture', {

--- a/examples/tests/zIndex.ts
+++ b/examples/tests/zIndex.ts
@@ -26,7 +26,7 @@ export default async function ({ renderer }: ExampleSettings) {
     width: 200,
     height: 200,
     color: 0xaabb66ff,
-    shader: renderer.makeShader('RoundedRectangle', {
+    shader: renderer.createShader('RoundedRectangle', {
       radius: 40,
     }),
     zIndex: 1,
@@ -39,7 +39,7 @@ export default async function ({ renderer }: ExampleSettings) {
     width: 200,
     height: 200,
     color: 0xffaaee00,
-    shader: renderer.makeShader('RoundedRectangle', {
+    shader: renderer.createShader('RoundedRectangle', {
       radius: 40,
     }),
     zIndex: 3,
@@ -52,7 +52,7 @@ export default async function ({ renderer }: ExampleSettings) {
     width: 200,
     height: 200,
     color: 0x0000ffff,
-    shader: renderer.makeShader('RoundedRectangle', {
+    shader: renderer.createShader('RoundedRectangle', {
       radius: 40,
     }),
     zIndex: 4,
@@ -65,7 +65,7 @@ export default async function ({ renderer }: ExampleSettings) {
     width: 600,
     height: 600,
     color: 0xaabb66ff,
-    // shader: renderer.makeShader('RoundedRectangle', {
+    // shader: renderer.createShader('RoundedRectangle', {
     //   radius: 40,
     // }),
     zIndex: 2,
@@ -79,7 +79,7 @@ export default async function ({ renderer }: ExampleSettings) {
     width: 200,
     height: 200,
     color: 0xffaaee00,
-    // shader: renderer.makeShader('RoundedRectangle', {
+    // shader: renderer.createShader('RoundedRectangle', {
     //   radius: 40,
     // }),
     zIndex: 4,
@@ -92,7 +92,7 @@ export default async function ({ renderer }: ExampleSettings) {
     width: 200,
     height: 200,
     color: 0x0000ffff,
-    // shader: renderer.makeShader('RoundedRectangle', {
+    // shader: renderer.createShader('RoundedRectangle', {
     //   radius: 40,
     // }),
     zIndex: 5,
@@ -105,7 +105,7 @@ export default async function ({ renderer }: ExampleSettings) {
     width: 1600,
     height: 800,
     color: 0x00ffffff,
-    // shader: renderer.makeShader('RoundedRectangle', {
+    // shader: renderer.createShader('RoundedRectangle', {
     //   radius: 40,
     // }),
     zIndex: 0,
@@ -146,7 +146,7 @@ export default async function ({ renderer }: ExampleSettings) {
     width: 10,
     height: 10,
     color: 0x00ffffff,
-    shader: renderer.makeShader('RoundedRectangle', {
+    shader: renderer.createShader('RoundedRectangle', {
       radius: 2,
     }),
     // eslint-disable-next-line  @typescript-eslint/no-loss-of-precision
@@ -162,7 +162,7 @@ export default async function ({ renderer }: ExampleSettings) {
     width: 10,
     height: 10,
     color: 0x00ffffff,
-    shader: renderer.makeShader('RoundedRectangle', {
+    shader: renderer.createShader('RoundedRectangle', {
       radius: 2,
     }),
     // eslint-disable-next-line  @typescript-eslint/no-loss-of-precision
@@ -178,7 +178,7 @@ export default async function ({ renderer }: ExampleSettings) {
     width: 10,
     height: 10,
     color: 0x00ffffff,
-    shader: renderer.makeShader('RoundedRectangle', {
+    shader: renderer.createShader('RoundedRectangle', {
       radius: 2,
     }),
     // @ts-expect-error Invalid prop test
@@ -194,7 +194,7 @@ export default async function ({ renderer }: ExampleSettings) {
     width: 10,
     height: 10,
     color: 0x00ffffff,
-    shader: renderer.makeShader('RoundedRectangle', {
+    shader: renderer.createShader('RoundedRectangle', {
       radius: 2,
     }),
     // @ts-expect-error Invalid prop test
@@ -210,7 +210,7 @@ export default async function ({ renderer }: ExampleSettings) {
     width: 10,
     height: 10,
     color: 0x00ffffff,
-    shader: renderer.makeShader('RoundedRectangle', {
+    shader: renderer.createShader('RoundedRectangle', {
       radius: 2,
     }),
     // @ts-expect-error Invalid prop test
@@ -226,7 +226,7 @@ export default async function ({ renderer }: ExampleSettings) {
     width: 10,
     height: 10,
     color: 0x00ffffff,
-    shader: renderer.makeShader('RoundedRectangle', {
+    shader: renderer.createShader('RoundedRectangle', {
       radius: 2,
     }),
     zIndex: undefined,
@@ -240,7 +240,7 @@ export default async function ({ renderer }: ExampleSettings) {
     width: 10,
     height: 10,
     color: 0x00ffffff,
-    shader: renderer.makeShader('RoundedRectangle', {
+    shader: renderer.createShader('RoundedRectangle', {
       radius: 2,
     }),
     // @ts-expect-error Invalid prop test
@@ -258,7 +258,7 @@ export default async function ({ renderer }: ExampleSettings) {
     width: 10,
     height: 10,
     color: 0x00ffffff,
-    shader: renderer.makeShader('RoundedRectangle', {
+    shader: renderer.createShader('RoundedRectangle', {
       radius: 2,
     }),
     // @ts-expect-error Invalid prop test

--- a/src/core/CoreTextureManager.ts
+++ b/src/core/CoreTextureManager.ts
@@ -245,9 +245,10 @@ export class CoreTextureManager {
    * Remove a `Texture` from the texture cache by its texture desc ID
    *
    * @remarks
-   * This is called externally by when we know that the `TextureDesc` has been
-   * garbage collected. This allows us to remove the `Texture` from the cache
-   * so that it can be garbage collected as well.
+   * This is called externally by when we know (at least reasonably well) that
+   * the `TextureRef` in the Main API space has been is no longer used. This
+   * allows us to remove the `Texture` from the Usage Cache so that it can be
+   * garbage collected as well.
    *
    * @param textureDescId
    */
@@ -255,9 +256,9 @@ export class CoreTextureManager {
     const { textureIdCache, textureRefCountMap } = this;
     const texture = textureIdCache.get(textureDescId);
     if (!texture) {
-      throw new Error(
-        `Texture ID ${textureDescId} is not in the texture ID cache`,
-      );
+      // Sometimes a texture is removed from the cache before it ever gets
+      // added to the cache. This is fine and not an error.
+      return;
     }
     textureIdCache.delete(textureDescId);
     if (textureRefCountMap.has(texture)) {

--- a/src/core/renderers/webgl/shaders/DynamicShader.ts
+++ b/src/core/renderers/webgl/shaders/DynamicShader.ts
@@ -70,7 +70,7 @@ import { FadeOutEffect } from './effects/FadeOutEffect.js';
  * field.
  */
 type MapEffectDescs<T extends keyof EffectMap> = T extends keyof EffectMap
-  ? GenericEffectDesc<T>
+  ? SpecificEffectDesc<T>
   : never;
 
 type EffectDesc = MapEffectDescs<keyof EffectMap>;
@@ -105,7 +105,7 @@ const Effects = {
   glitch: GlitchEffect,
 };
 
-export interface GenericEffectDesc<
+export interface SpecificEffectDesc<
   FxType extends keyof EffectMap = keyof EffectMap,
 > {
   type: FxType;

--- a/src/core/renderers/webgl/shaders/DynamicShader.ts
+++ b/src/core/renderers/webgl/shaders/DynamicShader.ts
@@ -37,6 +37,44 @@ import { BorderLeftEffect } from './effects/BorderLeftEffect.js';
 import { GlitchEffect } from './effects/GlitchEffect.js';
 import { FadeOutEffect } from './effects/FadeOutEffect.js';
 
+/**
+ * Allows the `keyof EffectMap` to be mapped over and form an discriminated
+ * union of all the EffectDescs structures individually.
+ *
+ * @remarks
+ * When used like the following:
+ * ```
+ * MapEffectDescs<keyof EffectMap>[]
+ * ```
+ * The resultant type will be a discriminated union like so:
+ * ```
+ * (
+ *   {
+ *     type: 'radius',
+ *     props?: {
+ *       radius?: number | number[];
+ *     }
+ *   } |
+ *   {
+ *     type: 'border',
+ *     props?: {
+ *       width?: number;
+ *       color?: number;
+ *     }
+ *   } |
+ *   // ...
+ * )[]
+ * ```
+ * Which means TypeScript will now base its type checking on the `type` field
+ * and will know exactly what the `props` field should be based on the `type`
+ * field.
+ */
+type MapEffectDescs<T extends keyof EffectMap> = T extends keyof EffectMap
+  ? GenericEffectDesc<T>
+  : never;
+
+type EffectDesc = MapEffectDescs<keyof EffectMap>;
+
 export interface DynamicShaderProps extends DimensionsShaderProp {
   effects?: EffectDesc[];
 }
@@ -67,7 +105,9 @@ const Effects = {
   glitch: GlitchEffect,
 };
 
-export interface EffectDesc<FxType extends keyof EffectMap = keyof EffectMap> {
+export interface GenericEffectDesc<
+  FxType extends keyof EffectMap = keyof EffectMap,
+> {
   type: FxType;
   props?: ExtractProps<EffectMap[FxType]>;
 }
@@ -319,7 +359,7 @@ export class DynamicShader extends WebGlCoreShader {
       effects: (props.effects ?? []).map((effect) => ({
         type: effect.type,
         props: Effects[effect.type].resolveDefaults(effect.props || {}),
-      })),
+      })) as MapEffectDescs<keyof EffectMap>[],
       $dimensions: {
         width: 0,
         height: 0,

--- a/src/core/textures/SubTexture.ts
+++ b/src/core/textures/SubTexture.ts
@@ -21,7 +21,7 @@ import type {
   TextureFailedEventHandler,
   TextureLoadedEventHandler,
 } from '../../common/CommonTypes.js';
-import type { TextureDesc } from '../../main-api/RendererMain.js';
+import type { TextureRef } from '../../main-api/RendererMain.js';
 import type { CoreTextureManager } from '../CoreTextureManager.js';
 import { Texture } from './Texture.js';
 
@@ -32,7 +32,7 @@ export interface SubTextureProps {
   /**
    * The texture that this sub-texture is a sub-region of.
    */
-  texture: TextureDesc;
+  texture: TextureRef;
 
   /**
    * The x pixel position of the top-left of the sub-texture within the parent

--- a/src/main-api/INode.ts
+++ b/src/main-api/INode.ts
@@ -19,7 +19,7 @@
 
 import type { IEventEmitter } from '@lightningjs/threadx';
 import type { IAnimationController } from '../common/IAnimationController.js';
-import type { ShaderDesc, TextureDesc } from './RendererMain.js';
+import type { ShaderRef, TextureRef } from './RendererMain.js';
 import type {
   TextRendererMap,
   TrProps,
@@ -206,7 +206,7 @@ export interface INodeWritableProps {
    * and TBD properties.
    *
    * To create a Texture in order to set it on this property, call
-   * {@link RendererMain.makeTexture}.
+   * {@link RendererMain.createTexture}.
    *
    * If the {@link src} is set on a Node, the Node will use the
    * {@link ImageTexture} by default and the Node will simply load the image at
@@ -215,7 +215,7 @@ export interface INodeWritableProps {
    * Note: If this is a Text Node, the Texture will be managed by the Node's
    * {@link TextRenderer} and should not be set explicitly.
    */
-  texture: TextureDesc | null;
+  texture: TextureRef | null;
   /**
    * The Node's shader
    *
@@ -225,12 +225,12 @@ export interface INodeWritableProps {
    * or {@link color}(s) within the Node without any special effects.
    *
    * To create a Shader in order to set it on this property, call
-   * {@link RendererMain.makeShader}.
+   * {@link RendererMain.createShader}.
    *
    * Note: If this is a Text Node, the Shader will be managed by the Node's
    * {@link TextRenderer} and should not be set explicitly.
    */
-  shader: ShaderDesc | null;
+  shader: ShaderRef | null;
   /**
    * Image URL
    *

--- a/src/main-api/texture-usage-trackers/FinalizationRegistryTextureUsageTracker.ts
+++ b/src/main-api/texture-usage-trackers/FinalizationRegistryTextureUsageTracker.ts
@@ -1,0 +1,45 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assertTruthy } from '../../utils.js';
+import type { TextureRef } from '../RendererMain.js';
+import { TextureUsageTracker } from './TextureUsageTracker.js';
+
+export class FinalizationRegistryTextureUsageTracker extends TextureUsageTracker {
+  private registry: FinalizationRegistry<number>;
+
+  constructor(releaseCallback: (textureDescId: number) => void) {
+    super(releaseCallback);
+    this.registry = new FinalizationRegistry(releaseCallback);
+  }
+
+  override registerTexture(texture: TextureRef): void {
+    assertTruthy(
+      texture.options?.id,
+      'Texture must have an ID to be registered',
+    );
+    this.registry.register(texture, texture.options?.id);
+  }
+  override incrementTextureRefCount(): void {
+    // No-op for FinalizationRegistry
+  }
+  override decrementTextureRefCount(): void {
+    // No-op for FinalizationRegistry
+  }
+}

--- a/src/main-api/texture-usage-trackers/ManualCountTextureUsageTracker.ts
+++ b/src/main-api/texture-usage-trackers/ManualCountTextureUsageTracker.ts
@@ -1,0 +1,154 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assertTruthy } from '../../utils.js';
+import type { TextureRef } from '../RendererMain.js';
+import { TextureUsageTracker } from './TextureUsageTracker.js';
+
+interface TextureRefInfo {
+  /**
+   * Texture Reference ID
+   */
+  id: number;
+  /**
+   * The number of references to this texture that are currently assigned to
+   * Nodes.
+   */
+  nodeRefCount: number;
+  /**
+   * The last time the texture reference count was updated.
+   *
+   * @remarks
+   * This is used to determine when a texture is no longer referenced by any
+   * Nodes and can be removed from the GPU.
+   */
+  lastUpdate: number;
+}
+
+export interface ManualCountTextureUsageTrackerOptions {
+  /**
+   * The interval at which to check if textures that are no longer referenced
+   * by any Nodes can be released from the Core Space Texture Usage Cache.
+   *
+   * @remarks
+   * Only valid when the {@link ManualCountTextureUsageTracker} is used.
+   *
+   * @defaultValue 10000 (10 seconds)
+   */
+  textureCleanupIntervalMs?: number;
+  /**
+   * The age at which a texture is considered to be no longer referenced by any
+   * Nodes and can be released from the Core Space Texture Usage Cache.
+   *
+   * @remarks
+   * Only valid when the {@link ManualCountTextureUsageTracker} is used.
+   *
+   * @defaultValue 60000 (1 minute)
+   */
+  textureCleanupAgeThreadholdMs?: number;
+}
+
+/**
+ * Usage-based Texture Garbage Collection Registry
+ */
+export class ManualCountTextureUsageTracker extends TextureUsageTracker {
+  textureMap: Map<number, TextureRefInfo> = new Map();
+  zeroReferenceTextureSet: Set<TextureRefInfo> = new Set();
+  options: Required<ManualCountTextureUsageTrackerOptions>;
+
+  constructor(
+    releaseCallback: (textureDescId: number) => void,
+    options: ManualCountTextureUsageTrackerOptions,
+  ) {
+    super(releaseCallback);
+    this.options = {
+      textureCleanupIntervalMs: options.textureCleanupIntervalMs ?? 10000,
+      textureCleanupAgeThreadholdMs:
+        options.textureCleanupAgeThreadholdMs ?? 60000,
+    };
+    // Periodically check for textures that are no longer referenced by any
+    // Nodes and notify RendererMain to release them.
+    setInterval(() => {
+      const now = Date.now();
+      const thresholdMs = this.options.textureCleanupAgeThreadholdMs;
+      for (const textureRefInfo of this.zeroReferenceTextureSet) {
+        if (now - textureRefInfo.lastUpdate > thresholdMs) {
+          this.releaseCallback(textureRefInfo.id);
+          this.textureMap.delete(textureRefInfo.id);
+          this.zeroReferenceTextureSet.delete(textureRefInfo);
+        }
+      }
+    }, this.options.textureCleanupIntervalMs);
+  }
+
+  registerTexture(texture: TextureRef) {
+    const textureId = texture.options?.id;
+    assertTruthy(textureId, 'Texture must have an id to be registered');
+    if (!this.textureMap.has(textureId)) {
+      const textureRefInfo: TextureRefInfo = {
+        id: textureId,
+        nodeRefCount: 0,
+        lastUpdate: Date.now(),
+      };
+      this.textureMap.set(textureId, textureRefInfo);
+      this.zeroReferenceTextureSet.add(textureRefInfo);
+    }
+  }
+
+  incrementTextureRefCount(texture: TextureRef) {
+    const textureId = texture.options?.id;
+    assertTruthy(textureId, 'Texture must have an id to be registered');
+    let textureRefInfo = this.textureMap.get(textureId);
+    if (!textureRefInfo) {
+      // Texture has not been registered yet, so register it now.
+      // This may happen if the TextureRef was cleaned up from the registry
+      // but was still alive in memory and eventually re-used.
+      this.registerTexture(texture);
+      textureRefInfo = this.textureMap.get(textureId);
+    }
+    assertTruthy(textureRefInfo, 'Texture must have been registered');
+    if (texture.txType === 'SubTexture') {
+      // If this is a SubTexture, then increment the reference count of the
+      // parent texture as well.
+      this.incrementTextureRefCount(texture.props.texture);
+    }
+    textureRefInfo.nodeRefCount++;
+    textureRefInfo.lastUpdate = Date.now();
+    if (this.zeroReferenceTextureSet.has(textureRefInfo)) {
+      this.zeroReferenceTextureSet.delete(textureRefInfo);
+    }
+  }
+
+  decrementTextureRefCount(texture: TextureRef) {
+    const textureId = texture.options?.id;
+    assertTruthy(textureId, 'Texture must have an id to be registered');
+    const textureRefInfo = this.textureMap.get(textureId);
+    assertTruthy(textureRefInfo, 'Texture must have been registered');
+    textureRefInfo.nodeRefCount--;
+    textureRefInfo.lastUpdate = Date.now();
+    if (textureRefInfo.nodeRefCount === 0) {
+      this.zeroReferenceTextureSet.add(textureRefInfo);
+    }
+    if (texture.txType === 'SubTexture') {
+      // If this is a SubTexture, then decrement the reference count of the
+      // parent texture as well.
+      this.decrementTextureRefCount(texture.props.texture);
+    }
+  }
+}

--- a/src/main-api/texture-usage-trackers/TextureUsageTracker.ts
+++ b/src/main-api/texture-usage-trackers/TextureUsageTracker.ts
@@ -1,0 +1,54 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { TextureRef } from '../RendererMain.js';
+
+/**
+ * Texture Usage Tracker for Usage Based Texture Garbage Collection
+ */
+export abstract class TextureUsageTracker {
+  constructor(protected releaseCallback: (textureDescId: number) => void) {}
+
+  /**
+   * Register a texture with the tracker.
+   *
+   * @param texture
+   */
+  abstract registerTexture(texture: TextureRef): void;
+
+  /**
+   * Increment the reference count for a texture.
+   *
+   * @remarks
+   * This should be called anytime a Node sets a new texture.
+   *
+   * @param texture
+   */
+  abstract incrementTextureRefCount(texture: TextureRef): void;
+
+  /**
+   * Decrement the Node reference count for a texture.
+   *
+   * @remarks
+   * This should be called anytime a Node removes a texture.
+   *
+   * @param texture
+   */
+  abstract decrementTextureRefCount(texture: TextureRef): void;
+}

--- a/src/render-drivers/threadx/worker/ThreadXRendererNode.ts
+++ b/src/render-drivers/threadx/worker/ThreadXRendererNode.ts
@@ -28,10 +28,7 @@ import { CoreAnimation } from '../../../core/animations/CoreAnimation.js';
 import { CoreAnimationController } from '../../../core/animations/CoreAnimationController.js';
 import type { Texture } from '../../../core/textures/Texture.js';
 import { CoreNode } from '../../../core/CoreNode.js';
-import type {
-  ShaderDesc,
-  TextureDesc,
-} from '../../../main-api/RendererMain.js';
+import type { ShaderRef, TextureRef } from '../../../main-api/RendererMain.js';
 import type { IAnimationSettings } from '../../../core/animations/CoreAnimation.js';
 import type { Dimensions } from '../../../common/CommonTypes.js';
 
@@ -112,19 +109,18 @@ export class ThreadXRendererNode extends SharedNode {
     });
     this.on(
       'loadTexture',
-      (target: ThreadXRendererNode, textureDesc: TextureDesc) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
+      (target: ThreadXRendererNode, textureDesc: TextureRef) => {
         this.coreNode.loadTexture(
           textureDesc.txType,
-          textureDesc.props as any,
+          textureDesc.props,
           textureDesc.options,
         );
       },
     );
     this.on(
       'loadShader',
-      (target: ThreadXRendererNode, shaderDesc: ShaderDesc) => {
-        this.coreNode.loadShader(shaderDesc.shType, shaderDesc.props as any);
+      (target: ThreadXRendererNode, shaderDesc: ShaderRef) => {
+        this.coreNode.loadShader(shaderDesc.shType, shaderDesc.props);
       },
     );
     this.on('unloadTexture', (target: ThreadXRendererNode) => {


### PR DESCRIPTION
- Usaged-Based Texture Memory management now defaults to a new manual reference count and time threshold strategy.
  - This removes the requirement of the FinalizationRegistry browser feature which is not available prior to chrome 84 / WPE 2.38. 
  - The prior behavior is still available by setting a new experimental renderer setting to `true`:
    - `experimental_FinalizationRegistryTextureUsageTracker`
- Added `texture-memory-stress` test with instructions on how to perform.
- Example tests may now export a `customSettings` function which returns any renderer settings overrides that the test requires to run. These settings are applied on top of all of the defaults specified by the example test launcher.
- Improve type checking for EffectDesc
  - `type` now determines the specific properties types checked.
- **Breaking changes:**
  - Refactor ShaderDesc / TextureDesc related areas including change their names to ShaderRef / TextureRef.
    - RendererMain.makeTexture renamed to RendererMain.createTexture
    - RendererMain.makeShader renamed to RendererMain.createShader
    - TextureDesc type renamed to TextureRef type
    - ShaderDesc type renamed to ShaderRef type
