### PR TITLE
Fix potential endValue issue if timingFunction is incorrectly implemented.

### DIFF
--- a/src/core/animations/CoreAnimation.ts
+++ b/src/core/animations/CoreAnimation.ts
@@ -93,8 +93,12 @@ export class CoreAnimation extends EventEmitter {
     }
   }
 
-  applyEasing(p: number, s: number, e: number): number {
-    return (this.timingFunction(p) || p) * (e - s) + s;
+  applyEasing(progress: number, startValue: number, endValue: number): number {
+    const easedProgress = this.timingFunction(progress) || progress;
+    const currentValue = easedProgress * (endValue - startValue) + startValue;
+
+    // Ensure currentValue doesn't exceed endValue
+    return Math.min(currentValue, endValue);
   }
 
   update(dt: number) {


### PR DESCRIPTION
In the original code, currentValue can exceed endValue if the timingFunction returns a value greater than 1 when passed a progress of 0.99.

To ensure that currentValue never exceeds endValue, regardless of the output of timingFunction, using Math.min to limit currentValue to endValue.