### PR TITLE
Remove PNPM warning for projects using the renderer as a dependency

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,3 +10,4 @@ build
 releases
 .tmp
 .env
+scripts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ligtningjs/renderer",
+  "name": "@lightningjs/renderer",
   "version": "0.7.2",
   "lockfileVersion": 2,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "@ligtningjs/renderer",
+      "name": "@lightningjs/renderer",
       "version": "0.7.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,18 @@
 {
-  "name": "@lightningjs/renderer",
+  "name": "@ligtningjs/renderer",
   "version": "0.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@lightningjs/renderer",
+      "name": "@ligtningjs/renderer",
       "version": "0.7.2",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@lightningjs/threadx": "^0.3.4",
-        "@protobufjs/eventemitter": "^1.1.0"
+        "@protobufjs/eventemitter": "^1.1.0",
+        "memize": "^2.1.0"
       },
       "devDependencies": {
         "@types/node": "^18.14.6",
@@ -25,6 +27,11 @@
         "typedoc": "^0.25.1",
         "typescript": "^5.2.2",
         "vitest": "^0.34.2"
+      },
+      "engines": {
+        "node": ">= 20.9.0",
+        "npm": ">= 10.0.0",
+        "pnpm": ">= 8.9.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2315,6 +2322,11 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/memize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
+      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -5203,6 +5215,11 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true
+    },
+    "memize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
+      "integrity": "sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg=="
     },
     "merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@lightningjs/renderer",
+  "name": "@ligtningjs/renderer",
   "version": "0.7.2",
   "description": "Lightning 3 Renderer",
   "type": "module",
@@ -11,6 +11,7 @@
     "./workers/renderer": "./dist/src/render-drivers/threadx/worker/renderer.js"
   },
   "scripts": {
+    "preinstall": "node scripts/please-use-pnpm.js",
     "start": "cd examples && pnpm start",
     "start:prod": "cd examples && pnpm start:prod",
     "build": "tsc --build",
@@ -79,11 +80,12 @@
     "exports",
     "LICENSE",
     "NOTICE",
-    "README.md"
+    "README.md",
+    "scripts"
   ],
   "packageManager": "pnpm@8.9.2",
   "engines": {
-    "npm": "please-use-pnpm",
+    "npm": ">= 10.0.0",
     "pnpm": ">= 8.9.2",
     "node": ">= 20.9.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ligtningjs/renderer",
+  "name": "@lightningjs/renderer",
   "version": "0.7.2",
   "description": "Lightning 3 Renderer",
   "type": "module",

--- a/scripts/please-use-pnpm.js
+++ b/scripts/please-use-pnpm.js
@@ -1,0 +1,13 @@
+if (
+  process.cwd() === process.env.INIT_CWD &&
+  !process.env.npm_execpath.includes('pnpm')
+) {
+  console.log('\x1b[31m');
+  console.log('=============================================\n');
+  console.log('     Please use PNPM as a package manager');
+  console.log('     See: https://pnpm.io/ for more info');
+  console.log('\n=============================================');
+  console.log('\x1b[0m');
+
+  process.exit(1);
+}


### PR DESCRIPTION
The Lightning renderer project uses PNPM as a package manager. And for anyone working on the renderer, using PNPM should obviously be required.

But for projects built on top of the renderer, there is no real reason to enforce the usage of PNPM.

Currently when installing the renderer as a dependency in an NPM based project, a warning is shown about unsupported engines. Which is not necesary and can cause confusion.

![image](https://github.com/lightning-js/renderer/assets/8299035/f1ccd355-f08d-42ed-af7c-a690347e612c)

This change removes this warning from NPM installs using the renderer as dependency, while still enforcing PNPM when working directly on the renderer code itself.

<img width="394" alt="image" src="https://github.com/lightning-js/renderer/assets/8299035/a6bc2ecd-ff8b-4ee5-9b80-0781db9fa7b2">
