### PR TITLE
Perf: Remove unnecessary cascading of premultiply colors update

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -409,8 +409,6 @@ export class CoreNode extends EventEmitter implements ICoreNode {
         );
       }
       this.updateIsRenderable();
-      this.setUpdateType(UpdateType.Children);
-      childUpdateType |= UpdateType.PremultipliedColors;
     }
 
     // No need to update zIndex if there is no parent


### PR DESCRIPTION
![dependency-graph](https://github.com/lightning-js/renderer/assets/6070611/d79824e5-3d58-4ce6-b7fa-00f8fea86025)
According to the dependency graph for CoreNodes, and the logic as I see it in the code, an update to a parent's premultiplied colors should not need to propagate/cascade down to its children.