### PR TITLE
resolve isseus skipping inBounds state

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -608,13 +608,32 @@ export class CoreNode extends EventEmitter implements ICoreNode {
   updateRenderState(parentClippingRect: RectWithValid) {
     const renderState = this.checkRenderBounds(parentClippingRect);
     if (renderState !== this.renderState) {
-      const previous = this.renderState;
+      let previous = this.renderState;
       this.renderState = renderState;
       if (previous === CoreNodeRenderState.InViewport) {
         this.emit('outOfViewport', {
           previous,
           current: renderState,
         });
+      }
+      if (
+        previous < CoreNodeRenderState.InBounds &&
+        renderState === CoreNodeRenderState.InViewport
+      ) {
+        this.emit(CoreNodeRenderStateMap.get(CoreNodeRenderState.InBounds)!, {
+          previous,
+          current: renderState,
+        });
+        previous = CoreNodeRenderState.InBounds;
+      } else if (
+        previous > CoreNodeRenderState.InBounds &&
+        renderState === CoreNodeRenderState.OutOfBounds
+      ) {
+        this.emit(CoreNodeRenderStateMap.get(CoreNodeRenderState.InBounds)!, {
+          previous,
+          current: renderState,
+        });
+        previous = CoreNodeRenderState.InBounds;
       }
       const event = CoreNodeRenderStateMap.get(renderState);
       assertTruthy(event);


### PR DESCRIPTION
This fix resolves skipping the InBounds state when the renderMargin is not configured. In most cases it means that the size of the bounds check is the same as the size of the viewport. With this fix it will still fire an inBounds event when going directly from outOfBounds to inViewport and vice versa.