### PR TITLE
Fixed casing of out of viewport event.

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -612,7 +612,7 @@ export class CoreNode extends EventEmitter implements ICoreNode {
       const previous = this.renderState;
       this.renderState = renderState;
       if (previous === CoreNodeRenderState.InViewport) {
-        this.emit('outOfViewPort', {
+        this.emit('outOfViewport', {
           previous,
           current: renderState,
         });


### PR DESCRIPTION
Event emitted for "out of viewport" was spelled with a capital `P` in `viewport`.

For consistency (and to match the provided example) this should probably have been a lowercase `p`.