### PR TITLE
Added production renderer setting for specifying environment

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,7 +1,0 @@
-interface ImportMetaEnv {
-  readonly PROD: boolean;
-}
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+  readonly PROD: boolean;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/main-api/Inspector.ts
+++ b/src/main-api/Inspector.ts
@@ -153,7 +153,8 @@ export class Inspector {
   private scaleY = 1;
 
   constructor(canvas: HTMLCanvasElement, settings: RendererMainSettings) {
-    if (isProductionEnvironment()) return;
+    if (isProductionEnvironment() || (import.meta.env && import.meta.env.PROD))
+      return;
 
     if (!settings) {
       throw new Error('settings is required');

--- a/src/main-api/RendererMain.ts
+++ b/src/main-api/RendererMain.ts
@@ -275,7 +275,8 @@ export interface RendererMainSettings {
    * Production environment
    *
    * @remarks
-   * Sets the renderer to run in production mode
+   * Sets the renderer to run in production mode as an override variable for cases the `import.meta.env.PROD`
+   * environment variable isn't available
    *
    * When set to `true` assertTruthy checks are skipped and ensures that
    * the inspector will not be attached, regardless of the `enableInspector` setting
@@ -432,7 +433,9 @@ export class RendererMain extends EventEmitter {
 
     targetEl.appendChild(canvas);
 
-    if (enableInspector && !isProductionEnvironment()) {
+    if (isProductionEnvironment() || (import.meta.env && import.meta.env.PROD))
+      return;
+    if (enableInspector) {
       this.inspector = new Inspector(canvas, resolvedSettings);
     }
   }

--- a/src/main-api/RendererMain.ts
+++ b/src/main-api/RendererMain.ts
@@ -40,7 +40,7 @@ import type { TextureUsageTracker } from './texture-usage-trackers/TextureUsageT
 import { EventEmitter } from '../common/EventEmitter.js';
 import { Inspector } from './Inspector.js';
 import { santizeCustomDataMap } from '../render-drivers/utils.js';
-import { isProductionEnvironment } from '../utils.js';
+import { isProductionEnvironment, setProductionEnvironment } from '../utils.js';
 
 /**
  * An immutable reference to a specific Texture type
@@ -270,6 +270,19 @@ export interface RendererMainSettings {
    * @defaultValue `false` (disabled)
    */
   enableInspector?: boolean;
+  /**
+   *
+   * Production environment
+   *
+   * @remarks
+   * Sets the renderer to run in production mode
+   *
+   * When set to `true` assertTruthy checks are skipped and ensures that
+   * the inspector will not be attached, regardless of the `enableInspector` setting
+   *
+   * @defaultValue `false`
+   */
+  production?: boolean;
 }
 
 /**
@@ -344,8 +357,11 @@ export class RendererMain extends EventEmitter {
         settings.numImageWorkers !== undefined ? settings.numImageWorkers : 2,
       enableContextSpy: settings.enableContextSpy ?? false,
       enableInspector: settings.enableInspector ?? false,
+      production: settings.production ?? false,
     };
     this.settings = resolvedSettings;
+
+    setProductionEnvironment(this.settings.production);
 
     const {
       appWidth,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,7 +79,8 @@ export function assertTruthy(
   condition: unknown,
   message?: string,
 ): asserts condition {
-  if (isProductionEnvironment()) return;
+  if (isProductionEnvironment() || (import.meta.env && import.meta.env.PROD))
+    return;
   if (!condition) {
     throw new Error(message || 'Assertion failed');
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -217,11 +217,21 @@ export function getImageAspectRatio(width: number, height: number): number {
   return width / height;
 }
 
+let productionEnvironment = false;
+
 /**
- * Checks import.meta if env is production
+ * Checks environment is set to production
  *
  * @returns
  */
 export function isProductionEnvironment(): boolean {
-  return import.meta.env && import.meta.env.PROD;
+  return productionEnvironment;
+}
+
+/**
+ * Sets the production environment
+ * @param environment
+ */
+export function setProductionEnvironment(environment: boolean): void {
+  productionEnvironment = environment;
 }


### PR DESCRIPTION
Currently the renderer depends on bundler specific `import.meta.env` for setting its production environment and skipping `assertTruthy` checks.

With this change, the production environment can be set from the App via a renderer setting. In an app the environment can still rely on `import.meta.env` (or any other mechanism to set the environment), but this leaves the renderer free of any bundler specific logic.

This solves issues when importing the renderer as a standalone prebuilt package (as is the case in the Lightning playground).

Open to suggestions on the naming. I have considered to name the property `environment` and allowing different strings (i.e. production, staging, testing, development), but ended up keeping it simple as it only seems to affect the assertTruthy check when running in prod.