### PR TITLE
GitHub Actions: Turn on merge queue

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 on:
-  - pull_request
-
+  pull_request:
+  merge_group:
+    types: [checks_requested]
 jobs:
   run-all-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
By default, when our PR check runs against each PR it is only testing the specific commit HEAD of the PR branch, without necessarily also considering the current HEAD of `main`, unless that commit has been merged in manually into the PR branch. Merge queues provide a way of automating this.

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
