### PR TITLE
Fix simple scene rendering

### DIFF
--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -23,13 +23,16 @@ import type { Stage } from './Stage.js';
  * Platform render loop initiator
  */
 export const startLoop = (stage: Stage) => {
+  let doOneMoreRaf = true;
   const runLoop = () => {
     stage.updateAnimations();
 
-    if (!stage.hasSceneUpdates()) {
+    const hasUpdates = stage.hasSceneUpdates();
+    if (!hasUpdates && !doOneMoreRaf) {
       setTimeout(runLoop, 16.666666666666668);
       return;
     }
+    doOneMoreRaf = hasUpdates;
 
     stage.drawFrame();
     requestAnimationFrame(runLoop);


### PR DESCRIPTION
Simple scenes that do not involve textures, text or any later mutations were not rendering to the canvas. I've tracked this down to a supposed double-buffer issue involing the performance optimization that stops drawing frames when there are no updates in the render tree detected. The Renderer was actually issusing the appropriate WebGL vertices and draw calls for these simple scenes but it seems a second pass at drawing is required in order for the scene to be drawn to the canvas.

This fix simply does an extra draw/raf cycle immediately after it previously drew updates.

I looked at writing a test for this but the behavior is not exhibited when running chromium headlessly.

Fixes #123