### PR TITLE
Examples: Implemented a statistics summary when `fps` is set

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -47,7 +47,9 @@ pnpm watch
 - `resolution` (number, default: 720)
   - Resolution (height) of to render the test at (in logical pixels)
 - `fps` (boolean, default: "false")
-  - Whether or not to log the latest FPS to the console every 1 second.
+  - Whether or not to log the latest FPS sample to the console every 1 second.
+  - After skipping the first 10 samples, every 30 samples after that will result
+    in a statistics summary printed to the console.
 - `ppr` (number, default: 1)
   - Device physical pixel ratio.
 - `multiplier` (number, default: 1)

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,7 +48,7 @@ pnpm watch
   - Resolution (height) of to render the test at (in logical pixels)
 - `fps` (boolean, default: "false")
   - Whether or not to log the latest FPS sample to the console every 1 second.
-  - After skipping the first 10 samples, every 30 samples after that will result
+  - After skipping the first 10 samples, every 100 samples after that will result
     in a statistics summary printed to the console.
 - `ppr` (number, default: 1)
   - Device physical pixel ratio.

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -211,8 +211,49 @@ async function initRenderer(
     driver,
   );
 
+  /**
+   * FPS sample captured
+   */
+  const fpsSamples: number[] = [];
+  /**
+   * Number of samples to capture before calculating FPS stats
+   */
+  const fpsSampleCount = 30;
+  /**
+   * Number of samples to skip before starting to capture FPS samples.
+   */
+  const fpsSampleSkipCount = 10;
+  /**
+   * FPS sample index
+   */
+  let fpsSampleIndex = 0;
   renderer.on('fpsUpdate', (target: RendererMain, fps: number) => {
     console.log(`FPS: ${fps}`);
+    const captureSample = fpsSampleIndex >= fpsSampleSkipCount;
+    if (captureSample) {
+      fpsSamples.push(fps);
+      const calculateStats =
+        (fpsSampleIndex - fpsSampleSkipCount + 1) % fpsSampleCount === 0;
+      if (fpsSampleIndex !== fpsSampleSkipCount && calculateStats) {
+        const sortedSamples = fpsSamples.sort((a, b) => a - b);
+        const averageFps =
+          fpsSamples.reduce((a, b) => a + b, 0) / fpsSamples.length;
+        const p99Fps = sortedSamples[Math.floor(fpsSamples.length * 0.99)]!;
+        const p95Fps = sortedSamples[Math.floor(fpsSamples.length * 0.95)]!;
+        const p75Fps = sortedSamples[Math.floor(fpsSamples.length * 0.75)]!;
+        const medianFps = sortedSamples[Math.floor(fpsSamples.length * 0.5)]!;
+        console.log(`---------------------------------`);
+        console.log(`Average FPS: ${averageFps}`);
+        console.log(`Median FPS: ${medianFps}`);
+        console.log(`P75 FPS: ${p75Fps}`);
+        console.log(`P95 FPS: ${p95Fps}`);
+        console.log(`P99 FPS: ${p99Fps}`);
+        console.log(`Num samples: ${fpsSamples.length}`);
+        console.log(`---------------------------------`);
+        fpsSamples.length = 0;
+      }
+    }
+    fpsSampleIndex++;
   });
 
   await renderer.init();


### PR DESCRIPTION
When `fps` is set on a run of an Example Test, skipping the first 10 fps samples, every 30 fps samples print out a statistics summary of those samples.

Example:
```
---------------------------------
Average FPS: 27.25
Median FPS: 26
P01 FPS: 19
P05 FPS: 26
P25 FPS: 26
Std Dev FPS: 2.7798381247835278
Num samples: 100
---------------------------------
```