### PR TITLE
Fix clipping when node is scaled

### DIFF
--- a/examples/common/utils.ts
+++ b/examples/common/utils.ts
@@ -1,0 +1,33 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Dimensions, ITextNode, INode } from '@lightningjs/renderer';
+
+export async function waitForTextDimensions(
+  node: ITextNode,
+): Promise<Dimensions> {
+  return new Promise((resolve) => {
+    node.once('textLoaded', (_node: INode, dimensions: Dimensions) => {
+      resolve({
+        width: dimensions.width,
+        height: dimensions.height,
+      });
+    });
+  });
+}

--- a/examples/tests/animation.ts
+++ b/examples/tests/animation.ts
@@ -27,7 +27,7 @@ interface AnimationExampleSettings {
   stopMethod: 'reverse' | 'reset' | false;
 }
 
-export default async function ({ renderer, appDimensions }: ExampleSettings) {
+export default async function ({ renderer }: ExampleSettings) {
   const node = renderer.createNode({
     x: 0,
     y: 0,

--- a/examples/tests/clipping.ts
+++ b/examples/tests/clipping.ts
@@ -20,6 +20,10 @@
 import type { ExampleSettings } from '../common/ExampleSettings.js';
 import { paginateTestRows } from '../common/paginateTestRows.js';
 import { PageContainer } from '../common/PageContainer.js';
+import { waitForTextDimensions } from '../common/utils.js';
+import { deg2Rad } from '@lightningjs/renderer/utils';
+import type { INodeWritableProps } from '@lightningjs/renderer';
+import robotImg from '../assets/robot/robot.png';
 
 const SQUARE_SIZE = 200;
 const PADDING = 20;
@@ -53,7 +57,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           y: -100,
           width: SQUARE_SIZE,
           height: SQUARE_SIZE,
-          color: 0xff0000ff,
+          src: robotImg,
           parent: clipContainerTopLeft,
         });
 
@@ -73,7 +77,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           y: -100,
           width: SQUARE_SIZE,
           height: SQUARE_SIZE,
-          color: 0xff0000ff,
+          src: robotImg,
           parent: clipContainerTopRight,
         });
 
@@ -93,7 +97,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           y: 100,
           width: SQUARE_SIZE,
           height: SQUARE_SIZE,
-          color: 0xff0000ff,
+          src: robotImg,
           parent: clipContainerBottomRight,
         });
 
@@ -113,7 +117,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           y: 100,
           width: SQUARE_SIZE,
           height: SQUARE_SIZE,
-          color: 0xff0000ff,
+          src: robotImg,
           parent: clipContainerBottomLeft,
         });
 
@@ -133,7 +137,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           y: -100,
           width: SQUARE_SIZE * 2,
           height: SQUARE_SIZE * 2,
-          color: 0xff0000ff,
+          src: robotImg,
           parent: clipAllSides,
         });
         return SQUARE_SIZE;
@@ -162,7 +166,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           y: -100,
           width: SQUARE_SIZE,
           height: SQUARE_SIZE,
-          color: 0xff0000ff,
+          src: robotImg,
           parent: clipContainerTopLeft2,
         });
 
@@ -185,7 +189,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           y: -100,
           width: SQUARE_SIZE,
           height: SQUARE_SIZE,
-          color: 0xff0000ff,
+          src: robotImg,
           parent: clipContainerTopRight2,
         });
 
@@ -208,7 +212,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           y: 100,
           width: SQUARE_SIZE,
           height: SQUARE_SIZE,
-          color: 0xff0000ff,
+          src: robotImg,
           parent: clipContainerBottomRight2,
         });
 
@@ -231,7 +235,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           y: 100,
           width: SQUARE_SIZE,
           height: SQUARE_SIZE,
-          color: 0xff0000ff,
+          src: robotImg,
           parent: clipContainerBottomLeft2,
         });
 
@@ -254,7 +258,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           y: -100,
           width: SQUARE_SIZE * 2,
           height: SQUARE_SIZE * 2,
-          color: 0xff0000ff,
+          src: robotImg,
           parent: clipAllSides2,
         });
 
@@ -282,6 +286,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           width: SQUARE_SIZE,
           height: SQUARE_SIZE,
           color: 0xff0000ff,
+          src: robotImg,
           parent: clipContainerTopLeft,
           clipping: true,
         });
@@ -290,7 +295,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           y: 50,
           width: SQUARE_SIZE / 2,
           height: SQUARE_SIZE / 2,
-          color: 0x0000ffff,
+          src: robotImg,
           parent: clipContainerTopLeft2,
         });
 
