### PR TITLE
Clear data attribute when value is undefined

### DIFF
--- a/src/main-api/Inspector.ts
+++ b/src/main-api/Inspector.ts
@@ -393,7 +393,12 @@ export class Inspector {
     if (property === 'data') {
       for (const key in value) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        div.setAttribute(`data-${key}`, String(value[key]));
+        const keyValue: unknown = value[key];
+        if (keyValue === undefined) {
+          div.removeAttribute(`data-${key}`);
+        } else {
+          div.setAttribute(`data-${key}`, String(keyValue));
+        }
       }
       return;
     }

--- a/src/render-drivers/utils.ts
+++ b/src/render-drivers/utils.ts
@@ -58,7 +58,7 @@ export async function loadCoreExtension(
 }
 
 export function santizeCustomDataMap(d: CustomDataMap): CustomDataMap {
-  const validTypes = { boolean: true, string: true, number: true };
+  const validTypes = { boolean: true, string: true, number: true, undefined: true };
 
   const keys = Object.keys(d);
   for (let i = 0; i < keys.length; i++) {


### PR DESCRIPTION
Fixes issue in #236 comments: unable to remove an attribute.

When using `data` prop:

1. Once a value is set, it can't be removed; it can only be replaced by another value,
2. Passing an `undefined` value results in `"undefined"` being serialized as the dataset value.

I thing there is an opportunity to use an `undefined` value to clear a property.

Note: I wasn't able to run visual regression tests and had issues with pre-commit hooks.