### PR TITLE
added canBatchShaderProps to dynamic shader

### DIFF
--- a/src/core/renderers/webgl/shaders/DynamicShader.ts
+++ b/src/core/renderers/webgl/shaders/DynamicShader.ts
@@ -170,6 +170,37 @@ export class DynamicShader extends WebGlCoreShader {
     });
   }
 
+  override canBatchShaderProps(
+    propsA: Required<DynamicShaderProps>,
+    propsB: Required<DynamicShaderProps>,
+  ): boolean {
+    if (
+      propsA.$dimensions.width !== propsB.$dimensions.width ||
+      propsA.$dimensions.height !== propsB.$dimensions.height ||
+      propsA.effects.length !== propsB.effects.length
+    ) {
+      return false;
+    }
+    const propsEffectsLen = propsA.effects.length;
+    let i = 0;
+    for (; i < propsEffectsLen; i++) {
+      const effectA = propsA.effects[i]!;
+      const effectB = propsB.effects[i]!;
+      if (effectA.type !== effectB.type) {
+        return false;
+      }
+      for (const key in effectA.props) {
+        if (
+          (effectB.props && !effectB.props[key]) ||
+          effectA.props[key] !== effectB.props![key]
+        ) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
   static createShader(
     props: DynamicShaderProps,
     effectContructors: Partial<EffectMap>,


### PR DESCRIPTION
Got the batch check for the dynamic shader working properly reducing the draw calls:

Draws without batch check:
<img width="297" alt="without_batch_check" src="https://github.com/lightning-js/renderer/assets/5020139/8d090787-c830-48b4-a016-afe988b0b7d9">

Draws with batch check:
<img width="268" alt="with_batch_check" src="https://github.com/lightning-js/renderer/assets/5020139/1f877f10-e2cb-4498-a31f-1a0208ec832e">

