### PR TITLE
ImageTexture: Fall back to HTMLImageElement in case createImageBitmap is not available

### DIFF
--- a/src/core/CoreTextureManager.ts
+++ b/src/core/CoreTextureManager.ts
@@ -145,7 +145,9 @@ export class CoreTextureManager {
     Texture,
     { cacheKey: string | false; count: number }
   > = new WeakMap();
-  imageWorkerManager: ImageWorkerManager;
+  imageWorkerManager: ImageWorkerManager | null = null;
+  hasCreateImageBitmap = !!self.createImageBitmap;
+  hasWorker = !!self.Worker;
   /**
    * Renderer that this texture manager is associated with
    *
@@ -157,7 +159,16 @@ export class CoreTextureManager {
 
   constructor(numImageWorkers: number) {
     // Register default known texture types
-    this.imageWorkerManager = new ImageWorkerManager(numImageWorkers);
+    if (this.hasCreateImageBitmap && this.hasWorker) {
+      this.imageWorkerManager = new ImageWorkerManager(numImageWorkers);
+    }
+
+    if (!this.hasCreateImageBitmap) {
+      console.warn(
+        '[Lightning] createImageBitmap is not supported on this browser. ImageTexture will be slower.',
+      );
+    }
+
     this.registerTextureType('ImageTexture', ImageTexture);
     this.registerTextureType('ColorTexture', ColorTexture);
     this.registerTextureType('NoiseTexture', NoiseTexture);

--- a/src/core/lib/ImageWorker.ts
+++ b/src/core/lib/ImageWorker.ts
@@ -87,9 +87,7 @@ export class ImageWorkerManager {
     const blob: Blob = new Blob([workerCode.replace('"use strict";', '')], {
       type: 'application/javascript',
     });
-    const blobURL: string = (window.URL ? URL : webkitURL).createObjectURL(
-      blob,
-    );
+    const blobURL: string = (self.URL ? URL : webkitURL).createObjectURL(blob);
     const workers: Worker[] = [];
     for (let i = 0; i < numWorkers; i++) {
       workers.push(new Worker(blobURL));

--- a/src/core/lib/ImageWorker.ts
+++ b/src/core/lib/ImageWorker.ts
@@ -22,21 +22,16 @@ import { type TextureData } from '../textures/Texture.js';
 type MessageCallback = [(value: any) => void, (reason: any) => void];
 
 export class ImageWorkerManager {
-  isWorkerSupported = !!self.Worker;
   imageWorkersEnabled = true;
   messageManager: Record<string, MessageCallback> = {};
   workers: Worker[] = [];
   workerIndex = 0;
 
   constructor(numImageWorkers: number) {
-    if (this.isWorkerSupported && numImageWorkers > 0) {
-      this.workers = this.createWorkers(numImageWorkers);
-      this.workers.forEach((worker) => {
-        worker.onmessage = this.handleMessage.bind(this);
-      });
-    } else {
-      this.imageWorkersEnabled = false;
-    }
+    this.workers = this.createWorkers(numImageWorkers);
+    this.workers.forEach((worker) => {
+      worker.onmessage = this.handleMessage.bind(this);
+    });
   }
 
   private handleMessage(event: MessageEvent) {

--- a/src/core/renderers/webgl/WebGlCoreCtxTexture.ts
+++ b/src/core/renderers/webgl/WebGlCoreCtxTexture.ts
@@ -23,6 +23,7 @@ import type { WebGlContextWrapper } from '../../lib/WebGlContextWrapper.js';
 import type { Texture } from '../../textures/Texture.js';
 import { isPowerOfTwo } from '../../utils.js';
 import { CoreContextTexture } from '../CoreContextTexture.js';
+import { isHTMLImageElement } from './internal/RendererUtils.js';
 
 const TRANSPARENT_TEXTURE_DATA = new Uint8Array([0, 0, 0, 0]);
 
@@ -135,7 +136,9 @@ export class WebGlCoreCtxTexture extends CoreContextTexture {
     // upload any data to the GPU.
     if (
       textureData.data instanceof ImageBitmap ||
-      textureData.data instanceof ImageData
+      textureData.data instanceof ImageData ||
+      // not using typeof HTMLImageElement due to web worker
+      isHTMLImageElement(textureData.data)
     ) {
       const data = textureData.data;
       width = data.width;

--- a/src/core/renderers/webgl/internal/RendererUtils.ts
+++ b/src/core/renderers/webgl/internal/RendererUtils.ts
@@ -129,3 +129,20 @@ export function createIndexBuffer(glw: WebGlContextWrapper, size: number) {
   const buffer = glw.createBuffer();
   glw.elementArrayBufferData(buffer, indices, glw.STATIC_DRAW);
 }
+
+/**
+ * Checks if an object is of type HTMLImageElement.
+ * This is used because we cant check for HTMLImageElement directly when the
+ * renderer is running in a seperate web worker context.
+ *
+ * @param obj
+ * @returns
+ */
+export function isHTMLImageElement(obj: unknown): obj is HTMLImageElement {
+  return (
+    obj !== null &&
+    typeof obj === 'object' &&
+    obj.constructor &&
+    obj.constructor.name === 'HTMLImageElement'
+  );
+}

--- a/src/core/textures/Texture.ts
+++ b/src/core/textures/Texture.ts
@@ -79,7 +79,13 @@ export interface TextureData {
   /**
    * The texture data
    */
-  data: ImageBitmap | ImageData | SubTextureProps | CompressedData | null;
+  data:
+    | ImageBitmap
+    | ImageData
+    | SubTextureProps
+    | CompressedData
+    | HTMLImageElement
+    | null;
   /**
    * Premultiply alpha when uploading texture data to the GPU
    *


### PR DESCRIPTION
In case the browser does not support createImageBitmap the renderer will fallback to using the Image() constructor using HTMLImageElement to fetch images.

**Note** This is slower over using createImageBitmap, Lightning will throw a console.warn to warn its users. 

Addresses: https://github.com/lightning-js/renderer/issues/192 and follows the same fallback pattern as Lightning 2.
This feature will allow the renderer to work on Chrome < 50 where createImageBitmap is not supported. See https://caniuse.com/createimagebitmap for more information.