### PR TITLE
Added undefined check to text autosize behavior.

### DIFF
--- a/src/core/CoreTextNode.ts
+++ b/src/core/CoreTextNode.ts
@@ -131,6 +131,9 @@ export class CoreTextNode extends CoreNode implements ICoreTextNode {
   }
 
   override set width(value: number) {
+    if (value === undefined) {
+      return;
+    }
     this.props.width = value;
     this.textRenderer.set.width(this.trState, value);
 
@@ -146,6 +149,9 @@ export class CoreTextNode extends CoreNode implements ICoreTextNode {
   }
 
   override set height(value: number) {
+    if (value === undefined) {
+      return;
+    }
     this.props.height = value;
     this.textRenderer.set.height(this.trState, value);
 


### PR DESCRIPTION
Adding a check for undefined width or height on text node fixes a case where text is not properly displayed in Blits upon first app load (introduced by the changes in #201)