### PR TITLE
Simplify viewport events

### DIFF
--- a/examples/tests/viewport-events.ts
+++ b/examples/tests/viewport-events.ts
@@ -1,0 +1,187 @@
+import type { IAnimationController } from '../../dist/exports/main-api.js';
+import type { ExampleSettings } from '../common/ExampleSettings.js';
+import test from './alpha-blending.js';
+
+export default async function ({ renderer, testRoot }: ExampleSettings) {
+  const degToRad = (deg: number) => {
+    return (Math.PI / 180) * deg;
+  };
+
+  const instructionText = renderer.createTextNode({
+    text: 'Press space to start animation, arrow keys to move, enter to reset',
+    fontSize: 30,
+    x: 10,
+    y: 960,
+    parent: testRoot,
+  });
+
+  const redStatus = renderer.createTextNode({
+    text: 'Red Status: ',
+    fontSize: 30,
+    x: 10,
+    y: 50,
+    parent: testRoot,
+  });
+
+  const blueStatus = renderer.createTextNode({
+    text: 'Blue Status: ',
+    fontSize: 30,
+    x: 10,
+    y: 10,
+    parent: testRoot,
+  });
+
+  const boundaryRect = renderer.createNode({
+    x: 1920 / 2 - (1920 * 0.75) / 2,
+    y: 1080 / 2 - (1080 * 0.75) / 2,
+    width: 1440,
+    height: 810,
+    color: 0x000000ff,
+    clipping: true,
+    parent: testRoot,
+  });
+
+  const redRect = renderer.createNode({
+    // skipRender: true,
+    x: 520,
+    y: 305,
+    alpha: 1,
+    width: 200,
+    height: 200,
+    color: 0xff0000ff,
+    pivot: 0,
+    parent: boundaryRect,
+  });
+
+  redRect.on('outOfViewport', () => {
+    console.log('rect outside view port');
+    redStatus.text = 'Red Status: rect outside view port';
+    redStatus.color = 0xff0000ff;
+  });
+
+  redRect.on('inViewport', () => {
+    console.log('rect in view port');
+    redStatus.text = 'Red Status: rect in view port';
+    redStatus.color = 0x00ff00ff;
+  });
+
+  redRect.on('inBounds', () => {
+    console.log('rect inside render bounds');
+    redStatus.text = 'Red Status: rect outside render bounds';
+    redStatus.color = 0xffff00ff;
+  });
+
+  const blueRect = renderer.createNode({
+    x: 1920 / 2 - 200,
+    y: 100,
+    alpha: 1,
+    width: 200,
+    height: 200,
+    color: 0x0000ffff,
+    pivot: 0,
+    parent: testRoot,
+  });
+
+  blueRect.on('outOfViewport', () => {
+    console.log('blue rect outside view port');
+    blueStatus.text = 'Blue Status: blue rect outside view port';
+    blueStatus.color = 0xff0000ff;
+  });
+
+  blueRect.on('inViewport', () => {
+    console.log('blue rect in view port');
+    blueStatus.text = 'Blue Status: blue rect in view port';
+    blueStatus.color = 0x00ff00ff;
+  });
+
+  blueRect.on('inBounds', () => {
+    console.log('blue rect inside render bounds');
+    blueStatus.text = 'Blue Status: blue rect outside render bounds';
+    blueStatus.color = 0xffff00ff;
+  });
+
+  let runAnimation = false;
+  const animate = async () => {
+    redRect
+      .animate(
+        {
+          x: -500,
+        },
+        {
+          duration: 4000,
+        },
+      )
+      .start();
+
+    await blueRect
+      .animate(
+        {
+          x: -1200,
+        },
+        {
+          duration: 4000,
+        },
+      )
+      .start()
+      .waitUntilStopped();
+
+    redRect.x = 1920 + 400;
+    blueRect.x = 1920 + 400;
+
+    redRect
+      .animate(
+        {
+          x: 520,
+        },
+        {
+          duration: 4000,
+        },
+      )
+      .start();
+
+    await blueRect
+      .animate(
+        {
+          x: 1920 / 2 - 200,
+        },
+        {
+          duration: 4000,
+        },
+      )
+      .start()
+      .waitUntilStopped();
+
+    if (runAnimation) {
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      setTimeout(animate, 2000);
+    }
+  };
+
+  const moveModifier = 10;
+  window.onkeydown = (e) => {
+    if (e.key === ' ') {
+      runAnimation = !runAnimation;
+
+      if (runAnimation) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        animate();
+      }
+    }
+
+    if (e.key === 'ArrowRight') {
+      redRect.x += moveModifier;
+      blueRect.x += moveModifier;
+    }
+
+    if (e.key === 'ArrowLeft') {
+      redRect.x -= moveModifier;
+      blueRect.x -= moveModifier;
+    }
+
+    if (e.key === 'Enter') {
+      runAnimation = false;
+      redRect.x = 520;
+      blueRect.x = 1920 / 2 - 200;
+    }
+  };
+}

--- a/examples/tests/viewport-events.ts
+++ b/examples/tests/viewport-events.ts
@@ -53,21 +53,21 @@ export default async function ({ renderer, testRoot }: ExampleSettings) {
     parent: boundaryRect,
   });
 
