### PR TITLE
VRT Dockerfile: Install the correct version of PNPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@ FROM mcr.microsoft.com/playwright:v1.39.0-jammy
 # Set the working directory
 WORKDIR /work
 
-# Install PNPM
-RUN npm install -g pnpm
-
 # Copy the necessary files to the container
 COPY .npmrc .npmrc
 COPY package.json package.json
+
+# Install PNPM
+RUN corepack prepare && corepack enable
 
 # Get pnpm to install the version of Node declared in .npmrc
 RUN pnpm exec ls


### PR DESCRIPTION
Prior to this change, the VRT Dockerfile installed the latest version of PNPM instead of that is specified in the project's package.json (8.9.2 as of this writing). This led to an issue where everytime you ran the VRT tests in --ci mode it would run pnpm 9 which would incorrectly update the pnpm-lock.yaml file.

This change uses `corepack` to install the project's version of PNPM.