### PR TITLE
Fix: Optimize Get Timing Function for animations

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -123,43 +123,41 @@ interface TimingFunctionMap {
   [key: string]: (time: number) => number | undefined;
 }
 
-const timingMapping: TimingFunctionMap = {
-  linear: (time: number): number => {
-    return time;
-  },
-  ease: getTimingBezier(0.25, 0.1, 0.25, 1.0),
-  'ease-in': getTimingBezier(0.42, 0, 1.0, 1.0),
-  'ease-out': getTimingBezier(0, 0, 0.58, 1.0),
-  'ease-in-out': getTimingBezier(0.42, 0, 0.58, 1.0),
-  'ease-in-sine': getTimingBezier(0.12, 0, 0.39, 0),
-  'ease-out-sine': getTimingBezier(0.12, 0, 0.39, 0),
-  'ease-in-out-sine': getTimingBezier(0.37, 0, 0.63, 1),
-  'ease-in-cubic': getTimingBezier(0.32, 0, 0.67, 0),
-  'ease-out-cubic': getTimingBezier(0.33, 1, 0.68, 1),
-  'ease-in-out-cubic': getTimingBezier(0.65, 0, 0.35, 1),
-  'ease-in-circ': getTimingBezier(0.55, 0, 1, 0.45),
-  'ease-out-circ': getTimingBezier(0, 0.55, 0.45, 1),
-  'ease-in-out-circ': getTimingBezier(0.85, 0, 0.15, 1),
-  'ease-in-back': getTimingBezier(0.36, 0, 0.66, -0.56),
-  'ease-out-back': getTimingBezier(0.34, 1.56, 0.64, 1),
-  'ease-in-out-back': getTimingBezier(0.68, -0.6, 0.32, 1.6),
-  'step-start': () => {
-    return 1;
-  },
-  'step-end': (time: number): number => {
-    return time === 1 ? 1 : 0;
-  },
+type TimingLookupArray = number[];
+interface TimingLookup {
+  [key: string]: TimingLookupArray;
+}
+
+const timingMapping: TimingFunctionMap = {};
+
+const timingLookup: TimingLookup = {
+  ease: [0.25, 0.1, 0.25, 1.0],
+  'ease-in': [0.42, 0, 1.0, 1.0],
+  'ease-out': [0, 0, 0.58, 1.0],
+  'ease-in-out': [0.42, 0, 0.58, 1.0],
+  'ease-in-sine': [0.12, 0, 0.39, 0],
+  'ease-out-sine': [0.12, 0, 0.39, 0],
+  'ease-in-out-sine': [0.37, 0, 0.63, 1],
+  'ease-in-cubic': [0.32, 0, 0.67, 0],
+  'ease-out-cubic': [0.33, 1, 0.68, 1],
+  'ease-in-out-cubic': [0.65, 0, 0.35, 1],
+  'ease-in-circ': [0.55, 0, 1, 0.45],
+  'ease-out-circ': [0, 0.55, 0.45, 1],
+  'ease-in-out-circ': [0.85, 0, 0.15, 1],
+  'ease-in-back': [0.36, 0, 0.66, -0.56],
+  'ease-out-back': [0.34, 1.56, 0.64, 1],
+  'ease-in-out-back': [0.68, -0.6, 0.32, 1.6],
 };
 
 const defaultTiming = (t: number): number => t;
 
 const parseCubicBezier = (str: string) => {
   //cubic-bezier(0.84, 0.52, 0.56, 0.6)
-  const regex = /cubic-bezier\((?:\s*(\d+\.?\d*)\s*,){3}\s*(\d+\.?\d*)\s*\)/;
+  const regex = /-?\d*\.?\d+/g;
   const match = str.match(regex);
 
   if (match) {
-    const [, num1, num2, num3, num4] = match.slice(1);
+    const [num1, num2, num3, num4] = match;
     const a = parseFloat(num1 || '0.42');
     const b = parseFloat(num2 || '0');
     const c = parseFloat(num3 || '1');
@@ -172,7 +170,7 @@ const parseCubicBezier = (str: string) => {
   }
 
   // parse failed, return linear
-  console.warn('Unknown timing function: ' + str);
+  console.warn('Unknown cubic-bezier timing: ' + str);
   return defaultTiming;
 };
 
@@ -187,10 +185,39 @@ export const getTimingFunction = (
     return timingMapping[str] || defaultTiming;
   }
 
+  if (str === 'linear') {
+    return (time: number) => {
+      return time;
+    };
+  }
+
+  if (str === 'step-start') {
+    return () => {
+      return 1;
+    };
+  }
+
+  if (str === 'step-end') {
+    return (time: number) => {
+      return time === 1 ? 1 : 0;
+    };
+  }
+
+  if (timingLookup[str] !== undefined) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore - TS doesn't understand that we've checked for undefined
+    const [a, b, c, d] = timingLookup[str];
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    const timing = getTimingBezier(a, b, c, d);
+    timingMapping[str] = timing;
+    return timing;
+  }
+
   if (str.startsWith('cubic-bezier')) {
     return parseCubicBezier(str);
   }
 
+  console.warn('Unknown timing function: ' + str);
   return defaultTiming;
 };
 

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -23,8 +23,6 @@
  * @module
  */
 