@@ -311,6 +316,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           width: SQUARE_SIZE,
           height: SQUARE_SIZE,
           color: 0xff0000ff,
+          src: robotImg,
           parent: clipContainerTopRight,
           clipping: true,
         });
@@ -319,7 +325,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           y: 50,
           width: SQUARE_SIZE / 2,
           height: SQUARE_SIZE / 2,
-          color: 0x0000ffff,
+          src: robotImg,
           parent: clipContainerTopRight2,
         });
 
@@ -340,6 +346,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           width: SQUARE_SIZE,
           height: SQUARE_SIZE,
           color: 0xff0000ff,
+          src: robotImg,
           parent: clipContainerBottomRight,
           clipping: true,
         });
@@ -348,7 +355,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           y: 150,
           width: SQUARE_SIZE / 2,
           height: SQUARE_SIZE / 2,
-          color: 0x0000ffff,
+          src: robotImg,
           parent: clipContainerBottomRight2,
         });
 
@@ -369,6 +376,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           width: SQUARE_SIZE,
           height: SQUARE_SIZE,
           color: 0xff0000ff,
+          src: robotImg,
           parent: clipContainerBottomLeft,
           clipping: true,
         });
@@ -377,7 +385,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           y: 150,
           width: SQUARE_SIZE / 2,
           height: SQUARE_SIZE / 2,
-          color: 0x0000ffff,
+          src: robotImg,
           parent: clipContainerBottomLeft2,
         });
 
@@ -398,6 +406,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           width: SQUARE_SIZE,
           height: SQUARE_SIZE,
           color: 0xff0000ff,
+          src: robotImg,
           parent: clipContainerAllSides,
           clipping: true,
         });
@@ -406,7 +415,7 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           y: 50,
           width: SQUARE_SIZE,
           height: SQUARE_SIZE,
-          color: 0x0000ffff,
+          src: robotImg,
           parent: clipContainerAllSides2,
         });
         return SQUARE_SIZE;
