### PR TITLE
Inspector: Lightning 3 node tree in the DOM for debugging

### DIFF
--- a/examples/index.ts
+++ b/examples/index.ts
@@ -74,6 +74,7 @@ const defaultPhysicalPixelRatio = 1;
   const enableContextSpy = urlParams.get('contextSpy') === 'true';
   const perfMultiplier = Number(urlParams.get('multiplier')) || 1;
   const resolution = Number(urlParams.get('resolution')) || 720;
+  const enableInspector = urlParams.get('inspector') === 'true';
   const physicalPixelRatio =
     Number(urlParams.get('ppr')) || defaultPhysicalPixelRatio;
   const logicalPixelRatio = resolution / appHeight;
@@ -94,6 +95,7 @@ const defaultPhysicalPixelRatio = 1;
       logFps,
       enableContextSpy,
       perfMultiplier,
+      enableInspector,
     );
     return;
   }
@@ -113,6 +115,7 @@ async function runTest(
   logFps: boolean,
   enableContextSpy: boolean,
   perfMultiplier: number,
+  enableInspector: boolean,
 ) {
   const testModule = testModules[getTestPath(test)];
   if (!testModule) {
@@ -133,6 +136,7 @@ async function runTest(
     enableContextSpy,
     logicalPixelRatio,
     physicalPixelRatio,
+    enableInspector,
     customSettings,
   );
 
@@ -177,6 +181,7 @@ async function initRenderer(
   enableContextSpy: boolean,
   logicalPixelRatio: number,
   physicalPixelRatio: number,
+  enableInspector: boolean,
   customSettings?: Partial<RendererMainSettings>,
 ) {
   let driver: ICoreDriver | null = null;
@@ -199,6 +204,7 @@ async function initRenderer(
       coreExtensionModule: coreExtensionModuleUrl,
       fpsUpdateInterval: logFps ? 1000 : 0,
       enableContextSpy,
+      enableInspector,
       ...customSettings,
     },
     'app',
@@ -305,6 +311,7 @@ async function runAutomation(driverName: string, logFps: boolean) {
     false,
     logicalPixelRatio,
     defaultPhysicalPixelRatio,
+    false, // enableInspector
   );
 
   // Iterate through all test modules

--- a/src/main-api/Inspector.ts
+++ b/src/main-api/Inspector.ts
@@ -99,9 +99,11 @@ const gradientColorPropertyMap = [
 ];
 
 export class Inspector {
-  private root: HTMLElement;
+  private root: HTMLElement | null = null;
 
   constructor(canvas: HTMLCanvasElement, settings: RendererMainSettings) {
+    if (import.meta.env.PROD) return;
+
     if (!settings) {
       throw new Error('settings is required');
     }
@@ -216,7 +218,7 @@ export class Inspector {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     value: any,
   ) {
-    if (!value) {
+    if (!value || !this.root) {
       return;
     }
 
@@ -282,8 +284,6 @@ export class Inspector {
     props: INodeAnimatableProps,
     settings: AnimationSettings,
   ) {
-    console.log('animateNode', props, settings);
-
     const {
       duration = 1000,
       delay = 0,

--- a/src/main-api/Inspector.ts
+++ b/src/main-api/Inspector.ts
@@ -102,8 +102,6 @@ export class Inspector {
   private root: HTMLElement;
 
   constructor(canvas: HTMLCanvasElement, settings: RendererMainSettings) {
-    // create div but take the dimensions of the canvas element
-
     if (!settings) {
       throw new Error('settings is required');
     }
@@ -132,6 +130,8 @@ export class Inspector {
     this.root.style.zIndex = '-65535';
 
     document.body.appendChild(this.root);
+
+    console.warn('Inspector is enabled, this will impact performance');
   }
 
   createDiv(

--- a/src/main-api/Inspector.ts
+++ b/src/main-api/Inspector.ts
@@ -35,10 +35,18 @@ const stylePropertyMap: {
   [key: string]: (value: string | number | boolean) => string | StyleResponse;
 } = {
   alpha: () => 'opacity',
-  x: () => 'left',
-  y: () => 'top',
-  width: () => 'width',
-  height: () => 'height',
+  x: (x) => {
+    return { prop: 'left', value: `${x}px` };
+  },
+  y: (y) => {
+    return { prop: 'top', value: `${y}px` };
+  },
+  width: (w) => {
+    return { prop: 'width', value: `${w}px` };
+  },
+  height: (h) => {
+    return { prop: 'height', value: `${h}px` };
+  },
   zIndex: () => 'zIndex',
   fontFamily: () => 'font-family',
   fontSize: () => 'font-size',

--- a/src/main-api/Inspector.ts
+++ b/src/main-api/Inspector.ts
@@ -171,7 +171,10 @@ export class Inspector {
         }
 
         if (property === 'animate') {
-          // this.animateNode();
+          return (props: INodeAnimatableProps, settings: AnimationSettings) => {
+            this.animateNode(div, node, props, settings);
+            return target.animate(props, settings);
+          };
         }
 
         return Reflect.get(target, property, receiver);
@@ -266,5 +269,51 @@ export class Inspector {
       div.setAttribute(String(stylePropertyMap[property]), String(value));
       return;
     }
+  }
+
+  // simple animation handler
+  animateNode(
+    div: HTMLElement,
+    node: INode,
+    props: INodeAnimatableProps,
+    settings: AnimationSettings,
+  ) {
+    console.log('animateNode', props, settings);
+
+    const {
+      duration = 1000,
+      delay = 0,
+      // easing = 'linear',
+      // repeat = 0,
+      // loop = false,
+      // stopMethod = false,
+    } = settings;
+
+    const {
+      x,
+      y,
+      width,
+      height,
+      alpha = 1,
+      rotation = 0,
+      scale = 1,
+      color,
+    } = props;
+
+    // ignoring loops and repeats for now, as that might be a bit too much for the inspector
+    function animate() {
+      setTimeout(() => {
+        div.style.top = `${y}px`;
+        div.style.left = `${x}px`;
+        div.style.width = `${width}px`;
+        div.style.height = `${height}px`;
+        div.style.opacity = `${alpha}`;
+        div.style.rotate = `${rotation}rad`;
+        div.style.scale = `${scale}`;
+        div.style.color = convertColorToRgba(color);
+      }, duration);
+    }
+
+    setTimeout(animate, delay);
   }
 }

--- a/src/main-api/Inspector.ts
+++ b/src/main-api/Inspector.ts
@@ -1,0 +1,206 @@
+import type {
+  INode,
+  INodeWritableProps,
+  ITextNode,
+  ITextNodeWritableProps,
+} from './INode.js';
+import type { ICoreDriver } from './ICoreDriver.js';
+import { type RendererMainSettings } from './RendererMain.js';
+
+const stylePropertyMap: { [key: string]: string } = {
+  alpha: 'opacity',
+  x: 'left',
+  y: 'top',
+  width: 'width',
+  height: 'height',
+  color: 'backgroundColor',
+  src: 'backgroundImage',
+  zIndex: 'zIndex',
+  fontFamily: 'font-family',
+  fontSize: 'font-size',
+  fontStyle: 'font-style',
+  fontWeight: 'font-weight',
+  fontStretch: 'font-stretch',
+  lineHeight: 'line-height',
+  letterSpacing: 'letter-spacing',
+  textAlign: 'text-align',
+  overflowSuffix: 'overflow-suffix',
+  maxLines: 'max-lines',
+  contain: 'contain',
+  verticalAlign: 'vertical-align',
+};
+
+const domPropertyMap: { [key: string]: string } = {
+  id: 'id',
+};
+
+export class Inspector {
+  private root: HTMLElement;
+
+  constructor(canvas: HTMLCanvasElement, settings: RendererMainSettings) {
+    // create div but take the dimensions of the canvas element
+
+    if (!settings) {
+      throw new Error('settings is required');
+    }
+
+    // calc dimensions based on the devicePixelRatio
+    const height = Math.ceil(
+      settings.appHeight ?? 1080 / (settings.deviceLogicalPixelRatio ?? 1),
+    );
+    const width = Math.ceil(
+      settings.appWidth ?? 1900 / (settings.deviceLogicalPixelRatio ?? 1),
+    );
+
+    this.root = document.createElement('div');
+    this.root.id = 'root';
+    this.root.style.left = '0';
+    this.root.style.top = '0';
+    this.root.style.width = `${width}px`;
+    this.root.style.height = `${height}px`;
+    this.root.style.position = 'absolute';
+    this.root.style.transformOrigin = '0 0 0';
+    this.root.style.transform = `scale(${
+      settings.deviceLogicalPixelRatio ?? 1
+    },${settings.deviceLogicalPixelRatio ?? 1})`;
+    this.root.style.overflow = 'hidden';
+    this.root.style.zIndex = '65535';
+
+    document.body.appendChild(this.root);
+  }
+
+  createDiv(
+    node: INode | ITextNode,
+    properties: INodeWritableProps | ITextNodeWritableProps,
+  ): HTMLElement {
+    const div = document.createElement('div');
+    div.style.position = 'absolute';
+    div.id = node.id.toString();
+
+    // set initial properties
+    for (const key in properties) {
+      this.updateNodeProperty(
+        div,
+        // really typescript? really?
+        key as keyof (INodeWritableProps & ITextNodeWritableProps),
+        (properties as INodeWritableProps & ITextNodeWritableProps)[
+          key as keyof (INodeWritableProps & ITextNodeWritableProps)
+        ],
+      );
+    }
+
+    return div;
+  }
+
+  createNode(driver: ICoreDriver, properties: INodeWritableProps): INode {
+    const node = driver.createNode(properties);
+    const div = this.createDiv(node, properties);
+
+    return new Proxy(node, {
+      set: (target, property: keyof INodeWritableProps, value) => {
+        if (property === 'parent' && value === null) {
+          this.destroyNode(node);
+        }
+
+        this.updateNodeProperty(div, property, value);
+        return Reflect.set(target, property, value);
+      },
+    });
+  }
+
+  createTextNode(
+    driver: ICoreDriver,
+    properties: ITextNodeWritableProps,
+  ): ITextNode {
+    const node = driver.createTextNode(properties);
+    const div = this.createDiv(node, properties);
+
+    return new Proxy(node, {
+      set: (target, property: keyof INodeWritableProps, value) => {
+        if (property === 'parent' && value === null) {
+          this.destroyNode(node);
+        }
+
+        this.updateNodeProperty(div, property, value);
+        return Reflect.set(target, property, value);
+      },
+    });
+  }
+
+  destroyNode(node: INode | ITextNode) {
+    const div = document.getElementById(node.id.toString());
+    div?.remove();
+  }
+
+  updateNodeProperty(
+    div: HTMLElement,
+    property: keyof INodeWritableProps | keyof ITextNodeWritableProps,
+    value: any,
+  ) {
+    // dont do anything with falsey values
+    if (!value) {
+      return;
+    }
+
+    if (property === 'parent') {
+      const parentId = value.id;
+
+      // only way to detect if the parent is the root node
+      // if you are reading this and have a better way, please let me know
+      if (parentId === 1) {
+        this.root.appendChild(div);
+        return;
+      }
+
+      const parent = document.getElementById(parentId.toString());
+      parent?.appendChild(div);
+      return;
+    }
+
+    if (property === 'text') {
+      div.innerHTML = value;
+      return;
+    }
+
+    if (property === 'clipping') {
+      div.style.overflow = value ? 'hidden' : 'visible';
+      return;
+    }
+
+    if (property === 'rotation') {
+      div.style.transform = `rotate(${value}rad)`;
+      return;
+    }
+
+    if (
+      property === 'scale' ||
+      property === 'scaleX' ||
+      property === 'scaleY'
+    ) {
+      div.style.transform = `${property}(${value})`;
+      return;
+    }
+
+    // TODO handle texture
+    // TODO handle shader
+    // TODO animations (whoa!)
+
+    // CSS mappable attribute
+    if (stylePropertyMap[property]) {
+      div.style.setProperty(
+        String(stylePropertyMap[property]),
+        value.toString(),
+      );
+      return;
+    }
+
+    // DOM properties
+    if (domPropertyMap[property]) {
+      div.setAttribute(String(stylePropertyMap[property]), value.toString());
+      return;
+    }
+
+    // all else can be mapped to data-attributes
+    div.setAttribute(`data-${property}`, value);
+  }
+}

--- a/src/main-api/RendererMain.ts
+++ b/src/main-api/RendererMain.ts
@@ -38,6 +38,7 @@ import {
 import { FinalizationRegistryTextureUsageTracker } from './texture-usage-trackers/FinalizationRegistryTextureUsageTracker.js';
 import type { TextureUsageTracker } from './texture-usage-trackers/TextureUsageTracker.js';
 import { EventEmitter } from '../common/EventEmitter.js';
+import { Inspector } from './Inspector.js';
 
 /**
  * An immutable reference to a specific Texture type
@@ -238,6 +239,18 @@ export interface RendererMainSettings {
    * @defaultValue `2`
    */
   numImageWorkers?: number;
+
+  /**
+   * Enable inspector
+   *
+   * @remarks
+   * When enabled the renderer will spawn a inspector. The inspector will
+   * replicate the state of the Nodes created in the renderer and allow
+   * inspection of the state of the nodes.
+   *
+   * @defaultValue `false` (disabled)
+   */
+  enableInspector?: boolean;
 }
 
 /**
@@ -269,6 +282,7 @@ export class RendererMain extends EventEmitter {
   readonly driver: ICoreDriver;
   readonly canvas: HTMLCanvasElement;
   readonly settings: Readonly<Required<RendererMainSettings>>;
+  private inspector: Inspector;
   private nodes: Map<number, INode> = new Map();
   private nextTextureId = 1;
 
@@ -308,6 +322,8 @@ export class RendererMain extends EventEmitter {
       numImageWorkers:
         settings.numImageWorkers !== undefined ? settings.numImageWorkers : 2,
       enableContextSpy: settings.enableContextSpy ?? false,
+      //enableInspector: settings.enableInspector ?? false,
+      enableInspector: true,
     };
     this.settings = resolvedSettings;
 
@@ -316,6 +332,7 @@ export class RendererMain extends EventEmitter {
       appHeight,
       deviceLogicalPixelRatio,
       devicePhysicalPixelRatio,
+      enableInspector,
     } = resolvedSettings;
 
     const releaseCallback = (textureId: number) => {
@@ -355,6 +372,9 @@ export class RendererMain extends EventEmitter {
     if (!targetEl) {
       throw new Error('Could not find target element');
     }
+
+    // init inspector
+    this.inspector = new Inspector(canvas, resolvedSettings);
 
     // Hook up the driver's callbacks
     driver.onCreateNode = (node) => {
@@ -401,6 +421,13 @@ export class RendererMain extends EventEmitter {
    * @returns
    */
   createNode(props: Partial<INodeWritableProps>): INode {
+    if (this.inspector) {
+      return this.inspector.createNode(
+        this.driver,
+        this.resolveNodeDefaults(props),
+      );
+    }
+
     return this.driver.createNode(this.resolveNodeDefaults(props));
   }
 
@@ -442,6 +469,10 @@ export class RendererMain extends EventEmitter {
       overflowSuffix: props.overflowSuffix ?? '...',
       debug: props.debug ?? {},
     };
+
+    if (this.inspector) {
+      return this.inspector.createTextNode(this.driver, data);
+    }
 
     return this.driver.createTextNode(data);
   }
@@ -514,6 +545,10 @@ export class RendererMain extends EventEmitter {
    * @returns
    */
   destroyNode(node: INode) {
+    if (this.inspector) {
+      this.inspector.destroyNode(node);
+    }
+
     return this.driver.destroyNode(node);
   }
 

--- a/src/main-api/RendererMain.ts
+++ b/src/main-api/RendererMain.ts
@@ -282,7 +282,7 @@ export class RendererMain extends EventEmitter {
   readonly driver: ICoreDriver;
   readonly canvas: HTMLCanvasElement;
   readonly settings: Readonly<Required<RendererMainSettings>>;
-  private inspector: Inspector;
+  private inspector: Inspector | null = null;
   private nodes: Map<number, INode> = new Map();
   private nextTextureId = 1;
 
@@ -322,8 +322,7 @@ export class RendererMain extends EventEmitter {
       numImageWorkers:
         settings.numImageWorkers !== undefined ? settings.numImageWorkers : 2,
       enableContextSpy: settings.enableContextSpy ?? false,
-      //enableInspector: settings.enableInspector ?? false,
-      enableInspector: true,
+      enableInspector: settings.enableInspector ?? false,
     };
     this.settings = resolvedSettings;
 
@@ -373,8 +372,9 @@ export class RendererMain extends EventEmitter {
       throw new Error('Could not find target element');
     }
 
-    // init inspector
-    this.inspector = new Inspector(canvas, resolvedSettings);
+    if (enableInspector) {
+      this.inspector = new Inspector(canvas, resolvedSettings);
+    }
 
     // Hook up the driver's callbacks
     driver.onCreateNode = (node) => {

--- a/src/main-api/RendererMain.ts
+++ b/src/main-api/RendererMain.ts
@@ -372,10 +372,6 @@ export class RendererMain extends EventEmitter {
       throw new Error('Could not find target element');
     }
 
-    if (enableInspector && !import.meta.env.PROD) {
-      this.inspector = new Inspector(canvas, resolvedSettings);
-    }
-
     // Hook up the driver's callbacks
     driver.onCreateNode = (node) => {
       this.nodes.set(node.id, node);
@@ -390,6 +386,10 @@ export class RendererMain extends EventEmitter {
     };
 
     targetEl.appendChild(canvas);
+
+    if (enableInspector && !import.meta.env.PROD) {
+      this.inspector = new Inspector(canvas, resolvedSettings);
+    }
   }
 
   /**

--- a/src/main-api/RendererMain.ts
+++ b/src/main-api/RendererMain.ts
@@ -372,7 +372,7 @@ export class RendererMain extends EventEmitter {
       throw new Error('Could not find target element');
     }
 
-    if (enableInspector) {
+    if (enableInspector && !import.meta.env.PROD) {
       this.inspector = new Inspector(canvas, resolvedSettings);
     }
 


### PR DESCRIPTION
Conditional inspector that can be enabled with:
```
enableInspector: true
```

Will replicate the Lightning node tree in a DIV DOM tree, and remap Lightning 3 node properties to applicable CSS properties for easy inspection using the web inspector in your devtools.

![Screenshot 2024-02-08 155139](https://github.com/lightning-js/renderer/assets/1534440/290edd84-b7eb-4af7-828d-6912856366bd)

Note: currently does not support attaching stuff like `testId` as requested in the original issue #94. This requires an extension to the `INode` interface that will need some more consideration.

Notes:
* Inspector works off of `RendererMain` so it can support both ThreadX and single threaded mode.
* Inspector wraps arround `createNode`, `createTextNode` APIs using Proxies.
* Inspector has a rudimentary understanding of animations, to reflect the DOM tree with animations being executed. However this does not work with loops and repeats at the moment.

Future considerations:
* Add a data key/value interface to the `INode`, limited to `string`, `boolean` and `number` that will be reflected back on the DOM tree in `data-*` elements.
* Listen for DevTool changes to the CSS using `MutationObserver` and reflect those onto the render node for results.


And last but not least, don't enable this in production folks. It's going to be bad mmmkay.