### PR TITLE
Refactor Effects + changes

### DIFF
--- a/examples/tests/dynamic-shader.ts
+++ b/examples/tests/dynamic-shader.ts
@@ -21,6 +21,10 @@ import type { ExampleSettings } from '../common/ExampleSettings.js';
 import robot from '../assets/robot/robot.png';
 
 export default async function ({ renderer }: ExampleSettings) {
+  const degToRad = (deg: number) => {
+    return (Math.PI / 180) * deg;
+  };
+
   const t1 = renderer.createNode({
     x: 200,
     y: 100,
@@ -37,7 +41,7 @@ export default async function ({ renderer }: ExampleSettings) {
         {
           type: 'linearGradient',
           props: {
-            angle: 220,
+            angle: 0,
             colors: [
               0xff0000ff, 0x00ff00ff, 0xff0000ff, 0x0000ffff, 0xffff00ff,
               0xff000000,
@@ -54,7 +58,7 @@ export default async function ({ renderer }: ExampleSettings) {
         {
           type: 'linearGradient',
           props: {
-            angle: 40,
+            angle: degToRad(40),
             colors: [
               0xff0000ff, 0x00ff00ff, 0xff0000ff, 0x0000ffff, 0xffff00ff,
               0xff0000ff,
@@ -103,7 +107,7 @@ export default async function ({ renderer }: ExampleSettings) {
         {
           type: 'linearGradient',
           props: {
-            angle: 60,
+            angle: degToRad(90),
             stops: [0.2, 0.3],
             colors: [
               0xff0000ff, 0x00ff00ff, 0xff0000ff, 0x0000ffff, 0xffff00ff,
@@ -160,7 +164,7 @@ export default async function ({ renderer }: ExampleSettings) {
         {
           type: 'linearGradient',
           props: {
-            angle: 180,
+            angle: degToRad(180),
             stops: [0.4, 0.8],
             colors: [0x0000ffff, 0x00000000],
           },
@@ -168,7 +172,7 @@ export default async function ({ renderer }: ExampleSettings) {
         {
           type: 'linearGradient',
           props: {
-            angle: -90,
+            angle: degToRad(-90),
             stops: [0.1, 0.75],
             colors: [0x0000ffff, 0x00000000],
           },

--- a/exports/core-api.ts
+++ b/exports/core-api.ts
@@ -82,6 +82,7 @@
 
 // Shaders
 export * from '../src/core/renderers/webgl/WebGlCoreShader.js';
+export * from '../src/core/renderers/webgl/shaders/effects/ShaderEffect.js';
 
 // Textures
 export * from '../src/core/textures/Texture.js';

--- a/src/core/renderers/webgl/shaders/effects/FadeOutEffect.ts
+++ b/src/core/renderers/webgl/shaders/effects/FadeOutEffect.ts
@@ -30,6 +30,7 @@ export interface FadeOutEffectProps extends DefaultEffectProps {
   /**
    * Fade around the edges of the node
    *
+   * @remarks
    * You can input an array with a length of up to four or a number.
    *
    * array length 4:

--- a/src/core/renderers/webgl/shaders/effects/FadeOutEffect.ts
+++ b/src/core/renderers/webgl/shaders/effects/FadeOutEffect.ts
@@ -22,7 +22,30 @@ import {
   type ShaderEffectUniforms,
 } from './ShaderEffect.js';
 
+/**
+ * Properties of the {@link FadeOutEffect}
+ *
+ */
 export interface FadeOutEffectProps extends DefaultEffectProps {
+  /**
+   * Fade around the edges of the node
+   *
+   * You can input an array with a length of up to four or a number.
+   *
+   * array length 4:
+   * [top, right, bottom, left]
+   *
+   * array length 2:
+   * [20, 40] -> [20(top), 40(right), 20(bottom), 40(left)]
+   *
+   * array length 3:
+   * [20, 40, 60] -> [20(top), 40(right), 60(bottom), 20(left)]
+   *
+   * number:
+   * 30 -> [30, 30, 30, 30]
+   *
+   * @default 10
+   */
   fade?: number | number[];
 }
 

--- a/src/core/renderers/webgl/shaders/effects/LinearGradientEffect.ts
+++ b/src/core/renderers/webgl/shaders/effects/LinearGradientEffect.ts
@@ -34,7 +34,7 @@ export interface LinearGradientEffectProps extends DefaultEffectProps {
    */
   colors?: number[];
   /**
-   * Angle of the LinearGradientEffect
+   * Angle of the LinearGradientEffect, Angle in Radians
    *
    * @default 0
    */
@@ -137,11 +137,6 @@ export class LinearGradientEffect extends ShaderEffect {
         return mix(higher, lower, 1.0);
       }
     `,
-    degToRad: `
-      float function(float d) {
-        return d * (PI / 180.0);
-      }
-    `,
     calcPoint: `
       vec2 function(float d, float angle) {
         return d * vec2(cos(angle), sin(angle)) + (u_dimensions * 0.5);
@@ -162,12 +157,10 @@ export class LinearGradientEffect extends ShaderEffect {
   static override onColorize = (props: LinearGradientEffectProps) => {
     const colors = props.colors!.length || 1;
     return `
-      float d = angle - 90.0;
-      float a = $degToRad(d);
+      float a = angle - (PI / 180.0 * 90.0);
       float lineDist = abs(u_dimensions.x * cos(a)) + abs(u_dimensions.y * sin(a));
-
       vec2 f = $calcPoint(lineDist * 0.5, a);
-      vec2 t = $calcPoint(lineDist * 0.5, $degToRad(d + 180.0));
+      vec2 t = $calcPoint(lineDist * 0.5, a + PI);
       vec2 gradVec = t - f;
       float dist = dot(v_textureCoordinate.xy * u_dimensions - f, gradVec) / dot(gradVec, gradVec);
 

--- a/src/core/renderers/webgl/shaders/effects/RadiusEffect.ts
+++ b/src/core/renderers/webgl/shaders/effects/RadiusEffect.ts
@@ -29,6 +29,20 @@ export interface RadiusEffectProps extends DefaultEffectProps {
   /**
    * Corner radius, in pixels, to cut out of the corners
    *
+   * You can input an array with a length of up to four or a number.
+   *
+   * array length 4:
+   * [topLeft, topRight, bottomRight, bottomLeft]
+   *
+   * array length 2:
+   * [20, 40] -> [20(topLeft), 40(topRight), 20(bottomRight), 40(bottomLeft)]
+   *
+   * array length 3:
+   * [20, 40, 60] -> [20(topLeft), 40(topRight), 60(bottomRight), 20(bottomLeft)]
+   *
+   * number:
+   * 30 -> [30, 30, 30, 30]
+   *
    * @default 10
    */
   radius?: number | number[];

--- a/src/core/renderers/webgl/shaders/effects/RadiusEffect.ts
+++ b/src/core/renderers/webgl/shaders/effects/RadiusEffect.ts
@@ -29,6 +29,7 @@ export interface RadiusEffectProps extends DefaultEffectProps {
   /**
    * Corner radius, in pixels, to cut out of the corners
    *
+   * @remarks
    * You can input an array with a length of up to four or a number.
    *
    * array length 4:


### PR DESCRIPTION
- Refactored the Effects to the ShaderManager, this way a developer can add their own custom effects.
- Added more docs on the FadeOutEffect and RadiusEffect.
- *breaking* Angle property is now in Radians not in Degrees. The reason for this change is that we only use radians in the core, and it saves a calculation for each pixel from degrees to radians. The dynamic-shader example has a example function that calculates degrees to radians (PI / 180 * degrees)