### PR TITLE
Feat: Allow custom data key/value storage on Nodes.

### DIFF
--- a/examples/tests/inspector.ts
+++ b/examples/tests/inspector.ts
@@ -1,0 +1,139 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import logo from '../assets/lightning.png';
+import type { ExampleSettings } from '../common/ExampleSettings.js';
+
+export default async function ({ renderer, testRoot }: ExampleSettings) {
+  const bg = renderer.createNode({
+    width: 1920,
+    height: 1080,
+    color: 0x000000ff,
+    parent: testRoot,
+  });
+
+  const dataNodeCheckBox = renderer.createNode({
+    width: 100,
+    height: 100,
+    x: 80,
+    y: 200,
+    color: 0xff0000ff,
+    parent: bg,
+  });
+
+  const dataNode = renderer.createNode({
+    width: 505,
+    height: 101,
+    x: 200,
+    y: 200,
+    src: logo,
+    parent: bg,
+    data: {
+      id: 'dataNode',
+      number: 1,
+      boolean: true,
+    },
+  });
+
+  const tooLongStringCheckBox = renderer.createNode({
+    width: 100,
+    height: 100,
+    x: 80,
+    y: 400,
+    color: 0xff0000ff,
+    parent: bg,
+  });
+
+  const tooLongString = renderer.createNode({
+    width: 505,
+    height: 101,
+    x: 200,
+    y: 400,
+    src: logo,
+    parent: bg,
+    data: {
+      id: 'tooLongString',
+      b: 'a'.repeat(2049),
+    },
+  });
+
+  const textNodeCheckBox = renderer.createNode({
+    width: 100,
+    height: 100,
+    x: 80,
+    y: 600,
+    color: 0xff0000ff,
+    parent: bg,
+  });
+
+  const textNode = renderer.createTextNode({
+    x: 200,
+    y: 600,
+    height: 100,
+    text: 'Hello World',
+    fontFamily: 'Ubuntu',
+    fontSize: 100,
+    parent: bg,
+    data: {
+      id: 'textNode',
+    },
+  });
+
+  const testDetailsText = renderer.createTextNode({
+    x: 30,
+    y: 80,
+    height: 100,
+    text: 'Boxes should turn green if the inspector is enabled',
+    fontFamily: 'Ubuntu',
+    fontSize: 50,
+    parent: bg,
+  });
+
+  const testQparamDetailsText = renderer.createTextNode({
+    x: 30,
+    y: 800,
+    height: 100,
+    text: 'Please make sure to run this test with ?inspector=true',
+    fontFamily: 'Ubuntu',
+    fontSize: 50,
+    parent: bg,
+  });
+
+  setTimeout(() => {
+    // Select the first element with data-id="dataNode"
+    const domDataNode = document.querySelector('[data-id="dataNode"]');
+    if (domDataNode) {
+      dataNodeCheckBox.color = 0x00ff00ff;
+    }
+
+    const domTooLongString = document.querySelector(
+      '[data-id="tooLongString"]',
+    );
+
+    if (domTooLongString) {
+      tooLongStringCheckBox.color = 0x00ff00ff;
+    }
+
+    const domTextNode = document.querySelector('[data-id="textNode"]');
+
+    if (domTextNode) {
+      textNodeCheckBox.color = 0x00ff00ff;
+    }
+  }, 1000);
+}

--- a/src/main-api/INode.ts
+++ b/src/main-api/INode.ts
@@ -392,7 +392,35 @@ export interface INodeWritableProps {
    * - `2 * Math.PI`: 360 rotation clockwise
    */
   rotation: number;
+  /**
+   * Node data element for custom data storage (optional)
+   *
+   * @remarks
+   * This property is used to store custom data on the Node as a key/value data store.
+   * Data values are limited to string, numbers, booleans. Strings will be truncated
+   * to a 2048 character limit for performance reasons.
+   *
+   * This is not a data storage mechanism for large amounts of data please use a
+   * dedicated data storage mechanism for that.
+   *
+   * The custom data will be reflected in the inspector as part of `data-*` attributes
+   *
+   * @default `undefined`
+   */
+  data?: CustomDataMap;
 }
