### PR TITLE
Perf: Skip rendering of nodes that do not have a width/height property.

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -409,6 +409,10 @@ export class CoreNode extends EventEmitter implements ICoreNode {
       return (this.isRenderable = true);
     }
 
+    if (!this.props.width || !this.props.height) {
+      return (this.isRenderable = false);
+    }
+
     if (this.props.shader) {
       return (this.isRenderable = true);
     }


### PR DESCRIPTION
Except when there is a texture set, this does not require an upfront width/height.