### PR TITLE
perf: state changes causing more state changes

### DIFF
--- a/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
+++ b/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
@@ -173,11 +173,11 @@ export class SdfTextRenderer extends TextRenderer<SdfTextRendererState> {
       },
       x: (state, value) => {
         state.props.x = value;
-        this.invalidateVisibleWindowCache(state);
+        // this.invalidateVisibleWindowCache(state);
       },
       y: (state, value) => {
         state.props.y = value;
-        this.invalidateVisibleWindowCache(state);
+        // this.invalidateVisibleWindowCache(state);
       },
       contain: (state, value) => {
         state.props.contain = value;

--- a/src/core/text-rendering/renderers/TextRenderer.ts
+++ b/src/core/text-rendering/renderers/TextRenderer.ts
@@ -484,8 +484,8 @@ export abstract class TextRenderer<
     }
     state.updateScheduled = true;
     queueMicrotask(() => {
-      state.updateScheduled = false;
       this.updateState(state);
+      state.updateScheduled = false;
     });
   }
 


### PR DESCRIPTION
Not invalidating the cache when x + y changes increased FPS a lot and didn't affect the app

Also I "think"
this.updateState(state); was making changes to state causing an update to be scheduled. Switch it till after to reset flag.