### PR TITLE
Implement distinct stress tests

### DIFF
--- a/examples/tests/stress-multi-level.ts
+++ b/examples/tests/stress-multi-level.ts
@@ -1,0 +1,89 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { type INode } from '@lightningjs/renderer';
+import logo from '../assets/lightning.png';
+import type { ExampleSettings } from '../common/ExampleSettings.js';
+
+const randomIntBetween = (from: number, to: number) =>
+  Math.floor(Math.random() * (to - from + 1) + from);
+
+export default async function ({
+  renderer,
+  testRoot,
+  perfMultiplier,
+}: ExampleSettings) {
+  // create nodes
+  const numOuterNodes = 100 * perfMultiplier;
+  const nodes: INode[] = [];
+  let totalNodes = 0;
+
+  const bg = renderer.createNode({
+    width: 1920,
+    height: 1080,
+    color: 0xff1e293b,
+    parent: testRoot,
+  });
+
+  for (let i = 0; i < numOuterNodes; i++) {
+    const container = renderer.createNode({
+      x: Math.random() * 1920,
+      y: Math.random() * 1080,
+      parent: bg,
+    });
+    const node = renderer.createNode({
+      width: 505,
+      height: 101,
+      src: logo,
+      parent: container,
+    });
+
+    nodes.push(container);
+    totalNodes += 2;
+  }
+
+  console.log(
+    `Created ${numOuterNodes} outer nodes with another node nested inside. Total nodes: ${totalNodes}`,
+  );
+
+  // create 100 animations
+  const animate = () => {
+    nodes.forEach((node) => {
+      node
+        .animate(
+          {
+            x: randomIntBetween(20, 1740),
+            y: randomIntBetween(20, 900),
+            rotation: Math.random() * Math.PI,
+          },
+          {
+            duration: 3000,
+            easing: 'ease-out',
+            loop: true,
+            stopMethod: 'reverse',
+          },
+        )
+        .start();
+    });
+  };
+
+  animate();
+
+  // setInterval(animate, 3000);
+}

--- a/examples/tests/stress-multi-texture.ts
+++ b/examples/tests/stress-multi-texture.ts
@@ -19,6 +19,8 @@
 
 import { type INode } from '@lightningjs/renderer';
 import logo from '../assets/lightning.png';
+import robot from '../assets/robot/robot.png';
+
 import type { ExampleSettings } from '../common/ExampleSettings.js';
 
 const randomIntBetween = (from: number, to: number) =>
@@ -29,7 +31,8 @@ export default async function ({
   testRoot,
   perfMultiplier,
 }: ExampleSettings) {
-  // create 100 nodes
+  // create nodes
+  const numOuterNodes = 100 * perfMultiplier;
   const nodes: INode[] = [];
 
   const bg = renderer.createNode({
@@ -39,20 +42,30 @@ export default async function ({
     parent: testRoot,
   });
 
-  for (let i = 0; i < 100 * perfMultiplier; i++) {
+  for (let i = 0; i < numOuterNodes; i++) {
     const node = renderer.createNode({
-      width: 505,
-      height: 101,
       x: Math.random() * 1920,
       y: Math.random() * 1080,
-      src: logo,
+      ...(i % 2 === 0
+        ? {
+            width: 505,
+            height: 101,
+            src: logo,
+          }
+        : {
+            width: 140,
+            height: 140,
+            src: robot,
+          }),
       parent: bg,
     });
 
     nodes.push(node);
   }
 
-  // create 100 animations
+  console.log(`Created ${numOuterNodes} nodes with alternating textures`);
+
+  // create animations
   const animate = () => {
     nodes.forEach((node) => {
       node

--- a/examples/tests/stress-single-level.ts
+++ b/examples/tests/stress-single-level.ts
@@ -1,0 +1,82 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { type INode } from '@lightningjs/renderer';
+import logo from '../assets/lightning.png';
+import type { ExampleSettings } from '../common/ExampleSettings.js';
+
+const randomIntBetween = (from: number, to: number) =>
+  Math.floor(Math.random() * (to - from + 1) + from);
+
+export default async function ({
+  renderer,
+  testRoot,
+  perfMultiplier,
+}: ExampleSettings) {
+  // create 100 nodes
+  const numOuterNodes = 100 * perfMultiplier;
+  const nodes: INode[] = [];
+
+  const bg = renderer.createNode({
+    width: 1920,
+    height: 1080,
+    color: 0xff1e293b,
+    parent: testRoot,
+  });
+
+  for (let i = 0; i < numOuterNodes; i++) {
+    const node = renderer.createNode({
+      width: 505,
+      height: 101,
+      x: Math.random() * 1920,
+      y: Math.random() * 1080,
+      src: logo,
+      parent: bg,
+    });
+
+    nodes.push(node);
+  }
+
+  console.log(`Created ${numOuterNodes} nodes with the same texture`);
+
+  // create 100 animations
+  const animate = () => {
+    nodes.forEach((node) => {
+      node
+        .animate(
+          {
+            x: randomIntBetween(20, 1740),
+            y: randomIntBetween(20, 900),
+            rotation: Math.random() * Math.PI,
+          },
+          {
+            duration: 3000,
+            easing: 'ease-out',
+            loop: true,
+            stopMethod: 'reverse',
+          },
+        )
+        .start();
+    });
+  };
+
+  animate();
+
+  // setInterval(animate, 3000);
+}


### PR DESCRIPTION
- `stress-single-level` (renamed from `stress`)
  - Animates `100 * multiplier` image nodes with the same texture
  - This tests one of the fastest render passes where everything is rendered with a single renderOp and texture bind.
- `stress-multi-level`
  - Animates `100 * multiplier` container nodes each that have a child node with the same texture
  - This tests the case where container nodes wrap an image node, which can result in a renderOp for each node draw and alternating texture binds, if not properly optimized.
- `stress-multi-texture`
  - Animates `100 * multiplier` image nodes with two alternating textures
  - This tests a worst case scenario where a new renderOp and texture bind is needed for each draw call.