### PR TITLE
Fix github action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,9 @@ jobs:
         with:
           node-version: 20
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 8
           run_install: false
 
       - name: Get pnpm store directory


### PR DESCRIPTION
pnpm/action-setup version 2 is [no longer working](https://github.com/pnpm/action-setup/issues/135). Upgrading to version 4.