### PR TITLE
Fix assertion error thrown in WebGlCoreCtxTexture getter

### DIFF
--- a/src/core/renderers/webgl/WebGlCoreCtxTexture.ts
+++ b/src/core/renderers/webgl/WebGlCoreCtxTexture.ts
@@ -92,6 +92,7 @@ export class WebGlCoreCtxTexture extends CoreContextTexture {
     this._nativeCtxTexture = this.createNativeCtxTexture();
     this.onLoadRequest()
       .then(({ width, height }) => {
+        // If the texture has been freed while loading, return early.
         if (this._state === 'freed') {
           return;
         }
@@ -103,6 +104,10 @@ export class WebGlCoreCtxTexture extends CoreContextTexture {
         this.textureSource.setState('loaded', { width, height });
       })
       .catch((err) => {
+        // If the texture has been freed while loading, return early.
+        if (this._state === 'freed') {
+          return;
+        }
         this._state = 'failed';
         this.textureSource.setState('failed', err);
         console.error(err);


### PR DESCRIPTION
The issue occurs when a texture is loading, free() is called on it by the GC, and then there is an error thrown by getTextureData() from the Texture source.

Fixes #275