### PR TITLE
Export ShaderController types to API

### DIFF
--- a/exports/index.ts
+++ b/exports/index.ts
@@ -39,6 +39,8 @@
 
 export * from '../src/main-api/INode.js';
 export * from '../src/main-api/Renderer.js';
+export * from '../src/main-api/ShaderController.js';
+export * from '../src/main-api/DynamicShaderController.js';
 export * from '../src/common/IAnimationController.js';
 export * from '../src/common/CommonTypes.js';
 

--- a/src/main-api/INode.ts
+++ b/src/main-api/INode.ts
@@ -57,8 +57,9 @@ export interface INode<SC extends BaseShaderController = BaseShaderController>
 /**
  * Properties used to animate() a Node
  */
-export interface INodeAnimateProps<SC extends BaseShaderController>
-  extends Omit<CoreNodeAnimateProps, 'shaderProps'> {
+export interface INodeAnimateProps<
+  SC extends BaseShaderController = BaseShaderController,
+> extends Omit<CoreNodeAnimateProps, 'shaderProps'> {
   shaderProps: Partial<SC['props']>;
 }
 


### PR DESCRIPTION
- Also make INodeAnimateProps use BaseShaderController as a default generic type.

Had multiple requests for this.