### PR TITLE
Canvas 2D renderer

### DIFF
--- a/examples/common/AppCoreExtension.ts
+++ b/examples/common/AppCoreExtension.ts
@@ -34,26 +34,28 @@ export default class AppCoreExtension extends CoreExtension {
       new WebTrFontFace('Ubuntu', {}, '/fonts/Ubuntu-Regular.ttf'),
     );
 
-    stage.fontManager.addFontFace(
-      new SdfTrFontFace(
-        'Ubuntu',
-        {},
-        'msdf',
-        stage,
-        '/fonts/Ubuntu-Regular.msdf.png',
-        '/fonts/Ubuntu-Regular.msdf.json',
-      ),
-    );
+    if (stage.renderer.mode === 'webgl') {
+      stage.fontManager.addFontFace(
+        new SdfTrFontFace(
+          'Ubuntu',
+          {},
+          'msdf',
+          stage,
+          '/fonts/Ubuntu-Regular.msdf.png',
+          '/fonts/Ubuntu-Regular.msdf.json',
+        ),
+      );
 
-    stage.fontManager.addFontFace(
-      new SdfTrFontFace(
-        'Ubuntu-ssdf',
-        {},
-        'ssdf',
-        stage,
-        '/fonts/Ubuntu-Regular.ssdf.png',
-        '/fonts/Ubuntu-Regular.ssdf.json',
-      ),
-    );
+      stage.fontManager.addFontFace(
+        new SdfTrFontFace(
+          'Ubuntu-ssdf',
+          {},
+          'ssdf',
+          stage,
+          '/fonts/Ubuntu-Regular.ssdf.png',
+          '/fonts/Ubuntu-Regular.ssdf.json',
+        ),
+      );
+    }
   }
 }

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -84,10 +84,16 @@ const defaultPhysicalPixelRatio = 1;
     driverName = 'main';
   }
 
+  let renderMode = urlParams.get('renderMode');
+  if (driverName === 'threadx' || (renderMode !== 'webgl' && renderMode !== 'canvas')) {
+    renderMode = 'webgl';
+  }
+
   if (test) {
     await runTest(
       test,
       driverName,
+      renderMode,
       urlParams,
       showOverlay,
       logicalPixelRatio,
@@ -100,7 +106,7 @@ const defaultPhysicalPixelRatio = 1;
     return;
   }
   assertTruthy(automation);
-  await runAutomation(driverName, logFps);
+  await runAutomation(driverName, renderMode, logFps);
 })().catch((err) => {
   console.error(err);
 });
