### PR TITLE
Add filtering to Visual Regression Tests

### DIFF
--- a/visual-regression/src/index.ts
+++ b/visual-regression/src/index.ts
@@ -113,6 +113,12 @@ const argv = yargs(hideBin(process.argv))
       default: false,
       description: 'Run in docker container with `ci` runtime environment',
     },
+    filter: {
+      type: 'string',
+      alias: 'f',
+      default: '*',
+      description: 'Tests to run ("*" wildcard pattern)',
+    },
   })
   .parseSync();
 
@@ -145,6 +151,7 @@ async function dockerCiMode(): Promise<number> {
     argv.verbose ? '--verbose' : '',
     argv.skipBuild ? '--skipBuild' : '',
     argv.port ? `--port ${argv.port}` : '',
+    argv.filter ? `--filter "${argv.filter}"` : '',
   ].join(' ');
 
   // Get the directory of the current file
@@ -239,6 +246,7 @@ async function runTest(browserType: 'chromium') {
   const paramString = Object.entries({
     browser: browserType,
     overwrite: argv.overwrite,
+    filter: argv.filter,
     RUNTIME_ENV: runtimeEnv,
   }).reduce((acc, [key, value]) => {
     return `${acc ? `${acc}, ` : ''}${`${key}: ${chalk.white(value)}`}`;
@@ -284,7 +292,9 @@ async function runTest(browserType: 'chromium') {
   }
 
   // Go to the examples page
-  await page.goto(`http://localhost:${argv.port}/?automation=true`);
+  await page.goto(
+    `http://localhost:${argv.port}/?automation=true&test=${argv.filter}`,
+  );
 
   /**
    * Keeps track of the latest snapshot index for each test


### PR DESCRIPTION
The Visual Regression test runner now supports a `--filter` option for filtering specific tests you'd like to run or capture.

Usage example:
```
pnpm test:visual --ci --filter="text-*"
```