### PR TITLE
check production environment via function

### DIFF
--- a/src/main-api/Inspector.ts
+++ b/src/main-api/Inspector.ts
@@ -9,6 +9,7 @@ import type { ICoreDriver } from './ICoreDriver.js';
 import { type RendererMainSettings } from './RendererMain.js';
 import type { AnimationSettings } from '../core/animations/CoreAnimation.js';
 import type { IAnimationController } from '../common/IAnimationController.js';
+import { isProductionEnvironment } from '../utils.js';
 
 /**
  * Inspector
@@ -152,7 +153,7 @@ export class Inspector {
   private scaleY = 1;
 
   constructor(canvas: HTMLCanvasElement, settings: RendererMainSettings) {
-    if (import.meta.env.PROD) return;
+    if (isProductionEnvironment()) return;
 
     if (!settings) {
       throw new Error('settings is required');

--- a/src/main-api/RendererMain.ts
+++ b/src/main-api/RendererMain.ts
@@ -40,6 +40,7 @@ import type { TextureUsageTracker } from './texture-usage-trackers/TextureUsageT
 import { EventEmitter } from '../common/EventEmitter.js';
 import { Inspector } from './Inspector.js';
 import { santizeCustomDataMap } from '../render-drivers/utils.js';
+import { isProductionEnvironment } from '../utils.js';
 
 /**
  * An immutable reference to a specific Texture type
@@ -403,7 +404,7 @@ export class RendererMain extends EventEmitter {
 
     targetEl.appendChild(canvas);
 
-    if (enableInspector && !import.meta.env.PROD) {
+    if (enableInspector && !isProductionEnvironment()) {
       this.inspector = new Inspector(canvas, resolvedSettings);
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,7 +79,7 @@ export function assertTruthy(
   condition: unknown,
   message?: string,
 ): asserts condition {
-  if (import.meta.env.PROD) return;
+  if (isProductionEnvironment()) return;
   if (!condition) {
     throw new Error(message || 'Assertion failed');
   }
@@ -204,4 +204,13 @@ export function hasOwn(obj: object, prop: string | number | symbol): boolean {
  */
 export function deg2Rad(degrees: number): number {
   return (degrees * Math.PI) / 180;
+}
+
+/**
+ * Checks import.meta if env is production
+ *
+ * @returns
+ */
+export function isProductionEnvironment(): boolean {
+  return import.meta.env && import.meta.env.PROD;
 }


### PR DESCRIPTION
I was running into problems with import.meta.env not being defined in environments. This function should resolve my problems when running using CDNs that can't set these values since import.meta is protected during runtime.