### PR TITLE
Fix image src conversion with local file paths (#287)

### DIFF
--- a/src/core/lib/ImageWorker.ts
+++ b/src/core/lib/ImageWorker.ts
@@ -125,11 +125,6 @@ export class ImageWorkerManager {
     return worker;
   }
 
-  private convertUrlToAbsolute(url: string): string {
-    const absoluteUrl = new URL(url, self.location.href);
-    return absoluteUrl.href;
-  }
-
   getImage(
     src: string,
     premultiplyAlpha: boolean | null,
@@ -137,14 +132,13 @@ export class ImageWorkerManager {
     return new Promise((resolve, reject) => {
       try {
         if (this.workers) {
-          const absoluteSrcUrl = this.convertUrlToAbsolute(src);
           const id = this.nextId++;
           this.messageManager[id] = [resolve, reject];
           const nextWorker = this.getNextWorker();
           if (nextWorker) {
             nextWorker.postMessage({
               id,
-              src: absoluteSrcUrl,
+              src: src,
               premultiplyAlpha,
             });
           }

--- a/src/core/lib/utils.ts
+++ b/src/core/lib/utils.ts
@@ -248,3 +248,28 @@ export function isBoundPositive(bound: Bound): boolean {
 export function isRectPositive(rect: Rect): boolean {
   return rect.width > 0 && rect.height > 0;
 }
+
+export function convertUrlToAbsolute(url: string): string {
+  // handle local file imports
+  if (self.location.protocol === 'file:') {
+    const path = self.location.pathname.split('/');
+    path.pop();
+    const basePath = path.join('/');
+    const baseUrl = self.location.protocol + '//' + basePath;
+
+    // check if url has a leading dot
+    if (url.charAt(0) === '.') {
+      url = url.slice(1);
+    }
+
+    // check if url has a leading slash
+    if (url.charAt(0) === '/') {
+      url = url.slice(1);
+    }
+
+    return baseUrl + '/' + url;
+  }
+
+  const absoluteUrl = new URL(url, self.location.href);
+  return absoluteUrl.href;
+}

--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -23,6 +23,7 @@ import {
   isCompressedTextureContainer,
   loadCompressedTexture,
 } from '../lib/textureCompression.js';
+import { convertUrlToAbsolute } from '../lib/utils.js';
 
 /**
  * Properties of the {@link ImageTexture}
@@ -108,13 +109,16 @@ export class ImageTexture extends Texture {
       return loadCompressedTexture(src);
     }
 
+    // Convert relative URL to absolute URL
+    const absoluteSrc = convertUrlToAbsolute(src);
+
     if (this.txManager.imageWorkerManager) {
       return await this.txManager.imageWorkerManager.getImage(
-        src,
+        absoluteSrc,
         premultiplyAlpha,
       );
     } else if (this.txManager.hasCreateImageBitmap) {
-      const response = await fetch(src);
+      const response = await fetch(absoluteSrc);
       const blob = await response.blob();
       const hasAlphaChannel =
         premultiplyAlpha ?? this.hasAlphaChannel(blob.type);
@@ -131,7 +135,7 @@ export class ImageTexture extends Texture {
       if (!(src.substr(0, 5) === 'data:')) {
         img.crossOrigin = 'Anonymous';
       }
-      img.src = src;
+      img.src = absoluteSrc;
       await new Promise<void>((resolve, reject) => {
         img.onload = () => resolve();
         img.onerror = () => reject(new Error(`Failed to load image`));
@@ -162,7 +166,7 @@ export class ImageTexture extends Texture {
     return {
       src: props.src ?? '',
       premultiplyAlpha: props.premultiplyAlpha ?? true, // null,
-      key: props.key ?? null
+      key: props.key ?? null,
     };
   }
 


### PR DESCRIPTION
Support for `file://` loads with relative to absolute path conversion. 
Fixes #287 