@@ -506,6 +515,223 @@ export default async function ({ testName, renderer }: ExampleSettings) {
           color: 0x000000ff,
           textRendererOverride: 'sdf',
           text: 'SDF ancestor clipping',
+        });
+
+        return SQUARE_SIZE;
+      },
+    },
+    {
+      title: 'Clipping bounds are scaled with the `scale` property',
+      content: async (rowNode) => {
+        let curX = 0;
+
+        const containerProps = {
+          width: SQUARE_SIZE,
+          height: SQUARE_SIZE,
+          parent: rowNode,
+          color: 0x00ff00ff,
+          clipping: true,
+        } satisfies Partial<INodeWritableProps>;
+
+        const clippingParentProps = {
+          mount: 0.5,
+          x: SQUARE_SIZE / 2,
+          y: SQUARE_SIZE / 2,
+          width: SQUARE_SIZE / 2,
+          height: SQUARE_SIZE / 2,
+          clipping: true,
+          // rotation: Math.PI / 4
+        } satisfies Partial<INodeWritableProps>;
+
+        const clippingChildProps = {
+          width: SQUARE_SIZE,
+          height: SQUARE_SIZE,
+          mount: 0.5,
+          src: robotImg,
+        } satisfies Partial<INodeWritableProps>;
+
+        const container = renderer.createNode({
+          ...containerProps,
+          x: curX,
+        });
+
+        const clippingParent = renderer.createNode({
+          ...clippingParentProps,
+          parent: container,
+        });
+
+        renderer.createNode({
+          ...clippingChildProps,
+          parent: clippingParent,
+        });
+
+        curX += SQUARE_SIZE + PADDING;
+
+        const dim = await waitForTextDimensions(
+          renderer.createTextNode({
+            mount: 0.5,
+            x: curX,
+            y: SQUARE_SIZE / 2,
+            text: 'scale 2 >',
+            parent: rowNode,
+          }),
+        );
+
+        curX += dim.width + PADDING;
+
+        const container2 = renderer.createNode({
+          ...containerProps,
+          x: curX,
+        });
+
+        const clippingParent2 = renderer.createNode({
+          ...clippingParentProps,
+          parent: container2,
+          scale: 2,
+        });
+
+        renderer.createNode({
+          ...clippingChildProps,
+          parent: clippingParent2,
+        });
+
+        curX += SQUARE_SIZE + PADDING;
+
+        const dim2 = await waitForTextDimensions(
+          renderer.createTextNode({
+            mount: 0.5,
+            x: curX,
+            y: SQUARE_SIZE / 2,
+            text: 'pivot 0 >',
+            parent: rowNode,
+          }),
+        );
+
+        curX += dim.width + PADDING;
+
+        const container3 = renderer.createNode({
+          ...containerProps,
+          x: curX,
+        });
+
+        const clippingParent3 = renderer.createNode({
+          ...clippingParentProps,
+          parent: container3,
+          scale: 2,
+          pivot: 0,
+        });
+
+        renderer.createNode({
+          ...clippingChildProps,
+          parent: clippingParent3,
+        });
+
+        curX += SQUARE_SIZE + PADDING;
+
+        const dim3 = await waitForTextDimensions(
+          renderer.createTextNode({
+            mount: 0.5,
+            x: curX,
+            y: SQUARE_SIZE / 2,
+            text: 'pivot 1 >',
+            parent: rowNode,
+          }),
+        );
+
+        curX += dim.width + PADDING;
+
+        const container4 = renderer.createNode({
+          ...containerProps,
+          x: curX,
+        });
+
+        const clippingParent4 = renderer.createNode({
+          ...clippingParentProps,
+          parent: container4,
+          scale: 2,
+          pivot: 1,
+        });
+
+        renderer.createNode({
+          ...clippingChildProps,
+          parent: clippingParent4,
+        });
+
+        return SQUARE_SIZE;
+      },
+    },
+    {
+      title: 'Clipping is automatically disabled when node is rotated',
+      content: async (rowNode) => {
+        let curX = 0;
+
+        const containerProps = {
+          width: SQUARE_SIZE,
+          height: SQUARE_SIZE,
+          parent: rowNode,
+          color: 0x00ff00ff,
+          clipping: true,
+        } satisfies Partial<INodeWritableProps>;
+
+        const clippingParentProps = {
+          mount: 0.5,
+          x: SQUARE_SIZE / 2,
+          y: SQUARE_SIZE / 2,
+          width: SQUARE_SIZE / 2,
+          height: SQUARE_SIZE / 2,
+          clipping: true,
+        } satisfies Partial<INodeWritableProps>;
+
+        const clippingChildProps = {
+          width: SQUARE_SIZE,
+          height: SQUARE_SIZE,
+          mount: 0.5,
+          src: robotImg,
+        } satisfies Partial<INodeWritableProps>;
+
+        const container = renderer.createNode({
+          ...containerProps,
+          x: curX,
+        });
+
+        const clippingParent = renderer.createNode({
+          ...clippingParentProps,
+          parent: container,
+        });
+
+        renderer.createNode({
+          ...clippingChildProps,
+          parent: clippingParent,
+        });
+
+        curX += SQUARE_SIZE + PADDING;
+
+        const dimensions = await waitForTextDimensions(
+          renderer.createTextNode({
+            mount: 0.5,
+            x: curX,
+            y: SQUARE_SIZE / 2,
+            text: 'rotate 45 degrees >',
+            parent: rowNode,
+          }),
+        );
+
+        curX += dimensions.width + PADDING;
+
+        const container2 = renderer.createNode({
+          ...containerProps,
+          x: curX,
+        });
+
+        const clippingParent2 = renderer.createNode({
+          ...clippingParentProps,
+          parent: container2,
+          rotation: deg2Rad(45),
+        });
+
+        renderer.createNode({
+          ...clippingChildProps,
+          parent: clippingParent2,
         });
 
         return SQUARE_SIZE;

--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -182,14 +182,18 @@ export class Stage {
 
   addQuads(node: CoreNode, parentClippingRect: Rect | null = null) {
     assertTruthy(this.renderer);
-    let clippingRect: Rect | null = node.clipping
-      ? {
-          x: node.worldContext.px,
-          y: node.worldContext.py,
-          width: node.width,
-          height: node.height,
-        }
-      : null;
+    const wc = node.worldContext;
+    const isRotated = wc.tb !== 0 || wc.tc !== 0;
+
+    let clippingRect: Rect | null =
+      node.clipping && !isRotated
+        ? {
+            x: wc.px,
+            y: wc.py,
+            width: node.width * wc.ta,
+            height: node.height * wc.td,
+          }
+        : null;
     if (parentClippingRect && clippingRect) {
       clippingRect = intersectRect(parentClippingRect, clippingRect);
     } else if (parentClippingRect) {


### PR DESCRIPTION
The clipping area is now scaled appropriately according to the `scale` properties.

Clipping is also now disabled when a clipping node is rotated (Lightning 2 behavior).

Fixes #54 

<img width="1282" alt="Screen Shot 2023-10-25 at 2 39 36 PM" src="https://github.com/lightning-js/renderer/assets/6070611/83ebe63f-6a9e-40fe-a319-5bace4f36f4c">
