### PR TITLE
SDF: Fix infinite layout loop

### DIFF
--- a/src/core/text-rendering/renderers/SdfTextRenderer/internal/layoutText.ts
+++ b/src/core/text-rendering/renderers/SdfTextRenderer/internal/layoutText.ts
@@ -235,6 +235,9 @@ export function layoutText(
             );
             curX = lastWord.xStart;
             bufferOffset = lastWord.bufferOffset;
+            // HACK: For the rest of the line when inserting the overflow suffix,
+            // set contain = 'none' to prevent an infinite loop.
+            contain = 'none';
           }
         } else {
           // This glyph fits, so we can add it to the buffer


### PR DESCRIPTION
Another hack to prevent an infinite loop situation that was introduced in v0.8.0.

I've written up an issue to address more wholistically the issues with the SDF layout engine
- #223 

Fixes #220