+
+/**
+ * A custom data map which can be stored on the INode
+ *
+ * @remarks
+ * This is a map of key-value pairs that can be stored on an INode. It is used
+ * to store custom data that can be used by the application.
+ * The data stored can only be of type string, number or boolean.
+ */
+export type CustomDataMap = {
+  [key: string]: string | number | boolean;
+};
 
 export type INodeAnimatableProps = {
   [Key in keyof INodeWritableProps as NonNullable<
@@ -403,6 +431,7 @@ export type INodeAnimatableProps = {
 };
 
 export interface INodeEvents {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [s: string]: (target: INode, data: any) => void;
 }
 

--- a/src/main-api/Inspector.ts
+++ b/src/main-api/Inspector.ts
@@ -376,14 +376,13 @@ export class Inspector {
     }
 
     // custom data properties
-    // Needs https://github.com/lightning-js/renderer/pull/178 to be merged
-    // if (property === 'data') {
-    //   for (const key in value) {
-    //     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    //     div.setAttribute(`data-${key}`, String(value[key]));
-    //   }
-    //   return;
-    // }
+    if (property === 'data') {
+      for (const key in value) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        div.setAttribute(`data-${key}`, String(value[key]));
+      }
+      return;
+    }
   }
 
   // simple animation handler

--- a/src/main-api/RendererMain.ts
+++ b/src/main-api/RendererMain.ts
@@ -39,6 +39,7 @@ import { FinalizationRegistryTextureUsageTracker } from './texture-usage-tracker
 import type { TextureUsageTracker } from './texture-usage-trackers/TextureUsageTracker.js';
 import { EventEmitter } from '../common/EventEmitter.js';
 import { Inspector } from './Inspector.js';
