### PR TITLE
Replaced reference to self with resolvedGlobal that resolves to globa…

### DIFF
--- a/src/core/text-rendering/renderers/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/renderers/CanvasTextRenderer.ts
@@ -42,11 +42,13 @@ import {
   type TrProps,
 } from './TextRenderer.js';
 
+const resolvedGlobal = typeof self === 'undefined' ? globalThis : self;
+
 /**
  * Global font set regardless of if run in the main thread or a web worker
  */
-const globalFontSet = ((self.document as any)?.fonts ||
-  (self as any).fonts) as FontFaceSet;
+const globalFontSet = ((resolvedGlobal.document as any)?.fonts ||
+  (resolvedGlobal as any).fonts) as FontFaceSet;
 
 declare module './TextRenderer.js' {
   interface TextRendererMap {


### PR DESCRIPTION
…lThis when self doesn't exist.

This prevents errors in runtimes where 'self' doesn't exists. For example inside a node based test runner.