### PR TITLE
Fix: Race condition on this.StoppedPromise with animations

### DIFF
--- a/src/core/animations/CoreAnimationController.ts
+++ b/src/core/animations/CoreAnimationController.ts
@@ -48,10 +48,16 @@ export class CoreAnimationController implements IAnimationController {
   state: AnimationControllerState;
 
   start(): IAnimationController {
-    this.makeStartedPromise();
+    this.startedPromise = new Promise((resolve) => {
+      this.startedResolve = resolve;
+    });
+
     this.animation.once('start', this.started.bind(this));
 
-    this.makeStoppedPromise();
+    this.stoppedPromise = new Promise((resolve) => {
+      this.stoppedResolve = resolve;
+    });
+
     this.animation.once('finished', this.finished.bind(this));
 
     // prevent registering the same animation twice
@@ -87,33 +93,13 @@ export class CoreAnimationController implements IAnimationController {
   }
 
   waitUntilStarted(): Promise<void> {
-    this.makeStartedPromise();
-    const promise = this.startedPromise;
-    assertTruthy(promise);
-    return promise;
+    assertTruthy(this.startedPromise);
+    return this.startedPromise;
   }
 
   waitUntilStopped(): Promise<void> {
-    this.makeStoppedPromise();
-    const promise = this.stoppedPromise;
-    assertTruthy(promise);
-    return promise;
-  }
-
-  private makeStartedPromise(): void {
-    if (this.startedResolve === null) {
-      this.startedPromise = new Promise((resolve) => {
-        this.startedResolve = resolve;
-      });
-    }
-  }
-
-  private makeStoppedPromise(): void {
-    if (this.stoppedResolve === null) {
-      this.stoppedPromise = new Promise((resolve) => {
-        this.stoppedResolve = resolve;
-      });
-    }
+    assertTruthy(this.stoppedPromise);
+    return this.stoppedPromise;
   }
 
   private started(): void {
@@ -139,6 +125,11 @@ export class CoreAnimationController implements IAnimationController {
     this.stoppedResolve = null;
 
     if (loop) {
+      // generate new promise and resolve function
+      this.stoppedPromise = new Promise((resolve) => {
+        this.stoppedResolve = resolve;
+      });
+
       return;
     }
 


### PR DESCRIPTION
This PR moves the creation of the promise to 1 spot for both the `start()` case as well as the `loop` case, whereas `waitUntilStopped()` only returns what's created prior. Avoiding potential race conditions.

In our tests we see an animation that gets created early on during boot of the app get "stuck", never getting a promise resolve and essentially hanging the calling party.

 *The theory*:
`waitUntilStopped()` calls  `this.makeStoppedPromise();` and grabs a promise from `this.stoppedPromise`. However if `this.makeStoppedPromise();` 's creation of its `promise` is pushed to the next tick because there is a lot going on (e.g. an app is booting up) essentially not assigning `this.stoppedResolve` yet this could lead to an unresolved promise (with a short animation).

 *AND/OR*:

Both the animation `start()` AND `waitUntilStopped` are calling `this.makeStoppedPromise();` nearly simulatenously or across tick boundaries, resulting in both passing the `(this.startedResolve === null)` check and essentially overwriting each others `this.startedResolve` values. Causing the first `this.stoppedResolve` to never resolve.

The following is an app loaded on Glass with the bug:
![StuckAnimation](https://github.com/lightning-js/renderer/assets/1534440/059a6b21-e2da-4446-ab86-198acc43db1f)

By adding a console log in the animation start, you can see its stuck per:
```js
diff --git a/src/core/animations/CoreAnimation.ts b/src/core/animations/CoreAnimation.ts
index 251b048..f27d0dd 100644
--- a/src/core/animations/CoreAnimation.ts
+++ b/src/core/animations/CoreAnimation.ts
@@ -114,6 +114,7 @@ export class CoreAnimation extends EventEmitter {

     if (this.delayFor <= 0 && this.progress === 0) {
       this.emit('start', {});
+      console.log('Starting animation', this.node.id, this.propsList);
     }

     this.progress += dt / duration;
```

Results in:
![StuckAnimation2](https://github.com/lightning-js/renderer/assets/1534440/f8c1073e-27e0-472d-a39c-9aa42cc3eec7)

With the suggested change the animation gets unloaded and CPU load normalizes:
![StuckAnimationFix](https://github.com/lightning-js/renderer/assets/1534440/d1977476-5a19-481e-a228-1e19c9fbebd3)

And no longer prints a stuck animation in the console.log:
![StuckAnimationFix2](https://github.com/lightning-js/renderer/assets/1534440/42e1b8cb-cf9f-4921-9cf9-874b9b16c908)
