### PR TITLE
feat: #196 add idle event

### DIFF
--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -23,14 +23,20 @@ import type { Stage } from './Stage.js';
  * Platform render loop initiator
  */
 export const startLoop = (stage: Stage) => {
+  let isIdle = false;
   const runLoop = () => {
     stage.updateAnimations();
 
     if (!stage.hasSceneUpdates()) {
       setTimeout(runLoop, 16.666666666666668);
+      if (!isIdle) {
+        stage.emit('idle');
+        isIdle = true;
+      }
       return;
     }
 
+    isIdle = false;
     stage.drawFrame();
     requestAnimationFrame(runLoop);
   };

--- a/src/main-api/ICoreDriver.ts
+++ b/src/main-api/ICoreDriver.ts
@@ -63,4 +63,6 @@ export interface ICoreDriver {
   onFpsUpdate(fpsData: FpsUpdatePayload): void;
 
   onFrameTick(frameTickData: FrameTickPayload): void;
+
+  onIdle?(): void;
 }

--- a/src/main-api/RendererMain.ts
+++ b/src/main-api/RendererMain.ts
@@ -397,6 +397,10 @@ export class RendererMain extends EventEmitter {
       this.emit('frameTick', frameTickData);
     };
 
+    driver.onIdle = () => {
+      this.emit('idle');
+    };
+
     targetEl.appendChild(canvas);
 
     if (enableInspector && !import.meta.env.PROD) {

--- a/src/render-drivers/main/MainCoreDriver.ts
+++ b/src/render-drivers/main/MainCoreDriver.ts
@@ -92,6 +92,10 @@ export class MainCoreDriver implements ICoreDriver {
     this.stage.on('frameTick', ((stage, frameTickData) => {
       this.onFrameTick(frameTickData);
     }) satisfies StageFrameTickHandler);
+
+    this.stage.on('idle', () => {
+      this.onIdle();
+    });
   }
 
   createNode(props: INodeWritableProps): INode {
@@ -143,6 +147,10 @@ export class MainCoreDriver implements ICoreDriver {
   }
 
   onFrameTick(frameTickData: FrameTickPayload) {
+    throw new Error('Method not implemented.');
+  }
+
+  onIdle() {
     throw new Error('Method not implemented.');
   }
   //#endregion


### PR DESCRIPTION
Emit an idle event when renderer isnt performing any actions. Useful for frameworks to do work when nothing is happening. Also threadx doesnt need this as its a separate thread.