### PR TITLE
Add release procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ npm run prod
 
 ## Test Examples
 
-[See README](./examples/README.md)
+See [examples/README.md](./examples/README.md)
+
+## Release Procedure
+
+See [RELEASE.md](./RELEASE.md)
 
 ## Main Space vs Core Space
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,45 @@
+# Release Procedure
+
+Publish a new release with the below instructions, you must first be a contributor
+who is authorized to both push directly to this repo and publish packages to the
+lighntingjs NPM scope.
+
+## Mark, push and publish the release
+
+```
+# Make sure you're on the main branch
+git checkout main
+
+# Stash any untracked + uncomitted changes
+git stash -u
+
+# Run the build once to make sure it completes without errors
+npm run build
+
+# Mark the version update
+# This creates a new tagged commit for the version
+npm version <release-increment> # patch/minor/major
+
+# Publish the package to NPM
+npm publish --access public
+
+# Push version commit to github
+git push
+
+# Push version tag to github
+git push vX.X.X
+
+# Pop the stash (if one was created)
+git stash pop
+```
+
+## Generate a release on GitHub
+
+1. Go to https://github.com/lightning-js/renderer/releases/new
+2. Choose a Tag: _Choose the newly pushed tag_
+3. Target: _main_
+4. Name the release with the same name as the tag: vX.X.X
+5. Click "Generate release notes"
+6. Edit the release notes as appropriate.
+7. Set as the latest release: _Check_
+8. Click "Publish release"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 Publish a new release with the below instructions, you must first be a contributor
 who is authorized to both push directly to this repo and publish packages to the
-lighntingjs NPM scope.
+lightningjs NPM scope.
 
 ## Mark, push and publish the release
 


### PR DESCRIPTION
Added the manual release procedure that I've been employing for releases. It does require pushing to the `main` branch because it relies on the standard `npm version` command in order to create the commit and tag for the version. I'd prefer a more automated approach in the future. Let me know if anyone has any feedback.