### PR TITLE
Add deg2rad exported util

### DIFF
--- a/examples/common/Component.ts
+++ b/examples/common/Component.ts
@@ -1,3 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type {
   INode,
   INodeWritableProps,

--- a/examples/common/ExampleSettings.ts
+++ b/examples/common/ExampleSettings.ts
@@ -1,3 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type { Dimensions, RendererMain } from '@lightningjs/renderer';
 
 export interface ExampleSettings {

--- a/examples/common/LocalStorage.ts
+++ b/examples/common/LocalStorage.ts
@@ -1,3 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Retreive state from local storage (if localStorage is available)
 // and set the state of the app accordingly.
 export function loadStorage<T>(testName: string): Partial<T> | null {

--- a/examples/common/LoremIpsum.ts
+++ b/examples/common/LoremIpsum.ts
@@ -1,3 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export function getLoremIpsum(numCharacters?: number) {
   if (numCharacters === undefined) {
     return loremIpsum;

--- a/examples/common/PageContainer.ts
+++ b/examples/common/PageContainer.ts
@@ -1,3 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type { INode, ITextNode, RendererMain } from '@lightningjs/renderer';
 import { Component } from './Component.js';
 import { loadStorage, saveStorage } from '../common/LocalStorage.js';

--- a/examples/common/paginateTestRows.ts
+++ b/examples/common/paginateTestRows.ts
@@ -1,3 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type { INode } from '@lightningjs/renderer';
 import { PageContainer } from './PageContainer.js';
 import { assertTruthy } from '@lightningjs/renderer/utils';

--- a/exports/utils.ts
+++ b/exports/utils.ts
@@ -37,5 +37,5 @@
  *
  * @packageDocumentation
  */
-export { assertTruthy, mergeColorAlpha } from '../src/utils.js';
+export { assertTruthy, mergeColorAlpha, deg2Rad } from '../src/utils.js';
 export { EventEmitter } from '../src/common/EventEmitter.js';

--- a/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
+++ b/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-// import { Colors } from '../../../Colors.js';
-// import type { Renderer } from '../../../Renderer.js';
 import { intersectBound, type Bound, type Rect } from '../../../lib/utils.js';
 import {
   TextRenderer,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,33 +17,6 @@
  * limitations under the License.
  */
 
-export const boltProperties = [
-  'x',
-  'y',
-  'z',
-  'w',
-  'h',
-  'color',
-  'alpha',
-  'parentId',
-  'textureId',
-  'rtt',
-  'scale',
-  'rotation',
-];
-
-export const pipelineEvents = {
-  created: 1,
-  updated: 2,
-  deleted: 4,
-  attached: 8,
-  detached: 16,
-  onscreen: 32,
-  offscreen: 64,
-  progress: 128,
-  finished: 256,
-};
-
 export function createWebGLContext(
   canvas: HTMLCanvasElement | OffscreenCanvas,
 ): WebGLRenderingContext | null {
@@ -199,4 +172,14 @@ export function mergeColorAlphaPremultiplied(
  */
 export function hasOwn(obj: object, prop: string | number | symbol): boolean {
   return Object.prototype.hasOwnProperty.call(obj, prop);
+}
+
+/**
+ * Converts degrees to radians
+ *
+ * @param degrees
+ * @returns
+ */
+export function deg2Rad(degrees: number): number {
+  return (degrees * Math.PI) / 180;
 }


### PR DESCRIPTION
New exported util function to make it easier to folks to convert degrees to radians. Framework libraries may re-export this if they'd like.

```
import { deg2Rad } from "@lightningjs/renderer/utils";
```