@@ -108,6 +114,7 @@ const defaultPhysicalPixelRatio = 1;
 async function runTest(
   test: string,
   driverName: string,
+  renderMode: string,
   urlParams: URLSearchParams,
   showOverlay: boolean,
   logicalPixelRatio: number,
@@ -132,6 +139,7 @@ async function runTest(
 
   const { renderer, appElement } = await initRenderer(
     driverName,
+    renderMode,
     logFps,
     enableContextSpy,
     logicalPixelRatio,
@@ -177,6 +185,7 @@ async function runTest(
 
 async function initRenderer(
   driverName: string,
+  renderMode: string,
   logFps: boolean,
   enableContextSpy: boolean,
   logicalPixelRatio: number,
@@ -206,6 +215,7 @@ async function initRenderer(
       fpsUpdateInterval: logFps ? 1000 : 0,
       enableContextSpy,
       enableInspector,
+      renderMode: renderMode as ('webgl' | 'canvas'),
       ...customSettings,
     },
     'app',
@@ -304,10 +314,11 @@ async function initRenderer(
   return { renderer, appElement };
 }
 
-async function runAutomation(driverName: string, logFps: boolean) {
+async function runAutomation(driverName: string, renderMode: string, logFps: boolean) {
   const logicalPixelRatio = defaultResolution / appHeight;
   const { renderer, appElement } = await initRenderer(
     driverName,
+    renderMode,
     logFps,
     false,
     logicalPixelRatio,

--- a/src/core/CoreShaderManager.ts
+++ b/src/core/CoreShaderManager.ts
@@ -61,6 +61,8 @@ import {
   type RadialProgressEffectProps,
 } from './renderers/webgl/shaders/effects/RadialProgressEffect.js';
 import { HolePunchEffect } from './renderers/webgl/shaders/effects/HolePunchEffect.js';
+import { WebGlCoreShader } from './renderers/webgl/WebGlCoreShader.js';
+import { UnsupportedShader } from './renderers/canvas/shaders/UnsupportedShader.js';
 
 export type { FadeOutEffectProps };
 export type { LinearGradientEffectProps };
@@ -75,6 +77,7 @@ export interface ShaderMap {
   RoundedRectangle: typeof RoundedRectangle;
   DynamicShader: typeof DynamicShader;
   SdfShader: typeof SdfShader;
+  UnsupportedShader: typeof UnsupportedShader;
 }
 
 export type ShaderNode<Type extends keyof ShaderMap> = {
@@ -168,6 +171,13 @@ export class CoreShaderManager {
     const ShaderClass = this.shConstructors[shType];
     if (!ShaderClass) {
       throw new Error(`Shader type "${shType as string}" is not registered`);
+    }
+
+    if (this.renderer.mode === 'canvas' && ShaderClass.prototype instanceof WebGlCoreShader) {
+      return {
+        shader: new UnsupportedShader(shType) as InstanceType<ShaderMap[Type]>,
+        props: {}
+      }
     }
 
     if (shType === 'DynamicShader') {

--- a/src/core/CoreShaderManager.ts
+++ b/src/core/CoreShaderManager.ts
@@ -176,7 +176,7 @@ export class CoreShaderManager {
     if (this.renderer.mode === 'canvas' && ShaderClass.prototype instanceof WebGlCoreShader) {
       return {
         shader: new UnsupportedShader(shType) as InstanceType<ShaderMap[Type]>,
-        props: {}
+        props: props as Record<string, unknown>
       }
     }
 

--- a/src/core/renderers/CoreRenderer.ts
+++ b/src/core/renderers/CoreRenderer.ts
@@ -18,12 +18,14 @@
  */
 
 import type { CoreShaderManager } from '../CoreShaderManager.js';
-import type { TextureOptions } from '../CoreTextureManager.js';
+import type { CoreTextureManager, TextureOptions } from '../CoreTextureManager.js';
 import type { Stage } from '../Stage.js';
-import type { Rect, RectWithValid } from '../lib/utils.js';
+import type { TextureMemoryManager } from '../TextureMemoryManager.js';
+import type { ContextSpy } from '../lib/ContextSpy.js';
+import type { RectWithValid } from '../lib/utils.js';
+import { ColorTexture } from '../textures/ColorTexture.js';
 import type { Texture } from '../textures/Texture.js';
 import { CoreContextTexture } from './CoreContextTexture.js';
-import type { CoreRenderOp } from './CoreRenderOp.js';
 import type { CoreShader } from './CoreShader.js';
 
 export interface QuadOptions {
@@ -48,15 +50,39 @@ export interface QuadOptions {
   td: number;
 }
 
+export interface CoreRendererOptions {
+  stage: Stage;
+  canvas: HTMLCanvasElement | OffscreenCanvas;
+  pixelRatio: number;
+  txManager: CoreTextureManager;
+  txMemManager: TextureMemoryManager;
+  shManager: CoreShaderManager;
+  clearColor: number;
+  bufferMemory: number;
+  contextSpy: ContextSpy | null;
+}
+
 export abstract class CoreRenderer {
+  public options: CoreRendererOptions;
+  public mode: 'webgl' | 'canvas' | undefined;
+
   protected stage: Stage;
 
-  constructor(stage: Stage) {
-    this.stage = stage;
+  //// Core Managers
+  txManager: CoreTextureManager;
+  txMemManager: TextureMemoryManager;
+  shManager: CoreShaderManager;
+
+  constructor(options: CoreRendererOptions) {
+    this.options = options;
+    this.stage = options.stage;
+    this.txManager = options.txManager;
+    this.txMemManager = options.txMemManager;
+    this.shManager = options.shManager;
   }
 
   abstract reset(): void;
-  abstract render(surface: 'screen' | CoreContextTexture): void;
+  abstract render(surface?: 'screen' | CoreContextTexture): void;
   abstract addQuad(quad: QuadOptions): void;
   abstract createCtxTexture(textureSource: Texture): CoreContextTexture;
   abstract getShaderManager(): CoreShaderManager;

--- a/src/core/renderers/canvas/CanvasCoreRenderer.ts
+++ b/src/core/renderers/canvas/CanvasCoreRenderer.ts
@@ -1,0 +1,141 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { CoreShaderManager } from "../../CoreShaderManager.js";
+import { SubTexture } from "../../textures/SubTexture.js";
+import type { Texture } from "../../textures/Texture.js";
+import type { CoreContextTexture } from "../CoreContextTexture.js";
+import { CoreRenderer, type CoreRendererOptions, type QuadOptions } from "../CoreRenderer.js";
+import { CanvasCoreTexture } from "./CanvasCoreTexture.js";
+import { formatRgba, parseColor } from "./internal/ColorUtils.js";
+
+export class CanvasCoreRenderer extends CoreRenderer {
+
+  private context: CanvasRenderingContext2D;
+  private canvas: HTMLCanvasElement;
+  private pixelRatio: number;
+
+  constructor(options: CoreRendererOptions) {
+    super(options);
+
+    this.mode = 'canvas';
+    this.shManager.renderer = this;
+
+    const { canvas, pixelRatio} = options;
+    this.canvas = canvas as HTMLCanvasElement;
+    this.context = canvas.getContext('2d') as CanvasRenderingContext2D;
+    this.pixelRatio = pixelRatio;
+  }
+
+  reset(): void {
+    // quick reset canvas
+    this.canvas.width = this.canvas.width ?? 1920;
+    this.context.scale(this.pixelRatio, this.pixelRatio);
+  }
+
+  render(): void {
+    // noop
+  }
+
+  addQuad(quad: QuadOptions): void {
+    const ctx = this.context;
+    const {
+      tx, ty, width, height, alpha, colorTl, ta, tb, tc, td, clippingRect
+    } = quad;
+    let texture = quad.texture;
+    let ctxTexture: CanvasCoreTexture | undefined = undefined;
+    let frame: { x: number, y: number, width: number, height: number } | undefined;
+
+    if (texture) {
+      if (texture instanceof SubTexture) {
+        frame = texture.props;
+        texture = texture.parentTexture;
+      }
+
+      ctxTexture = this.txManager.getCtxTexture(texture) as CanvasCoreTexture;
+      if (texture.state === 'freed') {
+        ctxTexture.load();
+        return;
+      }
+      if (texture.state !== 'loaded' || !ctxTexture.hasImage()) {
+        return;
+      }
+    }
+
+    const color = parseColor(colorTl);
+    const hasTransform = ta !== 1;
+    const hasClipping = clippingRect.width !== 0 && clippingRect.height !== 0;
+
+    if (hasTransform || hasClipping) {
+      ctx.save();
+    }
+
+    if (hasClipping) {
+      const { x, y, width, height } = quad.clippingRect;
+      ctx.beginPath();
+      ctx.moveTo(x, y);
+      ctx.lineTo(x + width, y);
+      ctx.lineTo(x + width, y + height);
+      ctx.lineTo(x, y + height);
+      ctx.closePath();
+      ctx.clip();
+    }
+
+    if (hasTransform) {
+      // Quad transform:
+      // | ta tb tx |
+      // | tc td ty |
+      // | 0  0  1  |
+      // C2D transform:
+      // | a  c  e  |
+      // | b  d  f  |
+      // | 0  0  1  |
+      const scale = this.pixelRatio;
+      ctx.setTransform(ta, tc, tb, td, tx * scale, ty * scale);
+      ctx.scale(scale, scale);
+      ctx.translate(-tx, -ty);
+    }
+
+    if (ctxTexture) {
+      const image = ctxTexture.getImage(color);
+      ctx.globalAlpha = alpha;
+      if (frame) {
+        ctx.drawImage(image, frame.x, frame.y, frame.width, frame.height, tx, ty, width, height);
+      } else {
+        ctx.drawImage(image, tx, ty, width, height);
+      }
+      ctx.globalAlpha = 1;
+    } else {
+      ctx.fillStyle = formatRgba(color);
+      ctx.fillRect(tx, ty, width, height);
+    }
+
+    if (hasTransform || hasClipping) {
+      ctx.restore();
+    }
+  }
+
+  createCtxTexture(textureSource: Texture): CoreContextTexture {
+    return new CanvasCoreTexture(this.txMemManager, textureSource);
+  }
+
+  getShaderManager(): CoreShaderManager {
+    return this.shManager;
+  }
+}

--- a/src/core/renderers/canvas/CanvasCoreRenderer.ts
+++ b/src/core/renderers/canvas/CanvasCoreRenderer.ts
@@ -18,6 +18,7 @@
  */
 
 import type { CoreShaderManager } from "../../CoreShaderManager.js";
+import { getRgbaComponents, type RGBA } from "../../lib/utils.js";
 import { SubTexture } from "../../textures/SubTexture.js";
 import type { Texture } from "../../textures/Texture.js";
 import type { CoreContextTexture } from "../CoreContextTexture.js";
@@ -30,6 +31,7 @@ export class CanvasCoreRenderer extends CoreRenderer {
   private context: CanvasRenderingContext2D;
   private canvas: HTMLCanvasElement;
   private pixelRatio: number;
+  private clearColor: RGBA | undefined;
 
   constructor(options: CoreRendererOptions) {
     super(options);
@@ -37,16 +39,25 @@ export class CanvasCoreRenderer extends CoreRenderer {
     this.mode = 'canvas';
     this.shManager.renderer = this;
 
-    const { canvas, pixelRatio} = options;
+    const { canvas, pixelRatio, clearColor } = options;
     this.canvas = canvas as HTMLCanvasElement;
     this.context = canvas.getContext('2d') as CanvasRenderingContext2D;
     this.pixelRatio = pixelRatio;
+    this.clearColor = clearColor ? getRgbaComponents(clearColor) : undefined;
   }
 
   reset(): void {
     // quick reset canvas
     this.canvas.width = this.canvas.width ?? 1920;
-    this.context.scale(this.pixelRatio, this.pixelRatio);
+    const ctx = this.context;
+
+    if (this.clearColor) {
+      const [r, g, b, a] = this.clearColor;
+      ctx.fillStyle = `rgba(${r}, ${g}, ${b}, ${a / 255})`;
+      ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+    }
+
+    ctx.scale(this.pixelRatio, this.pixelRatio);
   }
 
   render(): void {

--- a/src/core/renderers/canvas/CanvasCoreRenderer.ts
+++ b/src/core/renderers/canvas/CanvasCoreRenderer.ts
@@ -48,8 +48,9 @@ export class CanvasCoreRenderer extends CoreRenderer {
   }
 
   reset(): void {
-    // quick reset canvas
-    this.canvas.width = this.canvas.width ?? 1920;
+    // eslint-disable-next-line no-self-assign
+    this.canvas.width = this.canvas.width; // quick reset canvas
+
     const ctx = this.context;
 
     if (this.clearColor) {

--- a/src/core/renderers/canvas/CanvasCoreTexture.ts
+++ b/src/core/renderers/canvas/CanvasCoreTexture.ts
@@ -1,0 +1,117 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Dimensions } from "../../../common/CommonTypes.js";
+import { assertTruthy } from "../../../utils.js";
+import { CoreContextTexture } from "../CoreContextTexture.js";
+import { formatRgba, type IParsedColor } from "./internal/ColorUtils.js";
+
+export class CanvasCoreTexture extends CoreContextTexture {
+
+  protected image: ImageBitmap | HTMLCanvasElement | undefined;
+  protected tintCache: {
+    key: string;
+    image: HTMLCanvasElement
+  } | undefined;
+
+  load(): void {
+    if (this.textureSource.state !== 'freed') return;
+    this.textureSource.setState('loading');
+    this.onLoadRequest().then((size) => {
+      this.textureSource.setState('loaded', size);
+      this.memManager.setTextureMemUse(this, size.width * size.height * 4);
+    }).catch((err) => {
+      this.textureSource.setState('failed', err as Error);
+    });
+  }
+
+  free(): void {
+    this.image = undefined;
+    this.tintCache = undefined;
+    this.textureSource.setState('freed');
+    this.memManager.setTextureMemUse(this, 0);
+  }
+
+  hasImage(): boolean {
+    return this.image !== undefined;
+  }
+
+  getImage(color: IParsedColor): ImageBitmap | HTMLCanvasElement {
+    const image = this.image;
+    assertTruthy(image, 'Attempt to get unloaded image texture');
+
+    if (color.isWhite) {
+      return image;
+    }
+    const key = formatRgba(color);
+    if (this.tintCache?.key === key) {
+      return this.tintCache.image;
+    }
+
+    this.tintCache = {
+      key,
+      image: this.tintTexture(image, key)
+    }
+    return this.tintCache.image;
+  }
+
+  protected tintTexture(source: ImageBitmap | HTMLCanvasElement, color: string) {
+    const { width, height } = source;
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d');
+    if (ctx) {
+      // fill with target color
+      ctx.fillStyle = color;
+      ctx.globalCompositeOperation = 'copy';
+      ctx.fillRect(0, 0, width, height);
+
+      // multiply with image, resulting in non-transparent tinted image
+      ctx.globalCompositeOperation = 'multiply';
+      ctx.drawImage(source, 0, 0, width, height, 0, 0, width, height);
+
+      // apply original image alpha
+      ctx.globalCompositeOperation = 'destination-in';
+      ctx.drawImage(source, 0, 0, width, height, 0, 0, width, height);
+    }
+    return canvas;
+  }
+
+  get renderable(): boolean {
+    return this.textureSource.renderable;
+  }
+
+  private async onLoadRequest(): Promise<Dimensions> {
+    const { data } = await this.textureSource.getTextureData();
+    if (data instanceof ImageData) {
+      const canvas = document.createElement('canvas');
+      canvas.width = data.width;
+      canvas.height = data.height;
+      const ctx = canvas.getContext('2d');
+      if (ctx) ctx.putImageData(data, 0, 0);
+      this.image = canvas;
+      return { width: data.width, height: data.height };
+    } else if (data instanceof ImageBitmap) {
+      this.image = data;
+      return { width: data.width, height: data.height };
+    }
+    return { width: 0, height: 0 };
+  }
+}

--- a/src/core/renderers/canvas/CanvasCoreTexture.ts
+++ b/src/core/renderers/canvas/CanvasCoreTexture.ts
@@ -31,7 +31,9 @@ export class CanvasCoreTexture extends CoreContextTexture {
   } | undefined;
 
   load(): void {
-    if (this.textureSource.state !== 'freed') return;
+    if (this.textureSource.state !== 'freed') {
+      return;
+    }
     this.textureSource.setState('loading');
     this.onLoadRequest().then((size) => {
       this.textureSource.setState('loaded', size);

--- a/src/core/renderers/canvas/CanvasCoreTexture.ts
+++ b/src/core/renderers/canvas/CanvasCoreTexture.ts
@@ -52,7 +52,6 @@ export class CanvasCoreTexture extends CoreContextTexture {
     // Counting memory usage for:
     // - main image
     // - tinted image
-    // - should we count the source texture in addition?
     const mult = this.tintCache ? 8 : 4;
     if (this.textureSource.dimensions) {
       const { width, height } = this.textureSource.dimensions;

--- a/src/core/renderers/canvas/internal/C2DShaderUtils.ts
+++ b/src/core/renderers/canvas/internal/C2DShaderUtils.ts
@@ -18,7 +18,7 @@
  */
 
 import type { QuadOptions } from "../../CoreRenderer.js";
-import { UnsupportedShader } from "../shaders/UnsupportedShader.js";
+import { ROUNDED_RECTANGLE_SHADER_TYPE, UnsupportedShader } from "../shaders/UnsupportedShader.js";
 
 /**
  * Extract `RoundedRectangle` shader radius to apply as a clipping
@@ -26,7 +26,7 @@ import { UnsupportedShader } from "../shaders/UnsupportedShader.js";
 export function getRadius(quad: QuadOptions): number {
   if (quad.shader instanceof UnsupportedShader) {
     const shType = quad.shader.shType;
-    if (shType === "RoundedRectangle") {
+    if (shType === ROUNDED_RECTANGLE_SHADER_TYPE) {
       return quad.shaderProps?.radius as number ?? 0;
     }
   }

--- a/src/core/renderers/canvas/internal/C2DShaderUtils.ts
+++ b/src/core/renderers/canvas/internal/C2DShaderUtils.ts
@@ -1,0 +1,34 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { QuadOptions } from "../../CoreRenderer.js";
+import { UnsupportedShader } from "../shaders/UnsupportedShader.js";
+
+/**
+ * Extract `RoundedRectangle` shader radius to apply as a clipping
+ */
+export function getRadius(quad: QuadOptions): number {
+  if (quad.shader instanceof UnsupportedShader) {
+    const shType = quad.shader.shType;
+    if (shType === "RoundedRectangle") {
+      return quad.shaderProps?.radius as number ?? 0;
+    }
+  }
+  return 0;
+}

--- a/src/core/renderers/canvas/internal/ColorUtils.ts
+++ b/src/core/renderers/canvas/internal/ColorUtils.ts
@@ -36,14 +36,14 @@ const WHITE: IParsedColor = {
 /**
  * Extract color components
  */
-export function parseColor(value: number): IParsedColor {
-  if (value === 0xffffffff) {
+export function parseColor(abgr: number): IParsedColor {
+  if (abgr === 0xffffffff) {
     return WHITE;
   }
-  const a = ((value >>> 24) & 0xff) / 255;
-  const b = ((value >>> 16) & 0xff) & 0xff;
-  const g = ((value >>> 8) & 0xff) & 0xff;
-  const r = (value & 0xff) & 0xff;
+  const a = ((abgr >>> 24) & 0xff) / 255;
+  const b = ((abgr >>> 16) & 0xff) & 0xff;
+  const g = ((abgr >>> 8) & 0xff) & 0xff;
+  const r = (abgr & 0xff) & 0xff;
   return { isWhite: false, a, r, g, b }
 }
 

--- a/src/core/renderers/canvas/internal/ColorUtils.ts
+++ b/src/core/renderers/canvas/internal/ColorUtils.ts
@@ -1,0 +1,55 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface IParsedColor {
+  isWhite: boolean;
+  a: number;
+  r: number;
+  g: number;
+  b: number;
+}
+
+const WHITE: IParsedColor = {
+  isWhite: true,
+  a: 1,
+  r: 0xff,
+  g: 0xff,
+  b: 0xff
+}
+
+/**
+ * Extract color components
+ */
+export function parseColor(value: number): IParsedColor {
+  if (value === 0xffffffff) {
+    return WHITE;
+  }
+  const a = ((value >>> 24) & 0xff) / 255;
+  const b = ((value >>> 16) & 0xff) & 0xff;
+  const g = ((value >>> 8) & 0xff) & 0xff;
+  const r = (value & 0xff) & 0xff;
+  return { isWhite: false, a, r, g, b }
+}
+
+/**
+ * Format a parsed color into a rgba CSS color
+ */
+export function formatRgba({ a, r, g, b }: IParsedColor): string {
+  return `rgba(${r},${g},${b},${a})`;
+}

--- a/src/core/renderers/canvas/shaders/UnsupportedShader.ts
+++ b/src/core/renderers/canvas/shaders/UnsupportedShader.ts
@@ -19,6 +19,8 @@
 
 import { CoreShader } from "../../CoreShader.js";
 
+export const ROUNDED_RECTANGLE_SHADER_TYPE = "RoundedRectangle"
+
 export class UnsupportedShader extends CoreShader {
 
   public shType: string;
@@ -26,7 +28,9 @@ export class UnsupportedShader extends CoreShader {
   constructor(shType: string) {
     super();
     this.shType = shType;
-    console.warn('Unsupported shader:', shType);
+    if (shType !== ROUNDED_RECTANGLE_SHADER_TYPE) {
+      console.warn('Unsupported shader:', shType);
+    }
   }
 
   bindRenderOp(): void {

--- a/src/core/renderers/canvas/shaders/UnsupportedShader.ts
+++ b/src/core/renderers/canvas/shaders/UnsupportedShader.ts
@@ -1,0 +1,45 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CoreShader } from "../../CoreShader.js";
+
+export class UnsupportedShader extends CoreShader {
+
+  public shType: string;
+
+  constructor(shType: string) {
+    super();
+    this.shType = shType;
+    console.warn('Unsupported shader:', shType);
+  }
+
+  bindRenderOp(): void {
+    // noop
+  }
+  protected bindProps(): void {
+    // noop
+  }
+
+  attach(): void {
+    // noop
+  }
+  detach(): void {
+    // noop
+  }
+}

--- a/src/core/renderers/webgl/WebGlCoreRenderer.ts
+++ b/src/core/renderers/webgl/WebGlCoreRenderer.ts
@@ -21,9 +21,8 @@ import {
   assertTruthy,
   createWebGLContext,
   hasOwn,
-  mergeColorAlphaPremultiplied,
 } from '../../../utils.js';
-import { CoreRenderer, type QuadOptions } from '../CoreRenderer.js';
+import { CoreRenderer, type CoreRendererOptions, type QuadOptions } from '../CoreRenderer.js';
 import { WebGlCoreRenderOp } from './WebGlCoreRenderOp.js';
 import type { CoreContextTexture } from '../CoreContextTexture.js';
 import {
@@ -36,43 +35,23 @@ import {
 import { WebGlCoreCtxTexture } from './WebGlCoreCtxTexture.js';
 import { Texture } from '../../textures/Texture.js';
 import { ColorTexture } from '../../textures/ColorTexture.js';
-import type { Stage } from '../../Stage.js';
 import { SubTexture } from '../../textures/SubTexture.js';
 import { WebGlCoreCtxSubTexture } from './WebGlCoreCtxSubTexture.js';
-import type {
-  CoreTextureManager,
-  TextureOptions,
-} from '../../CoreTextureManager.js';
 import { CoreShaderManager } from '../../CoreShaderManager.js';
-import type { CoreShader } from '../CoreShader.js';
 import { BufferCollection } from './internal/BufferCollection.js';
 import {
   compareRect,
   getNormalizedRgbaComponents,
-  type Rect,
   type RectWithValid,
 } from '../../lib/utils.js';
 import type { Dimensions } from '../../../common/CommonTypes.js';
 import { WebGlCoreShader } from './WebGlCoreShader.js';
-import { RoundedRectangle } from './shaders/RoundedRectangle.js';
-import { ContextSpy } from '../../lib/ContextSpy.js';
 import { WebGlContextWrapper } from '../../lib/WebGlContextWrapper.js';
-import type { TextureMemoryManager } from '../../TextureMemoryManager.js';
 
 const WORDS_PER_QUAD = 24;
-const BYTES_PER_QUAD = WORDS_PER_QUAD * 4;
+// const BYTES_PER_QUAD = WORDS_PER_QUAD * 4;
 
-export interface WebGlCoreRendererOptions {
-  stage: Stage;
-  canvas: HTMLCanvasElement | OffscreenCanvas;
-  pixelRatio: number;
-  txManager: CoreTextureManager;
-  txMemManager: TextureMemoryManager;
-  shManager: CoreShaderManager;
-  clearColor: number;
-  bufferMemory: number;
-  contextSpy: ContextSpy | null;
-}
+export type WebGlCoreRendererOptions = CoreRendererOptions;
 
 interface CoreWebGlSystem {
   parameters: CoreWebGlParameters;
@@ -83,14 +62,6 @@ export class WebGlCoreRenderer extends CoreRenderer {
   //// WebGL Native Context and Data
   glw: WebGlContextWrapper;
   system: CoreWebGlSystem;
-
-  //// Core Managers
-  txManager: CoreTextureManager;
-  txMemManager: TextureMemoryManager;
-  shManager: CoreShaderManager;
-
-  //// Options
-  options: Required<WebGlCoreRendererOptions>;
 
   //// Persistent data
   quadBuffer: ArrayBuffer = new ArrayBuffer(1024 * 1024 * 4);
@@ -113,12 +84,11 @@ export class WebGlCoreRenderer extends CoreRenderer {
   defaultTexture: Texture;
 
   constructor(options: WebGlCoreRendererOptions) {
-    super(options.stage);
+    super(options);
+    this.mode = 'webgl';
+
     const { canvas, clearColor, bufferMemory } = options;
-    this.options = options;
-    this.txManager = options.txManager;
-    this.txMemManager = options.txMemManager;
-    this.shManager = options.shManager;
+
     this.defaultTexture = new ColorTexture(this.txManager);
     // When the default texture is loaded, request a render in case the
     // RAF is paused. Fixes: https://github.com/lightning-js/renderer/issues/123

--- a/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
+++ b/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
@@ -56,7 +56,7 @@ import type {
 import type { WebGlCoreCtxTexture } from '../../../renderers/webgl/WebGlCoreCtxTexture.js';
 import { EventEmitter } from '../../../../common/EventEmitter.js';
 import type { Matrix3d } from '../../../lib/Matrix3d.js';
-import type { WebGlCoreRenderer } from '../../../renderers/webgl/WebGlCoreRenderer.js';
+import { WebGlCoreRenderer } from '../../../renderers/webgl/WebGlCoreRenderer.js';
 
 declare module '../TextRenderer.js' {
   interface TextRendererMap {
@@ -582,7 +582,7 @@ export class SdfTextRenderer extends TextRenderer<SdfTextRendererState> {
     }
 
     const renderer: WebGlCoreRenderer = this.stage.renderer as WebGlCoreRenderer;
-    assertTruthy(renderer.mode === 'webgl');
+    assertTruthy(renderer instanceof WebGlCoreRenderer);
 
     const { fontSize, color, contain, scrollable, zIndex, debug } = state.props;
 

--- a/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
+++ b/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
@@ -56,6 +56,7 @@ import type {
 import type { WebGlCoreCtxTexture } from '../../../renderers/webgl/WebGlCoreCtxTexture.js';
 import { EventEmitter } from '../../../../common/EventEmitter.js';
 import type { Matrix3d } from '../../../lib/Matrix3d.js';
+import type { WebGlCoreRenderer } from '../../../renderers/webgl/WebGlCoreRenderer.js';
 
 declare module '../TextRenderer.js' {
   interface TextRendererMap {
@@ -580,7 +581,8 @@ export class SdfTextRenderer extends TextRenderer<SdfTextRendererState> {
       return;
     }
 
-    const { renderer } = this.stage;
+    const renderer: WebGlCoreRenderer = this.stage.renderer as WebGlCoreRenderer;
+    assertTruthy(renderer.mode === 'webgl');
 
     const { fontSize, color, contain, scrollable, zIndex, debug } = state.props;
 

--- a/src/main-api/RendererMain.ts
+++ b/src/main-api/RendererMain.ts
@@ -41,6 +41,7 @@ import { EventEmitter } from '../common/EventEmitter.js';
 import { Inspector } from './Inspector.js';
 import { santizeCustomDataMap } from '../render-drivers/utils.js';
 import { isProductionEnvironment } from '../utils.js';
+import type { StageOptions } from '../core/Stage.js';
 
 /**
  * An immutable reference to a specific Texture type
@@ -270,6 +271,11 @@ export interface RendererMainSettings {
    * @defaultValue `false` (disabled)
    */
   enableInspector?: boolean;
+
+  /**
+   * Renderer mode
+   */
+  renderMode?: 'webgl' | 'canvas';
 }
 
 /**
@@ -344,6 +350,7 @@ export class RendererMain extends EventEmitter {
         settings.numImageWorkers !== undefined ? settings.numImageWorkers : 2,
       enableContextSpy: settings.enableContextSpy ?? false,
       enableInspector: settings.enableInspector ?? false,
+      renderMode: settings.renderMode ?? 'webgl'
     };
     this.settings = resolvedSettings;
 

--- a/src/render-drivers/main/MainCoreDriver.ts
+++ b/src/render-drivers/main/MainCoreDriver.ts
@@ -64,6 +64,7 @@ export class MainCoreDriver implements ICoreDriver {
       fpsUpdateInterval: rendererSettings.fpsUpdateInterval,
       enableContextSpy: rendererSettings.enableContextSpy,
       numImageWorkers: rendererSettings.numImageWorkers,
+      renderMode: rendererSettings.renderMode,
       debug: {
         monitorTextureCache: false,
       },

--- a/src/render-drivers/threadx/worker/renderer.ts
+++ b/src/render-drivers/threadx/worker/renderer.ts
@@ -75,6 +75,7 @@ const threadx = ThreadX.init({
         fpsUpdateInterval: message.fpsUpdateInterval,
         enableContextSpy: message.enableContextSpy,
         numImageWorkers: message.numImageWorkers,
+        renderMode: 'webgl',
         debug: {
           monitorTextureCache: false,
         },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -155,17 +155,18 @@ export function setPremultiplyMode(mode: 'webgl' | 'canvas'): void {
 
 /**
  * Given an RGBA encoded number, returns back the RGBA number with it's alpha
- * component multiplied by the passed `alpha` parameter. Before returning, the
- * final alpha value is multiplied into the color channels.
+ * component multiplied by the passed `alpha` parameter.
+ *
+ * For the webGl renderer, each color channel is premultiplied by the final alpha value.
  *
  * @remarks
  * If `flipEndianess` is set to true, the function will returned an ABGR encoded number
  * which is useful when the color value needs to be passed into a shader attribute.
  *
- * NOTE: This method returns a PREMULTIPLIED alpha color which is generally only useful
- * in the context of the internal rendering process. Use {@link mergeColorAlpha} if you
- * need to blend an alpha value into a color in the context of the Renderer's
- * main API.
+ * NOTE: Depending on the mode set by {@link setPremultiplyMode}, this method returns
+ * a PREMULTIPLIED alpha color which is generally only useful in the context of the
+ * internal rendering process. Use {@link mergeColorAlpha} if you need to blend an alpha
+ * value into a color in the context of the Renderer's main API.
  *
  * @internalRemarks
  * Do not expose this method in the main API because Renderer users should instead use

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -143,6 +143,16 @@ export function mergeColorAlpha(rgba: number, alpha: number): number {
   return ((r << 24) | (g << 16) | (b << 8) | a) >>> 0;
 }
 
+let premultiplyRGB = true;
+
+/**
+ * RGB components should not be premultiplied when using Canvas renderer
+ * @param mode  Renderer mode
+ */
+export function setPremultiplyMode(mode: 'webgl' | 'canvas'): void {
+  premultiplyRGB = mode === 'webgl';
+}
+
 /**
  * Given an RGBA encoded number, returns back the RGBA number with it's alpha
  * component multiplied by the passed `alpha` parameter. Before returning, the
@@ -173,9 +183,10 @@ export function mergeColorAlphaPremultiplied(
   flipEndianess = false,
 ): number {
   const newAlpha = ((rgba & 0xff) / 255) * alpha;
-  const r = Math.trunc((rgba >>> 24) * newAlpha);
-  const g = Math.trunc(((rgba >>> 16) & 0xff) * newAlpha);
-  const b = Math.trunc(((rgba >>> 8) & 0xff) * newAlpha);
+  const rgbAlpha = premultiplyRGB ? newAlpha : 1;
+  const r = Math.trunc((rgba >>> 24) * rgbAlpha);
+  const g = Math.trunc(((rgba >>> 16) & 0xff) * rgbAlpha);
+  const b = Math.trunc(((rgba >>> 8) & 0xff) * rgbAlpha);
   const a = Math.trunc(newAlpha * 255);
 
   if (flipEndianess) {


### PR DESCRIPTION
Initial canvas 2D renderer.

Added `renderMode: 'webgl' | 'canvas'` renderer option.


https://github.com/lightning-js/renderer/assets/297963/5aaac948-7ae7-4c1c-a255-6de0a68359b8


Limitation:
- Only horizontal & vertical color gradients,
- Only `RoundedRectangle` "shader".

Future potential PRs:
- Canvas-text textures optimization to avoid doing Canvas -> ImageData -> Canvas
- Maybe a c2d shader API

Unsupported:
- All shaders (gracefully ignored) excepted `RoundedRectangle`,
- SDF text (fallback to canvas text).

Aside from that, all the examples render correctly! Rotation, clipping, tinting, spritesheets...