### PR TITLE
FIX: Offscreen Canvas context is not available

### DIFF
--- a/src/core/text-rendering/renderers/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/renderers/CanvasTextRenderer.ts
@@ -101,6 +101,7 @@ export class CanvasTextRenderer extends TextRenderer<CanvasTextRendererState> {
     if (!context) {
       // A browser may appear to support OffscreenCanvas but not actually support the Canvas '2d' context
       // Here we try getting the context again after falling back to an HTMLCanvasElement.
+      // See: https://github.com/lightning-js/renderer/issues/26#issuecomment-1750438486
       this.canvas = document.createElement('canvas');
       context = this.canvas.getContext('2d');
     }

--- a/src/core/text-rendering/renderers/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/renderers/CanvasTextRenderer.ts
@@ -97,7 +97,11 @@ export class CanvasTextRenderer extends TextRenderer<CanvasTextRendererState> {
     } else {
       this.canvas = document.createElement('canvas');
     }
-    const context = this.canvas.getContext('2d');
+    let context = this.canvas.getContext('2d');
+    if (!context) {
+      this.canvas = document.createElement('canvas');
+      context = this.canvas.getContext('2d');
+    }
     assertTruthy(context);
     this.context = context;
   }

--- a/src/core/text-rendering/renderers/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/renderers/CanvasTextRenderer.ts
@@ -99,6 +99,8 @@ export class CanvasTextRenderer extends TextRenderer<CanvasTextRendererState> {
     }
     let context = this.canvas.getContext('2d');
     if (!context) {
+      // A browser may appear to support OffscreenCanvas but not actually support the Canvas '2d' context
+      // Here we try getting the context again after falling back to an HTMLCanvasElement.
       this.canvas = document.createElement('canvas');
       context = this.canvas.getContext('2d');
     }


### PR DESCRIPTION
This PR aims to solve [this issue](https://github.com/lightning-js/renderer/issues/26#issuecomment-1750438486).
Solution: If the `OffscreenCanvas` is available but it's `context` is not, the code falls back to using `HTMLCanvasElement` and it's context.