### PR TITLE
passing renderCoords from CoreNode to addQuad

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -885,9 +885,16 @@ export class CoreNode extends EventEmitter {
       premultipliedColorBr,
     } = this;
 
-    const { zIndex, worldAlpha, globalTransform: gt, clippingRect } = this;
+    const {
+      zIndex,
+      worldAlpha,
+      globalTransform: gt,
+      clippingRect,
+      renderCoords,
+    } = this;
 
     assertTruthy(gt);
+    assertTruthy(renderCoords);
 
     // add to list of renderables to be sorted before rendering
     renderer.addQuad({
@@ -910,6 +917,7 @@ export class CoreNode extends EventEmitter {
       tb: gt.tb,
       tc: gt.tc,
       td: gt.td,
+      renderCoords,
       rtt,
       parentHasRenderTexture: this.parentHasRenderTexture,
       framebufferDimensions: this.framebufferDimensions,

--- a/src/core/renderers/CoreRenderer.ts
+++ b/src/core/renderers/CoreRenderer.ts
@@ -27,6 +27,7 @@ import type {
 import type { Stage } from '../Stage.js';
 import type { TextureMemoryManager } from '../TextureMemoryManager.js';
 import type { ContextSpy } from '../lib/ContextSpy.js';
+import type { RenderCoords } from '../lib/RenderCoords.js';
 import type { RectWithValid } from '../lib/utils.js';
 import { ColorTexture } from '../textures/ColorTexture.js';
 import type { Texture } from '../textures/Texture.js';
@@ -53,6 +54,7 @@ export interface QuadOptions {
   tb: number;
   tc: number;
   td: number;
+  renderCoords?: RenderCoords;
   rtt?: boolean;
   parentHasRenderTexture?: boolean;
   framebufferDimensions?: Dimensions;

--- a/src/core/renderers/webgl/WebGlCoreRenderer.ts
+++ b/src/core/renderers/webgl/WebGlCoreRenderer.ts
@@ -234,6 +234,7 @@ export class WebGlCoreRenderer extends CoreRenderer {
       tb,
       tc,
       td,
+      renderCoords,
       rtt: renderToTexture,
       parentHasRenderTexture,
       framebufferDimensions,
@@ -318,79 +319,112 @@ export class WebGlCoreRenderer extends CoreRenderer {
 
     curRenderOp = this.curRenderOp;
     assertTruthy(curRenderOp);
-
-    // render quad advanced
-    if (tb !== 0 || tc !== 0) {
+    if (renderCoords) {
+      const { x1, y1, x2, y2, x3, y3, x4, y4 } = renderCoords;
       // Upper-Left
-      fQuadBuffer[bufferIdx++] = tx; // vertexX
-      fQuadBuffer[bufferIdx++] = ty; // vertexY
+      fQuadBuffer[bufferIdx++] = x1; // vertexX
+      fQuadBuffer[bufferIdx++] = y1; // vertexY
       fQuadBuffer[bufferIdx++] = texCoordX1; // texCoordX
       fQuadBuffer[bufferIdx++] = texCoordY1; // texCoordY
       uiQuadBuffer[bufferIdx++] = colorTl; // color
       fQuadBuffer[bufferIdx++] = textureIdx; // texIndex
 
       // Upper-Right
-      fQuadBuffer[bufferIdx++] = tx + width * ta;
-      fQuadBuffer[bufferIdx++] = ty + width * tc;
+      fQuadBuffer[bufferIdx++] = x2;
+      fQuadBuffer[bufferIdx++] = y2;
       fQuadBuffer[bufferIdx++] = texCoordX2;
       fQuadBuffer[bufferIdx++] = texCoordY1;
       uiQuadBuffer[bufferIdx++] = colorTr;
       fQuadBuffer[bufferIdx++] = textureIdx;
 
       // Lower-Left
-      fQuadBuffer[bufferIdx++] = tx + height * tb;
-      fQuadBuffer[bufferIdx++] = ty + height * td;
+      fQuadBuffer[bufferIdx++] = x4;
+      fQuadBuffer[bufferIdx++] = y4;
       fQuadBuffer[bufferIdx++] = texCoordX1;
       fQuadBuffer[bufferIdx++] = texCoordY2;
       uiQuadBuffer[bufferIdx++] = colorBl;
       fQuadBuffer[bufferIdx++] = textureIdx;
 
       // Lower-Right
-      fQuadBuffer[bufferIdx++] = tx + width * ta + height * tb;
-      fQuadBuffer[bufferIdx++] = ty + width * tc + height * td;
+      fQuadBuffer[bufferIdx++] = x3;
+      fQuadBuffer[bufferIdx++] = y3;
       fQuadBuffer[bufferIdx++] = texCoordX2;
       fQuadBuffer[bufferIdx++] = texCoordY2;
       uiQuadBuffer[bufferIdx++] = colorBr;
       fQuadBuffer[bufferIdx++] = textureIdx;
     } else {
-      // Calculate the right corner of the quad
-      // multiplied by the scale
-      const rightCornerX = tx + width * ta;
-      const rightCornerY = ty + height * td;
+      // render quad advanced
+      if (tb !== 0 || tc !== 0) {
+        // Upper-Left
+        fQuadBuffer[bufferIdx++] = tx; // vertexX
+        fQuadBuffer[bufferIdx++] = ty; // vertexY
+        fQuadBuffer[bufferIdx++] = texCoordX1; // texCoordX
+        fQuadBuffer[bufferIdx++] = texCoordY1; // texCoordY
+        uiQuadBuffer[bufferIdx++] = colorTl; // color
+        fQuadBuffer[bufferIdx++] = textureIdx; // texIndex
 
-      // Upper-Left
-      fQuadBuffer[bufferIdx++] = tx; // vertexX
-      fQuadBuffer[bufferIdx++] = ty; // vertexY
-      fQuadBuffer[bufferIdx++] = texCoordX1; // texCoordX
-      fQuadBuffer[bufferIdx++] = texCoordY1; // texCoordY
-      uiQuadBuffer[bufferIdx++] = colorTl; // color
-      fQuadBuffer[bufferIdx++] = textureIdx; // texIndex
+        // Upper-Right
+        fQuadBuffer[bufferIdx++] = tx + width * ta;
+        fQuadBuffer[bufferIdx++] = ty + width * tc;
+        fQuadBuffer[bufferIdx++] = texCoordX2;
+        fQuadBuffer[bufferIdx++] = texCoordY1;
+        uiQuadBuffer[bufferIdx++] = colorTr;
+        fQuadBuffer[bufferIdx++] = textureIdx;
 
-      // Upper-Right
-      fQuadBuffer[bufferIdx++] = rightCornerX;
-      fQuadBuffer[bufferIdx++] = ty;
-      fQuadBuffer[bufferIdx++] = texCoordX2;
-      fQuadBuffer[bufferIdx++] = texCoordY1;
-      uiQuadBuffer[bufferIdx++] = colorTr;
-      fQuadBuffer[bufferIdx++] = textureIdx;
+        // Lower-Left
+        fQuadBuffer[bufferIdx++] = tx + height * tb;
+        fQuadBuffer[bufferIdx++] = ty + height * td;
+        fQuadBuffer[bufferIdx++] = texCoordX1;
+        fQuadBuffer[bufferIdx++] = texCoordY2;
+        uiQuadBuffer[bufferIdx++] = colorBl;
+        fQuadBuffer[bufferIdx++] = textureIdx;
 
-      // Lower-Left
-      fQuadBuffer[bufferIdx++] = tx;
-      fQuadBuffer[bufferIdx++] = rightCornerY;
-      fQuadBuffer[bufferIdx++] = texCoordX1;
-      fQuadBuffer[bufferIdx++] = texCoordY2;
-      uiQuadBuffer[bufferIdx++] = colorBl;
-      fQuadBuffer[bufferIdx++] = textureIdx;
+        // Lower-Right
+        fQuadBuffer[bufferIdx++] = tx + width * ta + height * tb;
+        fQuadBuffer[bufferIdx++] = ty + width * tc + height * td;
+        fQuadBuffer[bufferIdx++] = texCoordX2;
+        fQuadBuffer[bufferIdx++] = texCoordY2;
+        uiQuadBuffer[bufferIdx++] = colorBr;
+        fQuadBuffer[bufferIdx++] = textureIdx;
+      } else {
+        // Calculate the right corner of the quad
+        // multiplied by the scale
+        const rightCornerX = tx + width * ta;
+        const rightCornerY = ty + height * td;
 
-      // Lower-Right
-      fQuadBuffer[bufferIdx++] = rightCornerX;
-      fQuadBuffer[bufferIdx++] = rightCornerY;
-      fQuadBuffer[bufferIdx++] = texCoordX2;
-      fQuadBuffer[bufferIdx++] = texCoordY2;
-      uiQuadBuffer[bufferIdx++] = colorBr;
-      fQuadBuffer[bufferIdx++] = textureIdx;
+        // Upper-Left
+        fQuadBuffer[bufferIdx++] = tx; // vertexX
+        fQuadBuffer[bufferIdx++] = ty; // vertexY
+        fQuadBuffer[bufferIdx++] = texCoordX1; // texCoordX
+        fQuadBuffer[bufferIdx++] = texCoordY1; // texCoordY
+        uiQuadBuffer[bufferIdx++] = colorTl; // color
+        fQuadBuffer[bufferIdx++] = textureIdx; // texIndex
+
+        // Upper-Right
+        fQuadBuffer[bufferIdx++] = rightCornerX;
+        fQuadBuffer[bufferIdx++] = ty;
+        fQuadBuffer[bufferIdx++] = texCoordX2;
+        fQuadBuffer[bufferIdx++] = texCoordY1;
+        uiQuadBuffer[bufferIdx++] = colorTr;
+        fQuadBuffer[bufferIdx++] = textureIdx;
+
+        // Lower-Left
+        fQuadBuffer[bufferIdx++] = tx;
+        fQuadBuffer[bufferIdx++] = rightCornerY;
+        fQuadBuffer[bufferIdx++] = texCoordX1;
+        fQuadBuffer[bufferIdx++] = texCoordY2;
+        uiQuadBuffer[bufferIdx++] = colorBl;
+        fQuadBuffer[bufferIdx++] = textureIdx;
+
+        // Lower-Right
+        fQuadBuffer[bufferIdx++] = rightCornerX;
+        fQuadBuffer[bufferIdx++] = rightCornerY;
+        fQuadBuffer[bufferIdx++] = texCoordX2;
+        fQuadBuffer[bufferIdx++] = texCoordY2;
+        uiQuadBuffer[bufferIdx++] = colorBr;
+        fQuadBuffer[bufferIdx++] = textureIdx;
+      }
     }
-
     // Update the length of the current render op
     curRenderOp.length += WORDS_PER_QUAD;
     curRenderOp.numQuads++;

--- a/src/core/renderers/webgl/WebGlCoreRenderer.ts
+++ b/src/core/renderers/webgl/WebGlCoreRenderer.ts
@@ -352,78 +352,75 @@ export class WebGlCoreRenderer extends CoreRenderer {
       fQuadBuffer[bufferIdx++] = texCoordY2;
       uiQuadBuffer[bufferIdx++] = colorBr;
       fQuadBuffer[bufferIdx++] = textureIdx;
+    } else if (tb !== 0 || tc !== 0) {
+      // Upper-Left
+      fQuadBuffer[bufferIdx++] = tx; // vertexX
+      fQuadBuffer[bufferIdx++] = ty; // vertexY
+      fQuadBuffer[bufferIdx++] = texCoordX1; // texCoordX
+      fQuadBuffer[bufferIdx++] = texCoordY1; // texCoordY
+      uiQuadBuffer[bufferIdx++] = colorTl; // color
+      fQuadBuffer[bufferIdx++] = textureIdx; // texIndex
+
+      // Upper-Right
+      fQuadBuffer[bufferIdx++] = tx + width * ta;
+      fQuadBuffer[bufferIdx++] = ty + width * tc;
+      fQuadBuffer[bufferIdx++] = texCoordX2;
+      fQuadBuffer[bufferIdx++] = texCoordY1;
+      uiQuadBuffer[bufferIdx++] = colorTr;
+      fQuadBuffer[bufferIdx++] = textureIdx;
+
+      // Lower-Left
+      fQuadBuffer[bufferIdx++] = tx + height * tb;
+      fQuadBuffer[bufferIdx++] = ty + height * td;
+      fQuadBuffer[bufferIdx++] = texCoordX1;
+      fQuadBuffer[bufferIdx++] = texCoordY2;
+      uiQuadBuffer[bufferIdx++] = colorBl;
+      fQuadBuffer[bufferIdx++] = textureIdx;
+
+      // Lower-Right
+      fQuadBuffer[bufferIdx++] = tx + width * ta + height * tb;
+      fQuadBuffer[bufferIdx++] = ty + width * tc + height * td;
+      fQuadBuffer[bufferIdx++] = texCoordX2;
+      fQuadBuffer[bufferIdx++] = texCoordY2;
+      uiQuadBuffer[bufferIdx++] = colorBr;
+      fQuadBuffer[bufferIdx++] = textureIdx;
     } else {
-      // render quad advanced
-      if (tb !== 0 || tc !== 0) {
-        // Upper-Left
-        fQuadBuffer[bufferIdx++] = tx; // vertexX
-        fQuadBuffer[bufferIdx++] = ty; // vertexY
-        fQuadBuffer[bufferIdx++] = texCoordX1; // texCoordX
-        fQuadBuffer[bufferIdx++] = texCoordY1; // texCoordY
-        uiQuadBuffer[bufferIdx++] = colorTl; // color
-        fQuadBuffer[bufferIdx++] = textureIdx; // texIndex
+      // Calculate the right corner of the quad
+      // multiplied by the scale
+      const rightCornerX = tx + width * ta;
+      const rightCornerY = ty + height * td;
 
-        // Upper-Right
-        fQuadBuffer[bufferIdx++] = tx + width * ta;
-        fQuadBuffer[bufferIdx++] = ty + width * tc;
-        fQuadBuffer[bufferIdx++] = texCoordX2;
-        fQuadBuffer[bufferIdx++] = texCoordY1;
-        uiQuadBuffer[bufferIdx++] = colorTr;
-        fQuadBuffer[bufferIdx++] = textureIdx;
+      // Upper-Left
+      fQuadBuffer[bufferIdx++] = tx; // vertexX
+      fQuadBuffer[bufferIdx++] = ty; // vertexY
+      fQuadBuffer[bufferIdx++] = texCoordX1; // texCoordX
+      fQuadBuffer[bufferIdx++] = texCoordY1; // texCoordY
+      uiQuadBuffer[bufferIdx++] = colorTl; // color
+      fQuadBuffer[bufferIdx++] = textureIdx; // texIndex
 
-        // Lower-Left
-        fQuadBuffer[bufferIdx++] = tx + height * tb;
-        fQuadBuffer[bufferIdx++] = ty + height * td;
-        fQuadBuffer[bufferIdx++] = texCoordX1;
-        fQuadBuffer[bufferIdx++] = texCoordY2;
-        uiQuadBuffer[bufferIdx++] = colorBl;
-        fQuadBuffer[bufferIdx++] = textureIdx;
+      // Upper-Right
+      fQuadBuffer[bufferIdx++] = rightCornerX;
+      fQuadBuffer[bufferIdx++] = ty;
+      fQuadBuffer[bufferIdx++] = texCoordX2;
+      fQuadBuffer[bufferIdx++] = texCoordY1;
+      uiQuadBuffer[bufferIdx++] = colorTr;
+      fQuadBuffer[bufferIdx++] = textureIdx;
 
-        // Lower-Right
-        fQuadBuffer[bufferIdx++] = tx + width * ta + height * tb;
-        fQuadBuffer[bufferIdx++] = ty + width * tc + height * td;
-        fQuadBuffer[bufferIdx++] = texCoordX2;
-        fQuadBuffer[bufferIdx++] = texCoordY2;
-        uiQuadBuffer[bufferIdx++] = colorBr;
-        fQuadBuffer[bufferIdx++] = textureIdx;
-      } else {
-        // Calculate the right corner of the quad
-        // multiplied by the scale
-        const rightCornerX = tx + width * ta;
-        const rightCornerY = ty + height * td;
+      // Lower-Left
+      fQuadBuffer[bufferIdx++] = tx;
+      fQuadBuffer[bufferIdx++] = rightCornerY;
+      fQuadBuffer[bufferIdx++] = texCoordX1;
+      fQuadBuffer[bufferIdx++] = texCoordY2;
+      uiQuadBuffer[bufferIdx++] = colorBl;
+      fQuadBuffer[bufferIdx++] = textureIdx;
 
-        // Upper-Left
-        fQuadBuffer[bufferIdx++] = tx; // vertexX
-        fQuadBuffer[bufferIdx++] = ty; // vertexY
-        fQuadBuffer[bufferIdx++] = texCoordX1; // texCoordX
-        fQuadBuffer[bufferIdx++] = texCoordY1; // texCoordY
-        uiQuadBuffer[bufferIdx++] = colorTl; // color
-        fQuadBuffer[bufferIdx++] = textureIdx; // texIndex
-
-        // Upper-Right
-        fQuadBuffer[bufferIdx++] = rightCornerX;
-        fQuadBuffer[bufferIdx++] = ty;
-        fQuadBuffer[bufferIdx++] = texCoordX2;
-        fQuadBuffer[bufferIdx++] = texCoordY1;
-        uiQuadBuffer[bufferIdx++] = colorTr;
-        fQuadBuffer[bufferIdx++] = textureIdx;
-
-        // Lower-Left
-        fQuadBuffer[bufferIdx++] = tx;
-        fQuadBuffer[bufferIdx++] = rightCornerY;
-        fQuadBuffer[bufferIdx++] = texCoordX1;
-        fQuadBuffer[bufferIdx++] = texCoordY2;
-        uiQuadBuffer[bufferIdx++] = colorBl;
-        fQuadBuffer[bufferIdx++] = textureIdx;
-
-        // Lower-Right
-        fQuadBuffer[bufferIdx++] = rightCornerX;
-        fQuadBuffer[bufferIdx++] = rightCornerY;
-        fQuadBuffer[bufferIdx++] = texCoordX2;
-        fQuadBuffer[bufferIdx++] = texCoordY2;
-        uiQuadBuffer[bufferIdx++] = colorBr;
-        fQuadBuffer[bufferIdx++] = textureIdx;
-      }
+      // Lower-Right
+      fQuadBuffer[bufferIdx++] = rightCornerX;
+      fQuadBuffer[bufferIdx++] = rightCornerY;
+      fQuadBuffer[bufferIdx++] = texCoordX2;
+      fQuadBuffer[bufferIdx++] = texCoordY2;
+      uiQuadBuffer[bufferIdx++] = colorBr;
+      fQuadBuffer[bufferIdx++] = textureIdx;
     }
     // Update the length of the current render op
     curRenderOp.length += WORDS_PER_QUAD;


### PR DESCRIPTION
We are using the same calculations for the renderCoords we use in the .addQuad function in the WebGLCoreRenderer, with this fix we can use the already calculated renderCoords without having to do the calculations again every time a draw call is made.