### PR TITLE
Fix: missing CommonJS export

### DIFF
--- a/exports/index.ts
+++ b/exports/index.ts
@@ -1,0 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './main-api.js';
+export * from './core-api.js';
+export * from './utils.js';


### PR DESCRIPTION
Fixes #258 - this creates the missing cjs export point as declared already in `package.json`:
```
"main": "./dist/exports/index.js",
```