### PR TITLE
Include `exports` files for SourceMaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "files": [
     "dist",
     "src",
+    "exports",
     "LICENSE",
     "NOTICE",
     "README.md"


### PR DESCRIPTION
- Fixes all remaining Vite sourcemap errors that users of the Renderer experienced