### PR TITLE
Add ability to name VRT snapshots

### DIFF
--- a/examples/common/ExampleSettings.ts
+++ b/examples/common/ExampleSettings.ts
@@ -23,6 +23,17 @@ import type { INode, RendererMain } from '@lightningjs/renderer';
  * Keep in sync with `visual-regression/src/index.ts`
  */
 export interface SnapshotOptions {
+  /**
+   * Snapshot name
+   *
+   * @remarks
+   * This name, if provided, is appended to the end of the test name and used in
+   * the snapshot file name.
+   */
+  name?: string;
+  /**
+   * Clip the snapshot to a specific area of the canvas.
+   */
   clip?: {
     x: number;
     y: number;

--- a/visual-regression/README.md
+++ b/visual-regression/README.md
@@ -141,6 +141,16 @@ Test. Addtional snapshots can be defined by calling `settings.snapshot()`
 additional times, while of course making changes to the Renderer state in
 between calls.
 
+A name may be optionally provided in the snapshot call:
+
+```typescript
+settings.snapshot({ name: 'myname' });
+```
+
+This name will be appended to the name of the Example Test. For example, if
+run in the `alpha` Example Test, the name of Snapshot will be `alpha_myname-1`.
+The same name may be used multiple times.
+
 Example Tests that utilize the `PageContainer` class to define separate pages
 of static content may use the `pageContainer.snapshotPages()` helper method
 to automatically take snapshots of each of the pages defined in the container.

--- a/visual-regression/src/index.ts
+++ b/visual-regression/src/index.ts
@@ -43,6 +43,7 @@ import { fileURLToPath } from 'url';
  * Keep in sync with `examples/common/ExampleSettings.ts`
  */
 export interface SnapshotOptions {
+  name?: string;
   clip?: {
     x: number;
     y: number;
@@ -314,16 +315,17 @@ async function runTest(browserType: 'chromium') {
           height: Math.round(options.clip.height),
         };
       }
-      const snapshotIndex = (testCounters[test] =
-        (testCounters[test] || 0) + 1);
+      const subtestName = options.name ? `${test}_${options.name}` : test;
+      const snapshotIndex = (testCounters[subtestName] =
+        (testCounters[subtestName] || 0) + 1);
       const makeFilename = (postfix?: string) =>
-        `${test}-${snapshotIndex}${postfix ? `-${postfix}` : ''}.png`;
+        `${subtestName}-${snapshotIndex}${postfix ? `-${postfix}` : ''}.png`;
       const snapshotPath = path.join(snapshotSubDir, makeFilename());
       if (argv.capture) {
         process.stdout.write(
           chalk.gray(
             `Saving snapshot for ${chalk.white(
-              `${test}-${snapshotIndex}`,
+              `${subtestName}-${snapshotIndex}`,
             )}... `,
           ),
         );
@@ -342,7 +344,9 @@ async function runTest(browserType: 'chromium') {
         }
       } else {
         process.stdout.write(
-          chalk.gray(`Running ${chalk.white(`${test}-${snapshotIndex}`)}... `),
+          chalk.gray(
+            `Running ${chalk.white(`${subtestName}-${snapshotIndex}`)}... `,
+          ),
         );
         const actualPng = await page.screenshot({ clip: options?.clip });
         const actualImage = upng.decode(actualPng);


### PR DESCRIPTION
Calls to snapshot() now accept a `name` key in the options object. This name, if provided, is appended to the end of the test name and used in the snapshot file name.