### PR TITLE
Upload failed Visual Regression tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,3 +46,10 @@ jobs:
         run: pnpm run test:visual --color
         env:
           RUNTIME_ENV: ci
+
+      - name: Upload failed-results as artifact
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: failed-results
+          path: visual-regression/failed-results/

--- a/visual-regression/README.md
+++ b/visual-regression/README.md
@@ -103,6 +103,18 @@ to speed up the time it takes to verify if your changes cause any regressions.
 3. Before pushing new commits to the remote PR branch, compare your changes
    to the snapshots you took prior to starting your PR: `pnpm test:visual`
 
+## GitHub Actions Workflow
+
+The Visual Regression Tests run as a status check on every pull request update
+via the GitHub Actions workflow defined in `.github/workflows/tests.yml`. The tests
+that run are compared with the snapshots in the `certified-snapshots/chromium-ci`
+directory.
+
+When tests failed, the failure results that you normally find in
+`visual-regression/failed-results` are uploaded to the workflow run as a zip file
+artifact named **failed-results**. See [Where does the upload go?](https://github.com/actions/upload-artifact#where-does-the-upload-go)
+for more on how to find it.
+
 ## How to define Snapshots
 
 The Snapshots themselves are defined in the individual Example Tests located in the


### PR DESCRIPTION
Sometimes visual regression test fail on GitHub actions but pass locally even in `--ci` mode!

See included README update. The `failed-results` directory is now uploaded as an artifact of at the GitHub Actions workflow so that they can be examined.