### PR TITLE
Fix: Remove from active animations when reverse stopMethod is complete

### DIFF
--- a/src/core/animations/CoreAnimationController.ts
+++ b/src/core/animations/CoreAnimationController.ts
@@ -119,6 +119,7 @@ export class CoreAnimationController
     const { loop, stopMethod } = this.animation.settings;
 
     if (stopMethod === 'reverse') {
+      this.animation.once('finished', this.onFinished);
       this.animation.reverse();
       return;
     }


### PR DESCRIPTION
#318 - After stopMethod 'reverse' is done it is removed from animations. Also the animation loops in its entirety not only the reverse part when loop is true.