### PR TITLE
use renderCoords in add quads

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -884,12 +884,12 @@ export class CoreNode extends EventEmitter {
     const {
       zIndex,
       worldAlpha,
-      globalTransform: transform,
+      globalTransform: gt,
       clippingRect,
       renderCoords,
     } = this;
 
-    assertTruthy(transform);
+    assertTruthy(gt);
     assertTruthy(renderCoords);
 
     // add to list of renderables to be sorted before rendering
@@ -908,7 +908,12 @@ export class CoreNode extends EventEmitter {
       alpha: worldAlpha,
       clippingRect,
       renderCoords,
-      transform,
+      tx: gt.tx,
+      ty: gt.ty,
+      ta: gt.ta,
+      tb: gt.tb,
+      tc: gt.tc,
+      td: gt.td,
       rtt,
       parentHasRenderTexture: this.parentHasRenderTexture,
       framebufferDimensions: this.framebufferDimensions,

--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -881,9 +881,16 @@ export class CoreNode extends EventEmitter {
       premultipliedColorBr,
     } = this;
 
-    const { zIndex, worldAlpha, globalTransform: gt, clippingRect } = this;
+    const {
+      zIndex,
+      worldAlpha,
+      globalTransform: transform,
+      clippingRect,
+      renderCoords,
+    } = this;
 
-    assertTruthy(gt);
+    assertTruthy(transform);
+    assertTruthy(renderCoords);
 
     // add to list of renderables to be sorted before rendering
     renderer.addQuad({
@@ -900,12 +907,8 @@ export class CoreNode extends EventEmitter {
       shaderProps,
       alpha: worldAlpha,
       clippingRect,
-      tx: gt.tx,
-      ty: gt.ty,
-      ta: gt.ta,
-      tb: gt.tb,
-      tc: gt.tc,
-      td: gt.td,
+      renderCoords,
+      transform,
       rtt,
       parentHasRenderTexture: this.parentHasRenderTexture,
       framebufferDimensions: this.framebufferDimensions,

--- a/src/core/renderers/CoreRenderer.ts
+++ b/src/core/renderers/CoreRenderer.ts
@@ -27,7 +27,6 @@ import type {
 import type { Stage } from '../Stage.js';
 import type { TextureMemoryManager } from '../TextureMemoryManager.js';
 import type { ContextSpy } from '../lib/ContextSpy.js';
-import type { Matrix3d } from '../lib/Matrix3d.js';
 import type { RenderCoords } from '../lib/RenderCoords.js';
 import type { RectWithValid } from '../lib/utils.js';
 import { ColorTexture } from '../textures/ColorTexture.js';
@@ -49,8 +48,13 @@ export interface QuadOptions {
   shaderProps: Record<string, unknown> | null;
   alpha: number;
   clippingRect: RectWithValid;
+  tx: number;
+  ty: number;
+  ta: number;
+  tb: number;
+  tc: number;
+  td: number;
   renderCoords: RenderCoords;
-  transform: Matrix3d;
   rtt?: boolean;
   parentHasRenderTexture?: boolean;
   framebufferDimensions?: Dimensions;

--- a/src/core/renderers/CoreRenderer.ts
+++ b/src/core/renderers/CoreRenderer.ts
@@ -27,6 +27,8 @@ import type {
 import type { Stage } from '../Stage.js';
 import type { TextureMemoryManager } from '../TextureMemoryManager.js';
 import type { ContextSpy } from '../lib/ContextSpy.js';
+import type { Matrix3d } from '../lib/Matrix3d.js';
+import type { RenderCoords } from '../lib/RenderCoords.js';
 import type { RectWithValid } from '../lib/utils.js';
 import { ColorTexture } from '../textures/ColorTexture.js';
 import type { Texture } from '../textures/Texture.js';
@@ -47,12 +49,8 @@ export interface QuadOptions {
   shaderProps: Record<string, unknown> | null;
   alpha: number;
   clippingRect: RectWithValid;
-  tx: number;
-  ty: number;
-  ta: number;
-  tb: number;
-  tc: number;
-  td: number;
+  renderCoords: RenderCoords;
+  transform: Matrix3d;
   rtt?: boolean;
   parentHasRenderTexture?: boolean;
   framebufferDimensions?: Dimensions;

--- a/src/core/renderers/canvas/CanvasCoreRenderer.ts
+++ b/src/core/renderers/canvas/CanvasCoreRenderer.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import { assertTruthy } from '../../../utils.js';
 import type { CoreNode } from '../../CoreNode.js';
 import type { CoreShaderManager } from '../../CoreShaderManager.js';
 import { getRgbaComponents, type RGBA } from '../../lib/utils.js';
@@ -78,18 +79,13 @@ export class CanvasCoreRenderer extends CoreRenderer {
   addQuad(quad: QuadOptions): void {
     const ctx = this.context;
     const {
-      tx,
-      ty,
+      transform,
       width,
       height,
       alpha,
       colorTl,
       colorTr,
       colorBr,
-      ta,
-      tb,
-      tc,
-      td,
       clippingRect,
     } = quad;
     let texture = quad.texture;
@@ -113,6 +109,8 @@ export class CanvasCoreRenderer extends CoreRenderer {
         return;
       }
     }
+    assertTruthy(transform);
+    const { tx, ty, ta, tb, tc, td } = transform;
 
     const color = parseColor(colorTl);
     const hasTransform = ta !== 1;

--- a/src/core/renderers/canvas/CanvasCoreRenderer.ts
+++ b/src/core/renderers/canvas/CanvasCoreRenderer.ts
@@ -79,7 +79,12 @@ export class CanvasCoreRenderer extends CoreRenderer {
   addQuad(quad: QuadOptions): void {
     const ctx = this.context;
     const {
-      transform,
+      tx,
+      ty,
+      ta,
+      tb,
+      tc,
+      td,
       width,
       height,
       alpha,
@@ -109,8 +114,6 @@ export class CanvasCoreRenderer extends CoreRenderer {
         return;
       }
     }
-    assertTruthy(transform);
-    const { tx, ty, ta, tb, tc, td } = transform;
 
     const color = parseColor(colorTl);
     const hasTransform = ta !== 1;

--- a/src/core/renderers/webgl/WebGlCoreRenderer.ts
+++ b/src/core/renderers/webgl/WebGlCoreRenderer.ts
@@ -228,7 +228,6 @@ export class WebGlCoreRenderer extends CoreRenderer {
       shaderProps,
       alpha,
       clippingRect,
-      transform,
       renderCoords,
       rtt: renderToTexture,
       parentHasRenderTexture,

--- a/src/core/renderers/webgl/WebGlCoreRenderer.ts
+++ b/src/core/renderers/webgl/WebGlCoreRenderer.ts
@@ -228,12 +228,8 @@ export class WebGlCoreRenderer extends CoreRenderer {
       shaderProps,
       alpha,
       clippingRect,
-      tx,
-      ty,
-      ta,
-      tb,
-      tc,
-      td,
+      transform,
+      renderCoords,
       rtt: renderToTexture,
       parentHasRenderTexture,
       framebufferDimensions,
@@ -318,78 +314,40 @@ export class WebGlCoreRenderer extends CoreRenderer {
 
     curRenderOp = this.curRenderOp;
     assertTruthy(curRenderOp);
+    assertTruthy(renderCoords);
+    // if(renderCoords) {
+    const { x1, x2, x3, x4, y1, y2, y3, y4 } = renderCoords;
+    // Upper-Left
+    fQuadBuffer[bufferIdx++] = x1; // vertexX
+    fQuadBuffer[bufferIdx++] = y1; // vertexY
+    fQuadBuffer[bufferIdx++] = texCoordX1; // texCoordX
+    fQuadBuffer[bufferIdx++] = texCoordY1; // texCoordY
+    uiQuadBuffer[bufferIdx++] = colorTl; // color
+    fQuadBuffer[bufferIdx++] = textureIdx; // texIndex
 
-    // render quad advanced
-    if (tb !== 0 || tc !== 0) {
-      // Upper-Left
-      fQuadBuffer[bufferIdx++] = tx; // vertexX
-      fQuadBuffer[bufferIdx++] = ty; // vertexY
-      fQuadBuffer[bufferIdx++] = texCoordX1; // texCoordX
-      fQuadBuffer[bufferIdx++] = texCoordY1; // texCoordY
-      uiQuadBuffer[bufferIdx++] = colorTl; // color
-      fQuadBuffer[bufferIdx++] = textureIdx; // texIndex
+    // Upper-Right
+    fQuadBuffer[bufferIdx++] = x2;
+    fQuadBuffer[bufferIdx++] = y2;
+    fQuadBuffer[bufferIdx++] = texCoordX2;
+    fQuadBuffer[bufferIdx++] = texCoordY1;
+    uiQuadBuffer[bufferIdx++] = colorTr;
+    fQuadBuffer[bufferIdx++] = textureIdx;
 
-      // Upper-Right
-      fQuadBuffer[bufferIdx++] = tx + width * ta;
-      fQuadBuffer[bufferIdx++] = ty + width * tc;
-      fQuadBuffer[bufferIdx++] = texCoordX2;
-      fQuadBuffer[bufferIdx++] = texCoordY1;
-      uiQuadBuffer[bufferIdx++] = colorTr;
-      fQuadBuffer[bufferIdx++] = textureIdx;
+    // Lower-Left
+    fQuadBuffer[bufferIdx++] = x4;
+    fQuadBuffer[bufferIdx++] = y4;
+    fQuadBuffer[bufferIdx++] = texCoordX1;
+    fQuadBuffer[bufferIdx++] = texCoordY2;
+    uiQuadBuffer[bufferIdx++] = colorBl;
+    fQuadBuffer[bufferIdx++] = textureIdx;
 
-      // Lower-Left
-      fQuadBuffer[bufferIdx++] = tx + height * tb;
-      fQuadBuffer[bufferIdx++] = ty + height * td;
-      fQuadBuffer[bufferIdx++] = texCoordX1;
-      fQuadBuffer[bufferIdx++] = texCoordY2;
-      uiQuadBuffer[bufferIdx++] = colorBl;
-      fQuadBuffer[bufferIdx++] = textureIdx;
-
-      // Lower-Right
-      fQuadBuffer[bufferIdx++] = tx + width * ta + height * tb;
-      fQuadBuffer[bufferIdx++] = ty + width * tc + height * td;
-      fQuadBuffer[bufferIdx++] = texCoordX2;
-      fQuadBuffer[bufferIdx++] = texCoordY2;
-      uiQuadBuffer[bufferIdx++] = colorBr;
-      fQuadBuffer[bufferIdx++] = textureIdx;
-    } else {
-      // Calculate the right corner of the quad
-      // multiplied by the scale
-      const rightCornerX = tx + width * ta;
-      const rightCornerY = ty + height * td;
-
-      // Upper-Left
-      fQuadBuffer[bufferIdx++] = tx; // vertexX
-      fQuadBuffer[bufferIdx++] = ty; // vertexY
-      fQuadBuffer[bufferIdx++] = texCoordX1; // texCoordX
-      fQuadBuffer[bufferIdx++] = texCoordY1; // texCoordY
-      uiQuadBuffer[bufferIdx++] = colorTl; // color
-      fQuadBuffer[bufferIdx++] = textureIdx; // texIndex
-
-      // Upper-Right
-      fQuadBuffer[bufferIdx++] = rightCornerX;
-      fQuadBuffer[bufferIdx++] = ty;
-      fQuadBuffer[bufferIdx++] = texCoordX2;
-      fQuadBuffer[bufferIdx++] = texCoordY1;
-      uiQuadBuffer[bufferIdx++] = colorTr;
-      fQuadBuffer[bufferIdx++] = textureIdx;
-
-      // Lower-Left
-      fQuadBuffer[bufferIdx++] = tx;
-      fQuadBuffer[bufferIdx++] = rightCornerY;
-      fQuadBuffer[bufferIdx++] = texCoordX1;
-      fQuadBuffer[bufferIdx++] = texCoordY2;
-      uiQuadBuffer[bufferIdx++] = colorBl;
-      fQuadBuffer[bufferIdx++] = textureIdx;
-
-      // Lower-Right
-      fQuadBuffer[bufferIdx++] = rightCornerX;
-      fQuadBuffer[bufferIdx++] = rightCornerY;
-      fQuadBuffer[bufferIdx++] = texCoordX2;
-      fQuadBuffer[bufferIdx++] = texCoordY2;
-      uiQuadBuffer[bufferIdx++] = colorBr;
-      fQuadBuffer[bufferIdx++] = textureIdx;
-    }
+    // Lower-Right
+    fQuadBuffer[bufferIdx++] = x3;
+    fQuadBuffer[bufferIdx++] = y3;
+    fQuadBuffer[bufferIdx++] = texCoordX2;
+    fQuadBuffer[bufferIdx++] = texCoordY2;
+    uiQuadBuffer[bufferIdx++] = colorBr;
+    fQuadBuffer[bufferIdx++] = textureIdx;
 
     // Update the length of the current render op
     curRenderOp.length += WORDS_PER_QUAD;

--- a/src/core/text-rendering/renderers/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/renderers/CanvasTextRenderer.ts
@@ -639,13 +639,18 @@ export class CanvasTextRenderer extends TextRenderer<CanvasTextRendererState> {
         shader: null,
         shaderProps: null,
         zIndex,
+        tx: transform.tx,
+        ty: transform.ty - scrollY + renderWindow.y1,
+        ta: transform.ta,
+        tb: transform.tb,
+        tc: transform.tc,
+        td: transform.td,
         renderCoords: this.calculateRenderCoords(
           width,
           height,
           transform,
           transform.ty - scrollY + renderWindow.y1,
         ),
-        transform,
       });
     }
     if (canvasPages[1].valid) {
@@ -663,13 +668,18 @@ export class CanvasTextRenderer extends TextRenderer<CanvasTextRendererState> {
         shader: null,
         shaderProps: null,
         zIndex,
+        tx: transform.tx,
+        ty: transform.ty - scrollY + renderWindow.y1 + pageSize,
+        ta: transform.ta,
+        tb: transform.tb,
+        tc: transform.tc,
+        td: transform.td,
         renderCoords: this.calculateRenderCoords(
           width,
           height,
           transform,
           transform.ty - scrollY + renderWindow.y1 + pageSize,
         ),
-        transform,
       });
     }
     if (canvasPages[2].valid) {
@@ -687,13 +697,18 @@ export class CanvasTextRenderer extends TextRenderer<CanvasTextRendererState> {
         shader: null,
         shaderProps: null,
         zIndex,
+        tx: transform.tx,
+        ty: transform.ty - scrollY + renderWindow.y1 + pageSize + pageSize,
+        ta: transform.ta,
+        tb: transform.tb,
+        tc: transform.tc,
+        td: transform.td,
         renderCoords: this.calculateRenderCoords(
           width,
           height,
           transform,
           transform.ty - scrollY + renderWindow.y1 + pageSize + pageSize,
         ),
-        transform,
       });
     }
 


### PR DESCRIPTION
When calculating the renderCoords in the CoreNode we use the same formula's in the the addQuad WebGLCoreRenderer, with this fix the RenderCoords are now added to the QuadOptions this removes the need to recalculate the draw coordinates every time there is a redraw.

With this fix the transform values; tx,  ty, ta, tb, tc, td are no longer required in the WebGlCoreRenderer, they are however still required in the CanvasCoreRenderer, this is something I still need to investigate.

Because the CanvasCoreRenderer still operates slightly different the CanvasTextRenderer still needs to use both renderCoords and transform values. 