### PR TITLE
fix: cross image support on base images

### DIFF
--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -117,8 +117,7 @@ export class ImageTexture extends Texture {
       };
     } else {
       const img = new Image();
-      if (!(src.substr(0, 5) == 'data:')) {
-        // Base64.
+      if (!(src.substr(0, 5) === 'data:')) {
         img.crossOrigin = 'Anonymous';
       }
       img.src = src;

--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -117,6 +117,10 @@ export class ImageTexture extends Texture {
       };
     } else {
       const img = new Image();
+      if (!(src.substr(0, 5) == 'data:')) {
+        // Base64.
+        img.crossOrigin = 'Anonymous';
+      }
       img.src = src;
       await new Promise<void>((resolve, reject) => {
         img.onload = () => resolve();


### PR DESCRIPTION
Gets images loading in older browsers when cross domain. This is the same as what L2 did. Tested with TMDB app and its working.