### PR TITLE
Example Page: increase interval above 0

### DIFF
--- a/examples/tests/test.ts
+++ b/examples/tests/test.ts
@@ -309,7 +309,7 @@ export default async function ({ renderer }: ExampleSettings) {
 
   const interval = setInterval(() => {
     redRect.color++;
-  }, 0);
+  }, 100);
 
   setInterval(() => {
     if (blueRect) {


### PR DESCRIPTION
setInteral(0) on Safari causes browser to call that function as fast as possible