### PR TITLE
Fix: minor INode data type fix

### DIFF
--- a/src/main-api/INode.ts
+++ b/src/main-api/INode.ts
@@ -443,7 +443,7 @@ export interface INodeWritableProps {
  * The data stored can only be of type string, number or boolean.
  */
 export type CustomDataMap = {
-  [key: string]: string | number | boolean;
+  [key: string]: string | number | boolean | undefined;
 };
 
 export type INodeAnimatableProps = {


### PR DESCRIPTION
A tiny fix allowing `undefined` as `data` value - this clears the dataset prop in the DOM inspector.