### PR TITLE
Rename TextureTypeMap back to TextureMap

### DIFF
--- a/docs/example-projects/custom-shader-effect-texture/src/MyCustomTexture.ts
+++ b/docs/example-projects/custom-shader-effect-texture/src/MyCustomTexture.ts
@@ -8,7 +8,7 @@ import { assertTruthy } from '@lightningjs/renderer/utils';
  * Augment the EffectMap interface to include the CustomEffect
  */
 declare module '@lightningjs/renderer' {
-  interface TextureTypeMap {
+  interface TextureMap {
     MyCustomTexture: typeof MyCustomTexture;
   }
 }

--- a/examples/common/Character.ts
+++ b/examples/common/Character.ts
@@ -34,7 +34,7 @@ export class Character {
   constructor(
     private props: Partial<INodeProps>,
     private renderer: RendererMain,
-    private rightFrames: TextureMap['SubTexture'][],
+    private rightFrames: InstanceType<TextureMap['SubTexture']>[],
   ) {
     this.node = renderer.createNode({
       x: props.x,

--- a/exports/index.ts
+++ b/exports/index.ts
@@ -48,7 +48,6 @@ export * from '../src/common/CommonTypes.js';
 // context of the main API.
 export {
   CoreTextureManager,
-  type TextureTypeMap,
   type TextureMap,
 } from '../src/core/CoreTextureManager.js';
 export type { MemoryInfo } from '../src/core/TextureMemoryManager.js';

--- a/src/core/CoreTextureManager.ts
+++ b/src/core/CoreTextureManager.ts
@@ -34,20 +34,13 @@ import type { Texture } from './textures/Texture.js';
  * texture types. The ones included directly here are the ones that are
  * included in the core library.
  */
-export interface TextureTypeMap {
+export interface TextureMap {
   ColorTexture: typeof ColorTexture;
   ImageTexture: typeof ImageTexture;
   NoiseTexture: typeof NoiseTexture;
   SubTexture: typeof SubTexture;
   RenderTexture: typeof RenderTexture;
 }
-
-/**
- * Map of texture instance types
- */
-export type TextureMap = {
-  [K in keyof TextureTypeMap]: InstanceType<TextureTypeMap[K]>;
-};
 
 export type ExtractProps<Type> = Type extends { z$__type__Props: infer Props }
   ? Props
@@ -159,7 +152,7 @@ export class CoreTextureManager {
   /**
    * Map of texture constructors by their type name
    */
-  txConstructors: Partial<TextureTypeMap> = {};
+  txConstructors: Partial<TextureMap> = {};
 
   imageWorkerManager: ImageWorkerManager | null = null;
   hasCreateImageBitmap = !!self.createImageBitmap;
@@ -203,17 +196,17 @@ export class CoreTextureManager {
     this.registerTextureType('RenderTexture', RenderTexture);
   }
 
-  registerTextureType<Type extends keyof TextureTypeMap>(
+  registerTextureType<Type extends keyof TextureMap>(
     textureType: Type,
-    textureClass: TextureTypeMap[Type],
+    textureClass: TextureMap[Type],
   ): void {
     this.txConstructors[textureType] = textureClass;
   }
 
-  loadTexture<Type extends keyof TextureTypeMap>(
+  loadTexture<Type extends keyof TextureMap>(
     textureType: Type,
-    props: ExtractProps<TextureTypeMap[Type]>,
-  ): InstanceType<TextureTypeMap[Type]> {
+    props: ExtractProps<TextureMap[Type]>,
+  ): InstanceType<TextureMap[Type]> {
     let texture: Texture | undefined;
     const TextureClass = this.txConstructors[textureType];
     if (!TextureClass) {
@@ -234,7 +227,7 @@ export class CoreTextureManager {
         }
       }
     }
-    return texture as InstanceType<TextureTypeMap[Type]>;
+    return texture as InstanceType<TextureMap[Type]>;
   }
 
   private initTextureToCache(texture: Texture, cacheKey: string) {

--- a/src/main-api/Renderer.ts
+++ b/src/main-api/Renderer.ts
@@ -19,11 +19,7 @@
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { EffectMap, ShaderMap } from '../core/CoreShaderManager.js';
-import type {
-  ExtractProps,
-  TextureTypeMap,
-  TextureMap,
-} from '../core/CoreTextureManager.js';
+import type { ExtractProps, TextureMap } from '../core/CoreTextureManager.js';
 import { EventEmitter } from '../common/EventEmitter.js';
 import { Inspector } from './Inspector.js';
 import { assertTruthy, isProductionEnvironment } from '../utils.js';
@@ -447,14 +443,11 @@ export class RendererMain extends EventEmitter {
    * @param options
    * @returns
    */
-  createTexture<TxType extends keyof TextureTypeMap>(
+  createTexture<TxType extends keyof TextureMap>(
     textureType: TxType,
-    props: ExtractProps<TextureTypeMap[TxType]>,
-  ): TextureMap[TxType] {
-    return this.stage.txManager.loadTexture(
-      textureType,
-      props,
-    ) as TextureMap[TxType];
+    props: ExtractProps<TextureMap[TxType]>,
+  ): InstanceType<TextureMap[TxType]> {
+    return this.stage.txManager.loadTexture(textureType, props);
   }
 
   /**


### PR DESCRIPTION
TextureTypeMap was introduced when ThreadX was removed, and TextureMap existed as the "instance" version of TextureTypeMap. This is inconsistent with the ShaderMap and EffectMap, which don't have "instance" versions.

To fix this inconsistency, the "instance" version is removed and TextureTypeMap is renamed back to TextureMap