### PR TITLE
Fix: wrong load external resources when the local protocol is file://

### DIFF
--- a/src/core/lib/utils.ts
+++ b/src/core/lib/utils.ts
@@ -252,8 +252,12 @@ export function isRectPositive(rect: Rect): boolean {
 }
 
 export function convertUrlToAbsolute(url: string): string {
-  // handle local file imports if the url is not the network resource
-  if (self.location.protocol === 'file:' && !EXTERNAL_REGEX_URL.test(url)) {
+  // handle local file imports if the url isn't remote resource or data blob
+  if (
+    self.location.protocol === 'file:' &&
+    !EXTERNAL_REGEX_URL.test(url) &&
+    !url.startsWith('data:')
+  ) {
     const path = self.location.pathname.split('/');
     path.pop();
     const basePath = path.join('/');

--- a/src/core/lib/utils.ts
+++ b/src/core/lib/utils.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-export const EXTERNAL_REGEX_URL = /^(ftps?|https?):\/\//;
+export const PROTOCOL_REGEX = /^(data|ftps?|https?):/;
 
 export type RGBA = [r: number, g: number, b: number, a: number];
 export const getNormalizedRgbaComponents = (rgba: number): RGBA => {
@@ -253,11 +253,7 @@ export function isRectPositive(rect: Rect): boolean {
 
 export function convertUrlToAbsolute(url: string): string {
   // handle local file imports if the url isn't remote resource or data blob
-  if (
-    self.location.protocol === 'file:' &&
-    !EXTERNAL_REGEX_URL.test(url) &&
-    !url.startsWith('data:')
-  ) {
+  if (self.location.protocol === 'file:' && !PROTOCOL_REGEX.test(url)) {
     const path = self.location.pathname.split('/');
     path.pop();
     const basePath = path.join('/');

--- a/src/core/lib/utils.ts
+++ b/src/core/lib/utils.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-export const REGEX_URL = /^(ftps?|https?):\/\//;
+export const EXTERNAL_REGEX_URL = /^(ftps?|https?):\/\//;
 
 export type RGBA = [r: number, g: number, b: number, a: number];
 export const getNormalizedRgbaComponents = (rgba: number): RGBA => {
@@ -253,7 +253,7 @@ export function isRectPositive(rect: Rect): boolean {
 
 export function convertUrlToAbsolute(url: string): string {
   // handle local file imports if the url is not the network resource
-  if (self.location.protocol === 'file:' && !REGEX_URL.test(url)) {
+  if (self.location.protocol === 'file:' && !EXTERNAL_REGEX_URL.test(url)) {
     const path = self.location.pathname.split('/');
     path.pop();
     const basePath = path.join('/');

--- a/src/core/lib/utils.ts
+++ b/src/core/lib/utils.ts
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+export const REGEX_URL = /^(ftps?|https?):\/\//;
+
 export type RGBA = [r: number, g: number, b: number, a: number];
 export const getNormalizedRgbaComponents = (rgba: number): RGBA => {
   const r = rgba >>> 24;
@@ -250,8 +252,8 @@ export function isRectPositive(rect: Rect): boolean {
 }
 
 export function convertUrlToAbsolute(url: string): string {
-  // handle local file imports
-  if (self.location.protocol === 'file:') {
+  // handle local file imports if the url is not the network resource
+  if (self.location.protocol === 'file:' && !REGEX_URL.test(url)) {
     const path = self.location.pathname.split('/');
     path.pop();
     const basePath = path.join('/');


### PR DESCRIPTION
When an external image resource is loaded from https, the function convertUrlToAbsolute inside the utils.ts doesn't check if it is a network or internal resource.