### PR TITLE
Update ThreadX to v0.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@lightningjs/threadx": "^0.3.1",
+        "@lightningjs/threadx": "^0.3.3",
         "@protobufjs/eventemitter": "^1.1.0"
       },
       "devDependencies": {
@@ -508,9 +508,9 @@
       "dev": true
     },
     "node_modules/@lightningjs/threadx": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@lightningjs/threadx/-/threadx-0.3.1.tgz",
-      "integrity": "sha512-BLO5R9Lpl8kFRlWXWH+Jb5Mxgb5Qu8S8xEIkDv3x9LOSksnINN5ae1nBpkSm2EBPEpZCBs9IYsfcztlq+gpPog=="
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@lightningjs/threadx/-/threadx-0.3.3.tgz",
+      "integrity": "sha512-cctepz1aYBjfT0y0vx4KknT89DowbYyu158IxPszuzVXB4J0FfuBoBNx923FKiNXBGcVc7CnyWEJ9sNMatUhCQ=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "vitest": "^0.34.2"
   },
   "dependencies": {
-    "@lightningjs/threadx": "^0.3.1",
+    "@lightningjs/threadx": "^0.3.3",
     "@protobufjs/eventemitter": "^1.1.0"
   },
   "lint-staged": {


### PR DESCRIPTION
- Fixes a Vite error that users of the Renderer experienced due to missing source maps