### PR TITLE
Fix SDF text not moving with parent

### DIFF
--- a/examples/tests/text-overflow-suffix.ts
+++ b/examples/tests/text-overflow-suffix.ts
@@ -41,8 +41,8 @@ export default async function test(settings: ExampleSettings) {
   });
 
   await paginateTestRows(pageContainer, [
-    ...generateLineHeightTest(renderer, 'sdf'),
-    ...generateLineHeightTest(renderer, 'canvas'),
+    ...generateOverflowSuffixTest(renderer, 'sdf'),
+    ...generateOverflowSuffixTest(renderer, 'canvas'),
   ]);
 
   return pageContainer;
@@ -61,7 +61,7 @@ const NODE_PROPS = {
   contain: 'width',
 } satisfies Partial<ITextNodeWritableProps>;
 
-function generateLineHeightTest(
+function generateOverflowSuffixTest(
   renderer: RendererMain,
   textRenderer: 'canvas' | 'sdf',
 ): TestRow[] {

--- a/examples/tests/text-vertical-align.ts
+++ b/examples/tests/text-vertical-align.ts
@@ -41,8 +41,8 @@ export default async function test(settings: ExampleSettings) {
   });
 
   await paginateTestRows(pageContainer, [
-    ...generateLineHeightTest(renderer, 'sdf'),
-    ...generateLineHeightTest(renderer, 'canvas'),
+    ...generateVerticalAlignTest(renderer, 'sdf'),
+    ...generateVerticalAlignTest(renderer, 'canvas'),
   ]);
 
   return pageContainer;
@@ -59,7 +59,7 @@ const NODE_PROPS = {
   lineHeight: 70,
 } satisfies Partial<ITextNodeWritableProps>;
 
-function generateLineHeightTest(
+function generateVerticalAlignTest(
   renderer: RendererMain,
   textRenderer: 'canvas' | 'sdf',
 ): TestRow[] {

--- a/src/core/lib/WebGlContextWrapper.ts
+++ b/src/core/lib/WebGlContextWrapper.ts
@@ -940,7 +940,11 @@ export type UniformMethodMap = {
 };
 
 /**
+ * Compare two arrays for equality.
  *
+ * @remarks
+ * This function will not try to compare nested arrays or Float32Arrays and
+ * instead will always return false when they are encountered.
  *
  * @param a
  * @param b
@@ -951,8 +955,9 @@ export function compareArrays<T>(a: T[], b: T[]): boolean {
     return false;
   }
   return a.every((v, i) => {
-    if (Array.isArray(v)) {
-      return compareArrays(v, b[i] as any[]);
+    // Don't bother to compare nested arrays or Float32Arrays
+    if (Array.isArray(v) || v instanceof Float32Array) {
+      return false;
     } else {
       return v === b[i];
     }


### PR DESCRIPTION
The new WebGlContextWrapper was improperly assuming equality with deeply nested arrays so the transform uniform never gets updated.

Fixes #126