### PR TITLE
include src files for sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   },
   "files": [
     "dist",
+    "src",
     "LICENSE",
     "NOTICE",
     "README.md"


### PR DESCRIPTION
I've tested this locally and it fixes the issue where sourcemaps aren't found cause they are looking for the originally TS files which aren't in the dist directory