### PR TITLE
fix: Image worker broken with vite build

### DIFF
--- a/src/core/lib/ImageWorker.ts
+++ b/src/core/lib/ImageWorker.ts
@@ -35,7 +35,7 @@ interface getImageReturn {
  */
 
 /* eslint-disable */
-const createImageWorker = function worker() {
+function createImageWorker() {
   function hasAlphaChannel(mimeType: string) {
     return mimeType.indexOf('image/png') !== -1;
   }
@@ -96,7 +96,7 @@ const createImageWorker = function worker() {
         self.postMessage({ id: id, src: src, error: error.message });
       });
   };
-};
+}
 /* eslint-enable */
 
 export class ImageWorkerManager {
@@ -133,7 +133,7 @@ export class ImageWorkerManager {
   }
 
   private createWorkers(numWorkers = 1): Worker[] {
-    const workerCode = `${createImageWorker.toString()} worker()`;
+    const workerCode = `(${createImageWorker.toString()})()`;
 
     const blob: Blob = new Blob([workerCode.replace('"use strict";', '')], {
       type: 'application/javascript',


### PR DESCRIPTION
Fixes missing function name in image worker blob when building with vite