### PR TITLE
README: Add browser targets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ pnpm start
 pnpm start:prod
 ```
 
+## Browser Targets
+
+The Lightning 3 Renderer's goal is to work with the following browser versions and above:
+
+- Chrome v38 (Released October 7, 2014)
+
+Any JavaScript language features or browser APIs that cannot be automatically transpiled or polyfilled by industry standard transpilers (such as Babel) to target these versions must be carefully considered before use.
+
 ## Example Tests
 
 The Example Tests sub-project define a set of tests for various Renderer


### PR DESCRIPTION
Aiming to provide solid clarity on what Lightning 3's goal of browser support is.

Added the Chrome v38 requirement after discussing with @wouterlucas. If we know for sure any other browser versions (and dates) let's discuss here so we can add them.