### PR TITLE
Fix simple scene rendering

### DIFF
--- a/src/core/renderers/webgl/WebGlCoreRenderer.ts
+++ b/src/core/renderers/webgl/WebGlCoreRenderer.ts
@@ -115,6 +115,11 @@ export class WebGlCoreRenderer extends CoreRenderer {
     this.txManager = options.txManager;
     this.shManager = options.shManager;
     this.defaultTexture = new ColorTexture(this.txManager);
+    // When the default texture is loaded, request a render in case the
+    // RAF is paused. Fixes: https://github.com/lightning-js/renderer/issues/123
+    this.defaultTexture.once('loaded', () => {
+      this.stage.requestRender();
+    });
 
     const gl = createWebGLContext(canvas, options.contextSpy);
     const glw = (this.glw = new WebGlContextWrapper(gl));


### PR DESCRIPTION
Simple scenes that do not involve textures, text or any later mutations were not rendering to the canvas. This is due to the default texture "ColorTexture" not being loaded prior to the scene being rendered. This texture must be loaded before any solid color Nodes will render. When this issue was happening the RAF was paused right before the texture was loaded and that texture loaded event did not trigger a requestRender() from the stage.

The solution here is to request a render once from the stage after the default texture has loaded.

Fixes #123