-import memo from 'memize';
-
 export const EPSILON = 0.000001;
 export let ARRAY_TYPE =
   typeof Float32Array !== 'undefined' ? Float32Array : Array;
@@ -121,97 +119,80 @@ const getTimingBezier = (
   };
 };
 
-export const getTimingFunction = memo(
-  (str: string): ((time: number) => number | undefined) => {
-    switch (str) {
-      case 'linear':
-        return function (time: number) {
-          return time;
-        };
-      case 'ease':
-        return getTimingBezier(0.25, 0.1, 0.25, 1.0);
+interface TimingFunctionMap {
+  [key: string]: (time: number) => number | undefined;
+}
 
-      case 'ease-in':
-        return getTimingBezier(0.42, 0, 1.0, 1.0);
-      case 'ease-out':
-        return getTimingBezier(0, 0, 0.58, 1.0);
-      case 'ease-in-out':
-        return getTimingBezier(0.42, 0, 0.58, 1.0);
-
-      case 'ease-in-sine':
-        return getTimingBezier(0.12, 0, 0.39, 0);
-      case 'ease-out-sine':
-        return getTimingBezier(0.12, 0, 0.39, 0);
-      case 'ease-in-out-sine':
-        return getTimingBezier(0.37, 0, 0.63, 1);
-
-      case 'ease-in-cubic':
-        return getTimingBezier(0.32, 0, 0.67, 0);
-      case 'ease-out-cubic':
-        return getTimingBezier(0.33, 1, 0.68, 1);
-      case 'ease-in-out-cubic':
-        return getTimingBezier(0.65, 0, 0.35, 1);
-
-      case 'ease-in-circ':
-        return getTimingBezier(0.55, 0, 1, 0.45);
-      case 'ease-out-circ':
-        return getTimingBezier(0, 0.55, 0.45, 1);
-      case 'ease-in-out-circ':
-        return getTimingBezier(0.85, 0, 0.15, 1);
-
-      case 'ease-in-back':
-        return getTimingBezier(0.36, 0, 0.66, -0.56);
-      case 'ease-out-back':
-        return getTimingBezier(0.34, 1.56, 0.64, 1);
-      case 'ease-in-out-back':
-        return getTimingBezier(0.68, -0.6, 0.32, 1.6);
-
-      case 'step-start':
-        return function () {
-          return 1;
-        };
-      case 'step-end':
-        return function (time: number) {
-          return time === 1 ? 1 : 0;
-        };
-      default:
-        // eslint-disable-next-line no-case-declarations
-        const s = 'cubic-bezier(';
-        if (str && str.indexOf(s) === 0) {
-          const parts = str
-            .substr(s.length, str.length - s.length - 1)
-            .split(',');
-          if (parts.length !== 4) {
-            console.warn('Unknown timing function: ' + str);
-            // Fallback: use linear.
-            return function (time) {
-              return time;
-            };
-          }
-          const a = parseFloat(parts[0] || '0.42');
-          const b = parseFloat(parts[1] || '0');
-          const c = parseFloat(parts[2] || '1');
-          const d = parseFloat(parts[3] || '1');
-
-          if (isNaN(a) || isNaN(b) || isNaN(c) || isNaN(d)) {
-            console.warn(' Unknown timing function: ' + str);
-            // Fallback: use linear.
-            return function (time) {
-              return time;
-            };
-          }
-
-          return getTimingBezier(a, b, c, d);
-        } else {
-          console.warn('Unknown timing function: ' + str);
-          // Fallback: use linear.
-          return function (time) {
-            return time;
-          };
-        }
-    }
+const timingMapping: TimingFunctionMap = {
+  linear: (time: number): number => {
+    return time;
   },
-);
+  ease: getTimingBezier(0.25, 0.1, 0.25, 1.0),
+  'ease-in': getTimingBezier(0.42, 0, 1.0, 1.0),
+  'ease-out': getTimingBezier(0, 0, 0.58, 1.0),
+  'ease-in-out': getTimingBezier(0.42, 0, 0.58, 1.0),
+  'ease-in-sine': getTimingBezier(0.12, 0, 0.39, 0),
+  'ease-out-sine': getTimingBezier(0.12, 0, 0.39, 0),
+  'ease-in-out-sine': getTimingBezier(0.37, 0, 0.63, 1),
+  'ease-in-cubic': getTimingBezier(0.32, 0, 0.67, 0),
+  'ease-out-cubic': getTimingBezier(0.33, 1, 0.68, 1),
+  'ease-in-out-cubic': getTimingBezier(0.65, 0, 0.35, 1),
+  'ease-in-circ': getTimingBezier(0.55, 0, 1, 0.45),
+  'ease-out-circ': getTimingBezier(0, 0.55, 0.45, 1),
+  'ease-in-out-circ': getTimingBezier(0.85, 0, 0.15, 1),
+  'ease-in-back': getTimingBezier(0.36, 0, 0.66, -0.56),
+  'ease-out-back': getTimingBezier(0.34, 1.56, 0.64, 1),
+  'ease-in-out-back': getTimingBezier(0.68, -0.6, 0.32, 1.6),
+  'step-start': () => {
+    return 1;
+  },
+  'step-end': (time: number): number => {
+    return time === 1 ? 1 : 0;
+  },
+};
+
+const defaultTiming = (t: number): number => t;
+
+const parseCubicBezier = (str: string) => {
+  //cubic-bezier(0.84, 0.52, 0.56, 0.6)
+  const regex = /cubic-bezier\((?:\s*(\d+\.?\d*)\s*,){3}\s*(\d+\.?\d*)\s*\)/;
+  const match = str.match(regex);
+
+  if (match) {
+    const [, num1, num2, num3, num4] = match.slice(1);
+    const a = parseFloat(num1 || '0.42');
+    const b = parseFloat(num2 || '0');
+    const c = parseFloat(num3 || '1');
+    const d = parseFloat(num4 || '1');
+
+    const timing = getTimingBezier(a, b, c, d);
+    timingMapping[str] = timing;
+
+    return timing;
+  }
+
+  // parse failed, return linear
+  console.warn('Unknown timing function: ' + str);
+  return defaultTiming;
+};
+
+export const getTimingFunction = (
+  str: string,
+): ((time: number) => number | undefined) => {
+  if (str === '') {
+    return defaultTiming;
+  }
+
+  if (timingMapping[str] !== undefined) {
+    return timingMapping[str] || defaultTiming;
+  }
+
+  if (str.startsWith('cubic-bezier')) {
+    return parseCubicBezier(str);
+  }
+
+  return defaultTiming;
+};
 
 if (!Math.hypot)
   Math.hypot = (...args: number[]) => {


### PR DESCRIPTION
This PR properly optimizes the getTimingFunction, which is called during animations, and drops the memize dependency. Applying memoization negatively impacts the JIT's ability to optimize function paths in named easing cases while it helps for custom timings. The suggested change improves performance for both named as well as custom timing cases.

There are 2 distinct cases for `getTimingFunction`: using named easing timings and using custom `cubic-bezier` timings. In the case of named timings the original function proved to be faster then the updated memized function, as the JIT was able to optimize the old switch case fairly well. 

The original performance hit came from dealing with `cubic-bezier`'s due to their required manual string operations and `parseFloat` to convert the string to a `number`. This change caches where needed, storing the `cubic-bezier`s in a key/value object and relies on a `regex` to parse the string. 

Measurements with the original implementation, the memized implementation and the optimized implementation in this PR:

With 1 named value:
```
[Log] original x 4,628 ops/sec ±0.78% (47 runs sampled) (index.ts, line 17)
[Log] memoized x 2,096 ops/sec ±0.50% (47 runs sampled) (index.ts, line 17)
[Log] optimized x 5,666 ops/sec ±0.69% (47 runs sampled) (index.ts, line 17)
```

The optimized is doing about 1.5-2x of the memoized implementation. 
With 1 named value the original implementation is pretty close to the optimized one due to JITs ability to graph the early path out of the switch and apply caching.

With 2 named values:
```
[Log] original x 2,755 ops/sec ±0.68% (45 runs sampled) (index.ts, line 17)
[Log] memoized x 1,410 ops/sec ±1.10% (46 runs sampled) (index.ts, line 17)
[Log] optimized x 4,907 ops/sec ±1.05% (46 runs sampled) (index.ts, line 17)
```

With 2 the difference is still pretty similar, though the original function starts to fall behind.

With 3 named values: 
```
[Log] original x 1,319 ops/sec ±5.07% (39 runs sampled) (index.ts, line 17)
[Log] memoized x 1,264 ops/sec ±0.84% (47 runs sampled) (index.ts, line 17)
[Log] optimized x 4,927 ops/sec ±0.58% (26 runs sampled) (index.ts, line 17)
```

The optimized function is rather unaffected by the named exports and now does 3-4x of both other implementations.
The interesting part here is that the original starts to match the memoized implementation and the hash map is starting to pay off.

However if we run the same test with just 1 unique  `cubic-bezier` it starts to get really interesting.

With 1 cubic-bezier:
```
[Log] original x 176 ops/sec ±4.78% (37 runs sampled) (index.ts, line 17)
[Log] memoized x 2,054 ops/sec ±0.45% (47 runs sampled) (index.ts, line 17)
[Log] optimized x 5,722 ops/sec ±0.69% (46 runs sampled) (index.ts, line 17)
```

Here is where the original implementation drops on the floor, this is due to the string splits and `parseFloat`. Memoize starts to shine because it can cache the response pretty well. 

Though the optimized is still at 2.5x+ over memoized. 

Whether we use 1 or 6 unique  `cubic-bezier`'s, the original remains at the floor:

With 6 unique cubic beziers:
```
[Log] original x 167 ops/sec ±5.40% (38 runs sampled) (index.ts, line 17)
[Log] memoized x 1,113 ops/sec ±2.06% (45 runs sampled) (index.ts, line 17)
[Log] optimized x 4,676 ops/sec ±2.01% (48 runs sampled) (index.ts, line 17)
```

Even the memoized starts to almost drop by 50% - the original function remains almost unchanged. This is the JIT still  being bogged down by the same `parseFloat` bottleneck.

The new implementation still sits pretty stable and now doing 4x+ over memoized. 
If we mix named and cubic, you get this (this was a suggested "real use case") you get the following.

With 2 named and 1 unique cubic bezier:
```
[Log] original x 470 ops/sec ±4.24% (44 runs sampled) (index.ts, line 17)
[Log] memoized x 1,294 ops/sec ±0.78% (47 runs sampled) (index.ts, line 17)
[Log] optimized x 4,844 ops/sec ±1.24% (47 runs sampled) (index.ts, line 17)
```

What's interesting to see is that the original function starts to pick up again, this is because for the 2 named timings the JIT can apply inline caching and apply DFG graphing through the switch case routes. 

The new implementation is rather unchanged, still sitting at a 4x over memoized.

Now a worst case test, all possible named timings and a load of cubic's. 

With 17 named and 30 unique cubic beziers:
```
[Log] original x 246 ops/sec ±7.62% (38 runs sampled) (index.ts, line 17)
[Log] memoized x 245 ops/sec ±1.39% (46 runs sampled) (index.ts, line 17)
[Log] optimized x 3,016 ops/sec ±1.50% (46 runs sampled) (index.ts, line 17)
```

This is where it starts to get funny, both the original and the memoized approach are on the floor. While the optimized function still sits at 3k ops, doing 12x of both. 

Tests run by adding 1000 animation easing requests and measuring performance using `benchmark.js` from jsperf.
Tested on WPEWebKit 2.38 running on a Glass TV. 

_small note_ this will likely even get better once we get FTL and OMG on WPEWebKit in late 2024 😎 