### PR TITLE
refactor(CoreTextureManager): Eliminate ctxTextureCache

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -717,7 +717,7 @@ export class CoreNode extends EventEmitter {
     queueMicrotask(() => {
       // Preload texture if required
       if (this.textureOptions.preload) {
-        this.stage.txManager.getCtxTexture(texture).load();
+        texture.ctxTexture.load();
       }
       if (texture.state === 'loaded') {
         this.onTextureLoaded(texture, texture.dimensions!);

--- a/src/core/CoreTextureManager.ts
+++ b/src/core/CoreTextureManager.ts
@@ -137,8 +137,6 @@ export class CoreTextureManager {
    */
   zeroRefSet: Set<Texture> = new Set();
 
-  ctxTextureCache: WeakMap<Texture, CoreContextTexture> = new WeakMap();
-
   /**
    * Map of texture constructors by their type name
    */
@@ -290,7 +288,7 @@ export class CoreTextureManager {
         // Free the ctx texture if it exists.
         refCountMap.delete(texture);
         zeroRefSet.delete(texture);
-        this.ctxTextureCache.get(texture)?.free();
+        texture.ctxTexture.free();
       }
     }
   }
@@ -312,30 +310,5 @@ export class CoreTextureManager {
     return {
       keyCacheSize: this.keyCache.size,
     };
-  }
-
-  /**
-   * Get a CoreContextTexture for the given Texture source.
-   *
-   * @remarks
-   * If the texture source already has an allocated CoreContextTexture, it will be
-   * returned from the cache. Otherwise, a new CoreContextTexture will be created
-   * and cached.
-   *
-   * ContextTextures are stored in a WeakMap, so they will be garbage collected
-   * when the Texture source is no longer referenced.
-   *
-   * @param textureSource
-   * @returns
-   */
-  getCtxTexture(textureSource: Texture): CoreContextTexture {
-    if (this.ctxTextureCache.has(textureSource)) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      return this.ctxTextureCache.get(textureSource)!;
-    }
-    const texture = this.renderer.createCtxTexture(textureSource);
-
-    this.ctxTextureCache.set(textureSource, texture);
-    return texture;
   }
 }

--- a/src/core/renderers/canvas/CanvasCoreRenderer.ts
+++ b/src/core/renderers/canvas/CanvasCoreRenderer.ts
@@ -104,7 +104,7 @@ export class CanvasCoreRenderer extends CoreRenderer {
         texture = texture.parentTexture;
       }
 
-      ctxTexture = this.txManager.getCtxTexture(texture) as CanvasCoreTexture;
+      ctxTexture = texture.ctxTexture as CanvasCoreTexture;
       if (texture.state === 'freed') {
         ctxTexture.load();
         return;

--- a/src/core/renderers/webgl/WebGlCoreRenderer.ts
+++ b/src/core/renderers/webgl/WebGlCoreRenderer.ts
@@ -311,8 +311,7 @@ export class WebGlCoreRenderer extends CoreRenderer {
       [texCoordY1, texCoordY2] = [texCoordY2, texCoordY1];
     }
 
-    const { txManager } = this.stage;
-    const ctxTexture = txManager.getCtxTexture(texture);
+    const ctxTexture = texture.ctxTexture;
     assertTruthy(ctxTexture instanceof WebGlCoreCtxTexture);
     const textureIdx = this.addTexture(ctxTexture, bufferIdx);
 
@@ -583,7 +582,7 @@ export class WebGlCoreRenderer extends CoreRenderer {
       this.activeRttNode = node;
 
       assertTruthy(node.texture, 'RTT node missing texture');
-      const ctxTexture = txManager.getCtxTexture(node.texture);
+      const ctxTexture = node.texture.ctxTexture;
       assertTruthy(ctxTexture instanceof WebGlCoreCtxRenderTexture);
       this.renderToTextureActive = true;
 

--- a/src/core/text-rendering/font-face-types/SdfTrFontFace/SdfTrFontFace.ts
+++ b/src/core/text-rendering/font-face-types/SdfTrFontFace/SdfTrFontFace.ts
@@ -93,7 +93,7 @@ export class SdfTrFontFace<
     });
 
     // Pre-load it
-    stage.txManager.getCtxTexture(this.texture).load();
+    this.texture.ctxTexture.load();
 
     // Set this.data to the fetched data from dataUrl
     fetch(atlasDataUrl)

--- a/src/core/text-rendering/renderers/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/renderers/CanvasTextRenderer.ts
@@ -559,7 +559,7 @@ export class CanvasTextRenderer extends TextRenderer<CanvasTextRendererState> {
             this.canvas.height,
           ),
         });
-        this.stage.txManager.getCtxTexture(pageInfo.texture).load();
+        pageInfo.texture.ctxTexture.load();
 
         pageInfo.texture.setRenderableOwner(state, state.isRenderable);
       }

--- a/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
+++ b/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
@@ -712,7 +712,7 @@ export class SdfTextRenderer extends TextRenderer<SdfTextRendererState> {
 
     const texture = state.trFontFace?.texture;
     assertTruthy(texture);
-    const ctxTexture = this.stage.txManager.getCtxTexture(texture);
+    const ctxTexture = texture.ctxTexture;
 
     renderOp.addTexture(ctxTexture as WebGlCoreCtxTexture);
     renderOp.length = state.bufferNumFloats;

--- a/src/core/textures/Texture.ts
+++ b/src/core/textures/Texture.ts
@@ -21,6 +21,7 @@ import type { CoreTextureManager } from '../CoreTextureManager.js';
 import type { SubTextureProps } from './SubTexture.js';
 import type { Dimensions } from '../../common/CommonTypes.js';
 import { EventEmitter } from '../../common/EventEmitter.js';
+import type { CoreContextTexture } from '../renderers/CoreContextTexture.js';
 
 /**
  * Event handler for when a Texture is freed
@@ -196,6 +197,25 @@ export abstract class Texture extends EventEmitter {
    * @param isRenderable `true` if this Texture has renderable owners.
    */
   onChangeIsRenderable?(isRenderable: boolean): void;
+
+  /**
+   * Get the CoreContextTexture for this Texture
+   *
+   * @remarks
+   * Each Texture has a corresponding CoreContextTexture that is used to
+   * manage the texture's native data depending on the renderer's mode
+   * (WebGL, Canvas, etc).
+   *
+   * The Texture and CoreContextTexture are always linked together in a 1:1
+   * relationship.
+   */
+  get ctxTexture() {
+    // The first time this is called, create the ctxTexture
+    const ctxTexture = this.txManager.renderer.createCtxTexture(this);
+    // And replace this getter with the value for future calls
+    Object.defineProperty(this, 'ctxTexture', { value: ctxTexture });
+    return ctxTexture;
+  }
 
   /**
    * Returns true if the texture is assigned to any Nodes that are renderable.


### PR DESCRIPTION
This refactor eliminates the ctxTextureCache WeakMap and replaces it with access to CoreContextTextures directly from Texture objects themselves.

Since access is more direct and does not require a map look up each time this change should be performance positive. It also simplifies the code a good bit.

This is being done as a foundational step for further Texture memory work.