### PR TITLE
Fix initial texture loading from CoreNode

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -242,6 +242,10 @@ export class CoreNode extends EventEmitter {
     this.props = {
       ...props,
       parent: null,
+      texture: null,
+      shader: null,
+      src: '',
+      rtt: false,
       data: props.data || {},
     };
 

--- a/src/core/textures/NoiseTexture.ts
+++ b/src/core/textures/NoiseTexture.ts
@@ -77,7 +77,10 @@ export class NoiseTexture extends Texture {
     };
   }
 
-  static override makeCacheKey(props: NoiseTextureProps): string {
+  static override makeCacheKey(props: NoiseTextureProps): string | false {
+    if (props.cacheId === undefined) {
+      return false;
+    }
     const resolvedProps = NoiseTexture.resolveDefaults(props);
     return `NoiseTexture,${resolvedProps.width},${resolvedProps.height},${resolvedProps.cacheId}`;
   }


### PR DESCRIPTION
Also
- NoiseTexture: If cacheId not provided, don't cache the texture

Fixes issue with the `threshold-texture-memory` test