### PR TITLE
Remove texture index from vertex buffer

### DIFF
--- a/src/core/renderers/webgl/WebGlCoreRenderOp.ts
+++ b/src/core/renderers/webgl/WebGlCoreRenderOp.ts
@@ -48,6 +48,7 @@ export class WebGlCoreRenderOp extends CoreRenderOp {
     readonly clippingRect: Rect | null,
     readonly dimensions: Dimensions,
     readonly bufferIdx: number,
+    readonly quadIdx: number,
     readonly zIndex: number,
   ) {
     super();
@@ -79,7 +80,7 @@ export class WebGlCoreRenderOp extends CoreRenderOp {
     shader.bindRenderOp(this, shaderProps);
 
     // TODO: Reduce calculations required
-    const quadIdx = (this.bufferIdx / 24) * 6 * 2;
+    const quadElementOffset = this.quadIdx * 6 * 2;
 
     // Clipping
     if (this.clippingRect) {
@@ -101,7 +102,7 @@ export class WebGlCoreRenderOp extends CoreRenderOp {
       glw.TRIANGLES,
       6 * this.numQuads,
       glw.UNSIGNED_SHORT,
-      quadIdx,
+      quadElementOffset,
     );
   }
 }

--- a/src/core/renderers/webgl/shaders/DynamicShader.ts
+++ b/src/core/renderers/webgl/shaders/DynamicShader.ts
@@ -372,7 +372,6 @@ export class DynamicShader extends WebGlCoreShader {
     attribute vec2 a_textureCoordinate;
     attribute vec2 a_position;
     attribute vec4 a_color;
-    attribute float a_textureIndex;
 
     uniform vec2 u_resolution;
     uniform float u_pixelRatio;
@@ -389,7 +388,6 @@ export class DynamicShader extends WebGlCoreShader {
       // pass to fragment
       v_color = a_color;
       v_textureCoordinate = a_textureCoordinate;
-      v_textureIndex = a_textureIndex;
 
       // flip y
       gl_Position = vec4(clip_space * vec2(1.0, -1.0), 0, 1);

--- a/src/core/renderers/webgl/shaders/RoundedRectangle.ts
+++ b/src/core/renderers/webgl/shaders/RoundedRectangle.ts
@@ -102,7 +102,6 @@ export class RoundedRectangle extends WebGlCoreShader {
       attribute vec2 a_position;
       attribute vec2 a_textureCoordinate;
       attribute vec4 a_color;
-      attribute float a_textureIndex;
       attribute float a_depth;
 
       uniform vec2 u_resolution;

--- a/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
+++ b/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
@@ -563,6 +563,7 @@ export class SdfTextRenderer extends TextRenderer<SdfTextRendererState> {
       clippingRect,
       { height: textH, width: textW },
       0,
+      0,
       zIndex,
     );
 


### PR DESCRIPTION
Rapsberry PI FPS stats:
```
stress-multi-texture (chrome)

Before Change
http://192.168.8.248:5174/?test=stress-single-level&overlay=false&fps=true&resolution=1080&multiplier=2

---------------------------------
Average FPS: 31.71
Median FPS: 31
P01 FPS: 31
P05 FPS: 31
P25 FPS: 31
Std Dev FPS: 1.0420652570736635
Num samples: 100
---------------------------------

After Change
http://192.168.8.248:5173/?test=stress-single-level&overlay=false&fps=true&resolution=1080&multiplier=2
---------------------------------
Average FPS: 32.13
Median FPS: 32
P01 FPS: 31
P05 FPS: 31
P25 FPS: 31
Std Dev FPS: 1.2700787377166818
Num samples: 100
---------------------------------
```

Not really any significant change and we may have a path forward for batched texture renderering so I've decided not to move forward with this PR. This will simply exist as a record of this work.