### PR TITLE
Fixes duplicate node id.

### DIFF
--- a/src/render-drivers/main/MainCoreDriver.ts
+++ b/src/render-drivers/main/MainCoreDriver.ts
@@ -24,7 +24,7 @@ import type {
   INodeWritableProps,
   ITextNodeWritableProps,
 } from '../../main-api/INode.js';
-import { MainOnlyNode } from './MainOnlyNode.js';
+import { MainOnlyNode, getNewId } from './MainOnlyNode.js';
 import { Stage } from '../../core/Stage.js';
 import type {
   RendererMain,
@@ -44,7 +44,7 @@ export class MainCoreDriver implements ICoreDriver {
     canvas: HTMLCanvasElement,
   ): Promise<void> {
     this.stage = new Stage({
-      rootId: 1,
+      rootId: getNewId(),
       appWidth: rendererSettings.appWidth,
       appHeight: rendererSettings.appHeight,
       deviceLogicalPixelRatio: rendererSettings.deviceLogicalPixelRatio,


### PR DESCRIPTION
Both the root node and the first node get id: 1, although it doesn't matter with a nested Tree. It is an issue when experimenting with different tree strategies that rely on unique node id's.