-  redRect.on('outOfViewport', () => {
-    console.log('rect outside view port');
-    redStatus.text = 'Red Status: rect outside view port';
+  redRect.on('outOfBounds', () => {
+    console.log('red rect out of bounds');
+    redStatus.text = 'Red Status: rect out of bounds';
     redStatus.color = 0xff0000ff;
   });
 
   redRect.on('inViewport', () => {
-    console.log('rect in view port');
+    console.log('red rect in view port');
     redStatus.text = 'Red Status: rect in view port';
     redStatus.color = 0x00ff00ff;
   });
 
   redRect.on('inBounds', () => {
-    console.log('rect inside render bounds');
-    redStatus.text = 'Red Status: rect outside render bounds';
+    console.log('red rect inside render bounds');
+    redStatus.text = 'Red Status: rect in bounds';
     redStatus.color = 0xffff00ff;
   });
 
@@ -82,9 +82,9 @@ export default async function ({ renderer, testRoot }: ExampleSettings) {
     parent: testRoot,
   });
 
-  blueRect.on('outOfViewport', () => {
-    console.log('blue rect outside view port');
-    blueStatus.text = 'Blue Status: blue rect outside view port';
+  blueRect.on('outOfBounds', () => {
+    console.log('blue rect ouf ot bounds');
+    blueStatus.text = 'Blue Status: blue rect out of bounds';
     blueStatus.color = 0xff0000ff;
   });
 
@@ -96,7 +96,7 @@ export default async function ({ renderer, testRoot }: ExampleSettings) {
 
   blueRect.on('inBounds', () => {
     console.log('blue rect inside render bounds');
-    blueStatus.text = 'Blue Status: blue rect outside render bounds';
+    blueStatus.text = 'Blue Status: blue rect in bounds';
     blueStatus.color = 0xffff00ff;
   });
 

--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -53,14 +53,14 @@ import { RenderCoords } from './lib/RenderCoords.js';
 
 export enum CoreNodeRenderState {
   Init = 0,
-  OutOfViewport = 2,
+  OutOfBounds = 2,
   InBounds = 4,
   InViewport = 8,
 }
 
 const CoreNodeRenderStateMap: Map<CoreNodeRenderState, string> = new Map();
 CoreNodeRenderStateMap.set(CoreNodeRenderState.Init, 'init');
-CoreNodeRenderStateMap.set(CoreNodeRenderState.OutOfViewport, 'outOfViewport');
+CoreNodeRenderStateMap.set(CoreNodeRenderState.OutOfBounds, 'outOfBounds');
 CoreNodeRenderStateMap.set(CoreNodeRenderState.InBounds, 'inBounds');
 CoreNodeRenderStateMap.set(CoreNodeRenderState.InViewport, 'inViewport');
 
@@ -616,7 +616,7 @@ export class CoreNode extends EventEmitter implements ICoreNode {
     if (boundInsideBound(this.renderBound, this.preloadBound)) {
       return CoreNodeRenderState.InBounds;
     }
-    return CoreNodeRenderState.OutOfViewport;
+    return CoreNodeRenderState.OutOfBounds;
   }
 
   updateRenderState(parentClippingRect: RectWithValid) {
@@ -653,7 +653,7 @@ export class CoreNode extends EventEmitter implements ICoreNode {
     if (this.worldAlpha === 0 || !this.checkRenderProps()) {
       newIsRenderable = false;
     } else {
-      newIsRenderable = this.renderState > CoreNodeRenderState.OutOfViewport;
+      newIsRenderable = this.renderState > CoreNodeRenderState.OutOfBounds;
     }
     if (this.isRenderable !== newIsRenderable) {
       this.isRenderable = newIsRenderable;

--- a/src/render-drivers/main/MainOnlyNode.ts
+++ b/src/render-drivers/main/MainOnlyNode.ts
@@ -112,7 +112,7 @@ export class MainOnlyNode extends EventEmitter implements INode {
     this.coreNode.on('freed', this.onTextureFreed);
 
     this.coreNode.on('inBounds', this.onInBounds);
-    this.coreNode.on('outOfViewport', this.onOutOfViewport);
+    this.coreNode.on('outOfBounds', this.onOutOfBounds);
     this.coreNode.on('inViewport', this.onInViewport);
 
     // Assign properties to this object
@@ -439,10 +439,6 @@ export class MainOnlyNode extends EventEmitter implements INode {
 
   private onInBounds: NodeRenderStateEventHandler = (target, payload) => {
     this.emit('inBounds', payload);
-  };
-
-  private onOutOfViewport: NodeRenderStateEventHandler = (target, payload) => {
-    this.emit('outOfViewport', payload);
   };
 
   private onInViewport: NodeRenderStateEventHandler = (target, payload) => {

--- a/src/render-drivers/main/MainOnlyNode.ts
+++ b/src/render-drivers/main/MainOnlyNode.ts
@@ -111,7 +111,6 @@ export class MainOnlyNode extends EventEmitter implements INode {
     this.coreNode.on('failed', this.onTextureFailed);
     this.coreNode.on('freed', this.onTextureFreed);
 
-    this.coreNode.on('outOfBounds', this.onOutOfBounds);
     this.coreNode.on('inBounds', this.onInBounds);
     this.coreNode.on('outOfViewport', this.onOutOfViewport);
     this.coreNode.on('inViewport', this.onInViewport);


### PR DESCRIPTION
A node in the visible area gets a inViewport event A node in bounds gets a inBounds event
A node outside viewport & bounds gets a outOfViewport event

Nodes that are init or outofview port will get a renderable false. All events have a previous state and new state accordingly.

**BREAKING CHANGE**