### PR TITLE
FPS: Update FPS when in idle RAF

### DIFF
--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -243,11 +243,15 @@ export class Stage extends EventEmitter {
 
     renderer?.render();
 
+    this.calculateFps();
+
     // Reset renderRequested flag if it was set
     if (renderRequested) {
       this.renderRequested = false;
     }
+  }
 
+  calculateFps() {
     // If there's an FPS update interval, emit the FPS update event
     // when the specified interval has elapsed.
     const { fpsUpdateInterval } = this.options;

--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -27,6 +27,8 @@ export const startLoop = (stage: Stage) => {
     stage.updateAnimations();
 
     if (!stage.hasSceneUpdates()) {
+      // We still need to calculate the fps else it looks like the app is frozen
+      stage.calculateFps();
       setTimeout(runLoop, 16.666666666666668);
       return;
     }


### PR DESCRIPTION
Currently we do not fire FPS update events when the renderloop is in RAF idle state. This can give the perception that the app is stuck on the previously rendered frame speed.

This changes the FPS events to fire on RAF idle loops as well.