+import { santizeCustomDataMap } from '../render-drivers/utils.js';
 
 /**
  * An immutable reference to a specific Texture type
@@ -501,6 +502,7 @@ export class RendererMain extends EventEmitter {
       props.colorBl ?? props.colorBottom ?? props.colorLeft ?? color;
     const colorBr =
       props.colorBr ?? props.colorBottom ?? props.colorRight ?? color;
+    const data = santizeCustomDataMap(props.data ?? {});
 
     return {
       x: props.x ?? 0,
@@ -536,6 +538,7 @@ export class RendererMain extends EventEmitter {
       pivotX: props.pivotX ?? props.pivot ?? 0.5,
       pivotY: props.pivotY ?? props.pivot ?? 0.5,
       rotation: props.rotation ?? 0,
+      data: data,
     };
   }
 

--- a/src/render-drivers/main/MainOnlyNode.ts
+++ b/src/render-drivers/main/MainOnlyNode.ts
@@ -18,6 +18,7 @@
  */
 
 import type {
+  CustomDataMap,
   INode,
   INodeAnimatableProps,
   INodeWritableProps,
@@ -39,6 +40,7 @@ import type {
   NodeLoadedEventHandler,
   NodeFailedEventHandler,
 } from '../../common/CommonTypes.js';
+import { santizeCustomDataMap } from '../utils.js';
 
 let nextId = 1;
 
@@ -56,6 +58,7 @@ export class MainOnlyNode extends EventEmitter implements INode {
   protected _parent: MainOnlyNode | null = null;
   protected _texture: TextureRef | null = null;
   protected _shader: ShaderRef | null = null;
+  protected _data: CustomDataMap | undefined = {};
 
   constructor(
     props: INodeWritableProps,
@@ -110,6 +113,7 @@ export class MainOnlyNode extends EventEmitter implements INode {
     this.shader = props.shader;
     this.texture = props.texture;
     this.src = props.src;
+    this._data = props.data;
   }
 
   get x(): number {
@@ -423,6 +427,14 @@ export class MainOnlyNode extends EventEmitter implements INode {
     if (shader) {
       this.coreNode.loadShader(shader.shType, shader.props);
     }
+  }
+
+  get data(): CustomDataMap | undefined {
+    return this._data;
+  }
+
+  set data(d: CustomDataMap) {
+    this._data = santizeCustomDataMap(d);
   }
 
   destroy(): void {

--- a/src/render-drivers/threadx/ThreadXMainNode.ts
+++ b/src/render-drivers/threadx/ThreadXMainNode.ts
@@ -18,7 +18,11 @@
  */
 
 import type { IAnimationController } from '../../common/IAnimationController.js';
-import type { INode, INodeAnimatableProps } from '../../main-api/INode.js';
+import type {
+  CustomDataMap,
+  INode,
+  INodeAnimatableProps,
+} from '../../main-api/INode.js';
 import type {
   RendererMain,
   ShaderRef,
@@ -29,6 +33,7 @@ import type { NodeStruct } from './NodeStruct.js';
 import { SharedNode } from './SharedNode.js';
 import { ThreadXMainAnimationController } from './ThreadXMainAnimationController.js';
 import type { AnimationSettings } from '../../core/animations/CoreAnimation.js';
+import { santizeCustomDataMap } from '../utils.js';
 
 export class ThreadXMainNode extends SharedNode implements INode {
   private nextAnimationId = 1;
@@ -36,6 +41,7 @@ export class ThreadXMainNode extends SharedNode implements INode {
   protected _children: ThreadXMainNode[] = [];
   protected _texture: TextureRef | null = null;
   protected _shader: ShaderRef | null = null;
+  protected _data: CustomDataMap | undefined = {};
   private _src = '';
 
   /**
@@ -169,6 +175,14 @@ export class ThreadXMainNode extends SharedNode implements INode {
 
   get props() {
     return this.curProps;
+  }
+
+  get data(): CustomDataMap | undefined {
+    return this._data;
+  }
+
+  set data(d: CustomDataMap) {
+    this._data = santizeCustomDataMap(d);
   }
 
   override destroy() {

--- a/src/render-drivers/utils.ts
+++ b/src/render-drivers/utils.ts
@@ -58,21 +58,34 @@ export async function loadCoreExtension(
 }
 
 export function santizeCustomDataMap(d: CustomDataMap): CustomDataMap {
-  for (const key in d) {
-    const value = d[key];
+  const validTypes = { boolean: true, string: true, number: true };
 
-    if (typeof value === 'string' && value.length > 2048) {
+  const keys = Object.keys(d);
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    if (!key) {
+      continue;
+    }
+
+    const value = d[key];
+    const valueType = typeof value;
+
+    // Typescript doesn't understand the above const valueType ¯\_(ツ)_/¯
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore-next-line
+    if (valueType === 'string' && value.length > 2048) {
       console.warn(
         `Custom Data value for ${key} is too long, it will be truncated to 2048 characters`,
       );
+
+      // same here, see above comment, this can only be a string at this point
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore-next-line
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
       d[key] = value.substring(0, 2048);
     }
 
-    if (
-      typeof value !== 'boolean' &&
-      typeof value !== 'string' &&
-      typeof value !== 'number'
-    ) {
+    if (!validTypes[valueType as keyof typeof validTypes]) {
       console.warn(
         `Custom Data value for ${key} is not a boolean, string, or number, it will be ignored`,
       );

--- a/src/render-drivers/utils.ts
+++ b/src/render-drivers/utils.ts
@@ -1,5 +1,6 @@
 import { CoreExtension } from '../../exports/core-api.js';
 import type { Stage } from '../core/Stage.js';
+import type { CustomDataMap } from '../main-api/INode.js';
 
 /**
  * Type guard that checks if a Class extends CoreExtension.
@@ -54,4 +55,30 @@ export async function loadCoreExtension(
       `The core extension at '${coreExtensionModule}' does not extend CoreExtension.`,
     );
   }
+}
+
+export function santizeCustomDataMap(d: CustomDataMap): CustomDataMap {
+  for (const key in d) {
+    const value = d[key];
+
+    if (typeof value === 'string' && value.length > 2048) {
+      console.warn(
+        `Custom Data value for ${key} is too long, it will be truncated to 2048 characters`,
+      );
+      d[key] = value.substring(0, 2048);
+    }
+
+    if (
+      typeof value !== 'boolean' &&
+      typeof value !== 'string' &&
+      typeof value !== 'number'
+    ) {
+      console.warn(
+        `Custom Data value for ${key} is not a boolean, string, or number, it will be ignored`,
+      );
+      delete d[key];
+    }
+  }
+
+  return d;
 }


### PR DESCRIPTION
This allows the consumer of the Node's or TextNode's to inject small data properties that will be returned and/or added in the inspector `node-*` attributes.

For example:
```
  const dataNode = renderer.createNode({
    width: 505,
    height: 101,
    x: 200,
    y: 200,
    src: logo,
    parent: bg,
    data: {
      id :'dataNode',
      number: 1,
      boolean: true
    }
  });
```

In this case data: {} is an santized Map of key/values that will be stored on the main node.

*Note*: Custom data will not be passed to the CoreNode or ThreadX node. Thus data remains on the main thread and does not get forwarded to the Render thread in case of the ThreadX driver. This to avoid clashes/overhead on the ThreadX interface.

For performance reasons only strings, booleans and numbers are allowed. Passing in a nested object will not be permitted to avoid burdening Lightning nodes with excessive data.

Relates to https://github.com/lightning-js/renderer/pull/167 for `data-*` in the Inspector output.