### PR TITLE
Optimize Matrix3d storage and operations

### DIFF
--- a/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
+++ b/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
@@ -670,7 +670,7 @@ export class SdfTextRenderer extends TextRenderer<SdfTextRendererState> {
       webGlBuffers,
       this.sdfShader,
       {
-        transform: transform.data,
+        transform: transform.getFloatArr(),
         // IMPORTANT: The SDF Shader expects the color NOT to be premultiplied
         // for the best blending results. Which is why we use `mergeColorAlpha`
         // instead of `mergeColorAlphaPremultiplied` here.


### PR DESCRIPTION
Matrix3d now stores its values properties instead of a Float32Array. This should potentially cut down on any performance penalty between transforming native JavaScript numbers to Float32 values and vice-versa.

The bottom row of the matrix is now considered a constant [0, 0, 1] which will be true for all 2D operations. The bottom row values hence no longer are stored in the Matrix3d instance.

Also because of the bottom-row assumption the `multiply` operation no longer needs to calculate the bottom row.

The Float32Array, needed by SDF Text Nodes is now only generated (and updated) when needed. This should significantly reduce the number of arrays allocated in an application.

- [x] Pending performance and memory review