### PR TITLE
Support for Tree Shakable Canvas/WebGL renderer and Font Engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,18 @@ import {
   SdfTrFontFace,
 } from '@lightningjs/renderer';
 
+import {
+  WebGlCoreRenderer,
+  SdfTextRenderer,
+} from '@lightningjs/renderer/webgl';
+import { CanvasTextRenderer } from '@lightningjs/renderer/canvas';
+
 const renderer = new RendererMain(
   {
     appWidth: 1920,
     appHeight: 1080,
+    renderEngine: WebGlCoreRenderer,
+    fontEngines: [SdfTextRenderer, CanvasTextRenderer],
     // ...Other Renderer Config
   },
   'app', // id of div to insert Canvas.
@@ -128,3 +136,12 @@ renderer.stage.fontManager.addFontFace(
   ),
 );
 ```
+
+Please note that the WebGL renderer supports both SDF Fonts and Web Fonts, however the
+Canvas renderer only supports Web Fonts:
+
+| Font Type Renderer | SDF Font | Web Font |
+| ------------------ | -------- | -------- |
+| WebGL              | Y        | Y        |
+| Canvas             | N        | Y        |
+|                    |          |          |

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -236,7 +236,7 @@ async function initRenderer(
       enableInspector,
       renderEngine:
         renderMode === 'webgl' ? WebGlCoreRenderer : CanvasCoreRenderer,
-      fontEngines: [CanvasTextRenderer, SdfTextRenderer],
+      fontEngines: [SdfTextRenderer, CanvasTextRenderer],
       ...customSettings,
     },
     'app',

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -23,6 +23,15 @@ import {
   type RendererMainSettings,
   type FpsUpdatePayload,
 } from '@lightningjs/renderer';
+import {
+  WebGlCoreRenderer,
+  SdfTextRenderer,
+} from '@lightningjs/renderer/webgl';
+import {
+  CanvasCoreRenderer,
+  CanvasTextRenderer,
+} from '@lightningjs/renderer/canvas';
+
 import { assertTruthy } from '@lightningjs/renderer/utils';
 import * as mt19937 from '@stdlib/random-base-mt19937';
 import type {
@@ -225,7 +234,9 @@ async function initRenderer(
       fpsUpdateInterval: logFps ? 1000 : 0,
       enableContextSpy,
       enableInspector,
-      renderMode: renderMode as 'webgl' | 'canvas',
+      renderEngine:
+        renderMode === 'webgl' ? WebGlCoreRenderer : CanvasCoreRenderer,
+      fontEngines: [CanvasTextRenderer, SdfTextRenderer],
       ...customSettings,
     },
     'app',

--- a/examples/tests/text-canvas.ts
+++ b/examples/tests/text-canvas.ts
@@ -71,7 +71,7 @@ export default async function test(settings: ExampleSettings) {
       ] || 0xff0000ff;
   };
 
-  const spawn = (amount = 100) => {
+  const spawn = (amount = 1) => {
     for (let i = 0; i < amount; i++) {
       renderNode(i.toString());
     }

--- a/exports/canvas.ts
+++ b/exports/canvas.ts
@@ -1,0 +1,36 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Canvas Text Renderer
+ *
+ * @remarks
+ * This module exports the Canvas Text Renderer for the Lightning 3 Renderer.
+ * The Canvas Text Renderer is used to render text using the Canvas API,
+ * this is slightly less performant than the SDF Text Renderer. However
+ * the Canvas Text Renderer is more widely supported on older devices.
+ *
+ * You can import the exports from this module like so:
+ * ```ts
+ * import { CanvasTextRenderer } from '@lightning/renderer';
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+export { CanvasTextRenderer } from '../src/core/text-rendering/renderers/CanvasTextRenderer.js';

--- a/exports/canvas.ts
+++ b/exports/canvas.ts
@@ -34,3 +34,4 @@
  */
 
 export { CanvasTextRenderer } from '../src/core/text-rendering/renderers/CanvasTextRenderer.js';
+export { CanvasCoreRenderer } from '../src/core/renderers/canvas/CanvasCoreRenderer.js';

--- a/exports/index.ts
+++ b/exports/index.ts
@@ -77,8 +77,6 @@ export * from '../src/core/textures/Texture.js';
 
 // Text Rendering & Fonts
 // export * from '../src/core/text-rendering/renderers/TextRenderer.js';
-// export { CanvasTextRenderer } from '../src/core/text-rendering/renderers/CanvasTextRenderer.js';
-// export { SdfTextRenderer } from '../src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.js';
 export * from '../src/core/text-rendering/font-face-types/TrFontFace.js';
 export * from '../src/core/text-rendering/font-face-types/WebTrFontFace.js';
 export * from '../src/core/text-rendering/font-face-types/SdfTrFontFace/SdfTrFontFace.js';

--- a/exports/index.ts
+++ b/exports/index.ts
@@ -76,9 +76,9 @@ export type { ShaderProgramSources } from '../src/core/renderers/webgl/internal/
 export * from '../src/core/textures/Texture.js';
 
 // Text Rendering & Fonts
-export * from '../src/core/text-rendering/renderers/TextRenderer.js';
-export * from '../src/core/text-rendering/renderers/CanvasTextRenderer.js';
-export * from '../src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.js';
+// export * from '../src/core/text-rendering/renderers/TextRenderer.js';
+// export { CanvasTextRenderer } from '../src/core/text-rendering/renderers/CanvasTextRenderer.js';
+// export { SdfTextRenderer } from '../src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.js';
 export * from '../src/core/text-rendering/font-face-types/TrFontFace.js';
 export * from '../src/core/text-rendering/font-face-types/WebTrFontFace.js';
 export * from '../src/core/text-rendering/font-face-types/SdfTrFontFace/SdfTrFontFace.js';

--- a/exports/webgl.ts
+++ b/exports/webgl.ts
@@ -35,3 +35,4 @@
  */
 
 export { SdfTextRenderer } from '../src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.js';
+export { WebGlCoreRenderer } from '../src/core/renderers/webgl/WebGlCoreRenderer.js';

--- a/exports/webgl.ts
+++ b/exports/webgl.ts
@@ -1,0 +1,37 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * SDF Font renderer
+ *
+ * @remarks
+ * This module exports the SDF Font renderer for the Lightning 3 Renderer.
+ * The SDF Font renderer is used to render text using Single-Channel Signed
+ * Distance Field (SSDF) fonts or Multi-Channel Signed Distance Field (MSDF)
+ * fonts. The SDF font renderer is used to render text in a way that is
+ * optimized for GPU rendering.
+ *
+ * You can import the exports from this module like so:
+ * ```ts
+ * import { SdfTextRenderer } from '@lightning/renderer';
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+export { SdfTextRenderer } from '../src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.js';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "main": "./dist/exports/index.js",
   "exports": {
     ".": "./dist/exports/index.js",
-    "./utils": "./dist/exports/utils.js"
+    "./utils": "./dist/exports/utils.js",
+    "./canvas": "./dist/exports/canvas.js",
+    "./webgl": "./dist/exports/webgl.js"
   },
   "scripts": {
     "preinstall": "node scripts/please-use-pnpm.js",

--- a/package.json
+++ b/package.json
@@ -66,8 +66,7 @@
     "vitest-mock-extended": "^1.3.1"
   },
   "dependencies": {
-    "@protobufjs/eventemitter": "^1.1.0",
-    "memize": "^2.1.0"
+    "@protobufjs/eventemitter": "^1.1.0"
   },
   "lint-staged": {
     "*.ts": [

--- a/package.json
+++ b/package.json
@@ -65,9 +65,6 @@
     "vitest": "^1.6.0",
     "vitest-mock-extended": "^1.3.1"
   },
-  "dependencies": {
-    "@protobufjs/eventemitter": "^1.1.0"
-  },
   "lint-staged": {
     "*.ts": [
       "prettier --write",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@protobufjs/eventemitter':
         specifier: ^1.1.0
         version: 1.1.0
-      memize:
-        specifier: ^2.1.0
-        version: 2.1.0
     devDependencies:
       '@types/node':
         specifier: ^20.0.0
@@ -3072,10 +3069,6 @@ packages:
     engines: {node: '>= 12'}
     hasBin: true
     dev: true
-
-  /memize@2.1.0:
-    resolution: {integrity: sha512-yywVJy8ctVlN5lNPxsep5urnZ6TTclwPEyigM9M3Bi8vseJBOfqNrGWN/r8NzuIt3PovM323W04blJfGQfQSVg==}
-    dev: false
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@protobufjs/eventemitter':
-        specifier: ^1.1.0
-        version: 1.1.0
     devDependencies:
       '@types/node':
         specifier: ^20.0.0
@@ -484,10 +480,6 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
     dev: true
-
-  /@protobufjs/eventemitter@1.1.0:
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
-    dev: false
 
   /@rollup/rollup-android-arm-eabi@4.18.0:
     resolution: {integrity: sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==}

--- a/src/core/CoreTextNode.ts
+++ b/src/core/CoreTextNode.ts
@@ -35,6 +35,7 @@ import type {
 import type { RectWithValid } from './lib/utils.js';
 import { assertTruthy } from '../utils.js';
 import { Matrix3d } from './lib/Matrix3d.js';
+import { EventEmitter } from '../common/EventEmitter.js';
 
 export interface CoreTextNodeProps extends CoreNodeProps, TrProps {
   /**
@@ -70,7 +71,7 @@ export interface CoreTextNodeProps extends CoreNodeProps, TrProps {
  * For non-text rendering, see {@link CoreNode}.
  */
 export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
-  textRenderer: TextRenderer;
+  textRenderer: TextRenderer | null = null;
   trState: TextRendererState;
   private _textRendererOverride: CoreTextNodeProps['textRendererOverride'] =
     null;
@@ -105,6 +106,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
         verticalAlign: props.verticalAlign,
         overflowSuffix: props.overflowSuffix,
       });
+
     this.textRenderer = resolvedTextRenderer;
     this.trState = textRendererState;
   }
@@ -153,7 +155,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
 
   override set width(value: number) {
     this.props.width = value;
-    this.textRenderer.set.width(this.trState, value);
+    this.textRenderer?.set.width(this.trState, value);
 
     // If not containing, we must update the local transform to account for the
     // new width
@@ -168,7 +170,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
 
   override set height(value: number) {
     this.props.height = value;
-    this.textRenderer.set.height(this.trState, value);
+    this.textRenderer?.set.height(this.trState, value);
 
     // If not containing in the horizontal direction, we must update the local
     // transform to account for the new height
@@ -182,7 +184,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   }
 
   override set color(value: number) {
-    this.textRenderer.set.color(this.trState, value);
+    this.textRenderer?.set.color(this.trState, value);
   }
 
   get text(): string {
@@ -190,7 +192,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   }
 
   set text(value: string) {
-    this.textRenderer.set.text(this.trState, value);
+    this.textRenderer?.set.text(this.trState, value);
   }
 
   get textRendererOverride(): CoreTextNodeProps['textRendererOverride'] {
@@ -200,7 +202,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   set textRendererOverride(value: CoreTextNodeProps['textRendererOverride']) {
     this._textRendererOverride = value;
 
-    this.textRenderer.destroyState(this.trState);
+    this.textRenderer?.destroyState(this.trState);
 
     const { resolvedTextRenderer, textRendererState } =
       this.resolveTextRendererAndState(this.trState.props);
@@ -213,7 +215,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   }
 
   set fontSize(value: CoreTextNodeProps['fontSize']) {
-    this.textRenderer.set.fontSize(this.trState, value);
+    this.textRenderer?.set.fontSize(this.trState, value);
   }
 
   get fontFamily(): CoreTextNodeProps['fontFamily'] {
@@ -221,7 +223,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   }
 
   set fontFamily(value: CoreTextNodeProps['fontFamily']) {
-    this.textRenderer.set.fontFamily(this.trState, value);
+    this.textRenderer?.set.fontFamily(this.trState, value);
   }
 
   get fontStretch(): CoreTextNodeProps['fontStretch'] {
@@ -229,7 +231,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   }
 
   set fontStretch(value: CoreTextNodeProps['fontStretch']) {
-    this.textRenderer.set.fontStretch(this.trState, value);
+    this.textRenderer?.set.fontStretch(this.trState, value);
   }
 
   get fontStyle(): CoreTextNodeProps['fontStyle'] {
@@ -237,7 +239,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   }
 
   set fontStyle(value: CoreTextNodeProps['fontStyle']) {
-    this.textRenderer.set.fontStyle(this.trState, value);
+    this.textRenderer?.set.fontStyle(this.trState, value);
   }
 
   get fontWeight(): CoreTextNodeProps['fontWeight'] {
@@ -245,7 +247,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   }
 
   set fontWeight(value: CoreTextNodeProps['fontWeight']) {
-    this.textRenderer.set.fontWeight(this.trState, value);
+    this.textRenderer?.set.fontWeight(this.trState, value);
   }
 
   get textAlign(): CoreTextNodeProps['textAlign'] {
@@ -253,7 +255,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   }
 
   set textAlign(value: CoreTextNodeProps['textAlign']) {
-    this.textRenderer.set.textAlign(this.trState, value);
+    this.textRenderer?.set.textAlign(this.trState, value);
   }
 
   get contain(): CoreTextNodeProps['contain'] {
@@ -261,7 +263,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   }
 
   set contain(value: CoreTextNodeProps['contain']) {
-    this.textRenderer.set.contain(this.trState, value);
+    this.textRenderer?.set.contain(this.trState, value);
   }
 
   get scrollable(): CoreTextNodeProps['scrollable'] {
@@ -269,7 +271,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   }
 
   set scrollable(value: CoreTextNodeProps['scrollable']) {
-    this.textRenderer.set.scrollable(this.trState, value);
+    this.textRenderer?.set.scrollable(this.trState, value);
   }
 
   get scrollY(): CoreTextNodeProps['scrollY'] {
@@ -277,7 +279,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   }
 
   set scrollY(value: CoreTextNodeProps['scrollY']) {
-    this.textRenderer.set.scrollY(this.trState, value);
+    this.textRenderer?.set.scrollY(this.trState, value);
   }
 
   get offsetY(): CoreTextNodeProps['offsetY'] {
@@ -285,7 +287,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   }
 
   set offsetY(value: CoreTextNodeProps['offsetY']) {
-    this.textRenderer.set.offsetY(this.trState, value);
+    this.textRenderer?.set.offsetY(this.trState, value);
   }
 
   get letterSpacing(): CoreTextNodeProps['letterSpacing'] {
@@ -293,7 +295,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   }
 
   set letterSpacing(value: CoreTextNodeProps['letterSpacing']) {
-    this.textRenderer.set.letterSpacing(this.trState, value);
+    this.textRenderer?.set.letterSpacing(this.trState, value);
   }
 
   get lineHeight(): CoreTextNodeProps['lineHeight'] {
@@ -301,7 +303,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   }
 
   set lineHeight(value: CoreTextNodeProps['lineHeight']) {
-    if (this.textRenderer.set.lineHeight) {
+    if (this.textRenderer?.set.lineHeight) {
       this.textRenderer.set.lineHeight(this.trState, value);
     }
   }
@@ -311,7 +313,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   }
 
   set maxLines(value: CoreTextNodeProps['maxLines']) {
-    if (this.textRenderer.set.maxLines) {
+    if (this.textRenderer?.set.maxLines) {
       this.textRenderer.set.maxLines(this.trState, value);
     }
   }
@@ -321,7 +323,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   }
 
   set textBaseline(value: CoreTextNodeProps['textBaseline']) {
-    if (this.textRenderer.set.textBaseline) {
+    if (this.textRenderer?.set.textBaseline) {
       this.textRenderer.set.textBaseline(this.trState, value);
     }
   }
@@ -331,7 +333,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   }
 
   set verticalAlign(value: CoreTextNodeProps['verticalAlign']) {
-    if (this.textRenderer.set.verticalAlign) {
+    if (this.textRenderer?.set.verticalAlign) {
       this.textRenderer.set.verticalAlign(this.trState, value);
     }
   }
@@ -341,7 +343,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   }
 
   set overflowSuffix(value: CoreTextNodeProps['overflowSuffix']) {
-    if (this.textRenderer.set.overflowSuffix) {
+    if (this.textRenderer?.set.overflowSuffix) {
       this.textRenderer.set.overflowSuffix(this.trState, value);
     }
   }
@@ -351,7 +353,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   }
 
   set debug(value: CoreTextNodeProps['debug']) {
-    this.textRenderer.set.debug(this.trState, value);
+    this.textRenderer?.set.debug(this.trState, value);
   }
 
   override update(delta: number, parentClippingRect: RectWithValid) {
@@ -360,8 +362,8 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
     assertTruthy(this.globalTransform);
 
     // globalTransform is updated in super.update(delta)
-    this.textRenderer.set.x(this.trState, this.globalTransform.tx);
-    this.textRenderer.set.y(this.trState, this.globalTransform.ty);
+    this.textRenderer?.set.x(this.trState, this.globalTransform.tx);
+    this.textRenderer?.set.y(this.trState, this.globalTransform.ty);
   }
 
   override checkRenderProps(): boolean {
@@ -373,7 +375,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
 
   override onChangeIsRenderable(isRenderable: boolean) {
     super.onChangeIsRenderable(isRenderable);
-    this.textRenderer.setIsRenderable(this.trState, isRenderable);
+    this.textRenderer?.setIsRenderable(this.trState, isRenderable);
   }
 
   override renderQuads(renderer: CoreRenderer) {
@@ -381,7 +383,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
 
     // If the text renderer does not support rendering quads, fallback to the
     // default renderQuads method
-    if (!this.textRenderer.renderQuads) {
+    if (!this.textRenderer?.renderQuads) {
       super.renderQuads(renderer);
       return;
     }
@@ -425,7 +427,29 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   override destroy(): void {
     super.destroy();
 
-    this.textRenderer.destroyState(this.trState);
+    this.textRenderer?.destroyState(this.trState);
+  }
+
+  private createDummystate(props: TrProps): TextRendererState {
+    return {
+      props,
+      updateScheduled: false,
+      status: 'initialState',
+      emitter: new EventEmitter(),
+      forceFullLayoutCalc: false,
+      textW: undefined, // Assuming textW can be undefined initially
+      textH: undefined, // Assuming textH can be undefined initially
+      isRenderable: false, // Assuming the text is not renderable initially
+      debugData: {
+        updateCount: 0, // Initial value for updateCount
+        layoutCount: 0, // Initial value for layoutCount
+        drawCount: 0, // Initial value for drawCount
+        lastLayoutNumCharacters: 0, // Initial value for lastLayoutNumCharacters
+        layoutSum: 0, // Initial value for layoutSum
+        drawSum: 0, // Initial value for drawSum
+        bufferSize: 0, // Initial value for bufferSize
+      },
+    };
   }
 
   /**
@@ -434,7 +458,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
    * @returns
    */
   private resolveTextRendererAndState(props: TrProps): {
-    resolvedTextRenderer: TextRenderer;
+    resolvedTextRenderer: TextRenderer | null;
     textRendererState: TextRendererState;
   } {
     const resolvedTextRenderer = this.stage.resolveTextRenderer(
@@ -442,6 +466,14 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
       this._textRendererOverride,
     );
 
+    if (!resolvedTextRenderer) {
+      // return early and dont set any listeners or state updates, as there is
+      // no text renderer to use.
+      return {
+        resolvedTextRenderer: null,
+        textRendererState: this.createDummystate(props),
+      };
+    }
     const textRendererState = resolvedTextRenderer.createState(props, this);
 
     textRendererState.emitter.on('loaded', this.onTextLoaded);

--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -174,20 +174,23 @@ export class Stage {
     // Create text renderers
     this.textRenderers = {};
     fontEngines.forEach((fontEngineConstructor) => {
-      const className = fontEngineConstructor.name;
-      if (className === 'SdfTextRenderer' && renderMode === 'canvas') {
+      // const className = fontEngineConstructor.name;
+      const fontEngineInstance = new fontEngineConstructor(this);
+      const className = fontEngineInstance.type;
+
+      if (className === 'sdf' && renderMode === 'canvas') {
         console.warn(
           'SdfTextRenderer is not compatible with Canvas renderer. Skipping...',
         );
         return;
       }
 
-      const fontEngineInstance = new fontEngineConstructor(this);
+      // const fontEngineInstance = new fontEngineConstructor(this);
       if (fontEngineInstance instanceof TextRenderer) {
-        if (className === 'CanvasTextRenderer') {
+        if (className === 'canvas') {
           this.textRenderers['canvas'] =
             fontEngineInstance as CanvasTextRenderer;
-        } else if (className === 'SdfTextRenderer') {
+        } else if (className === 'sdf') {
           this.textRenderers['sdf'] = fontEngineInstance as SdfTextRenderer;
         }
       }

--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -174,7 +174,6 @@ export class Stage {
     // Create text renderers
     this.textRenderers = {};
     fontEngines.forEach((fontEngineConstructor) => {
-      // const className = fontEngineConstructor.name;
       const fontEngineInstance = new fontEngineConstructor(this);
       const className = fontEngineInstance.type;
 
@@ -185,7 +184,6 @@ export class Stage {
         return;
       }
 
-      // const fontEngineInstance = new fontEngineConstructor(this);
       if (fontEngineInstance instanceof TextRenderer) {
         if (className === 'canvas') {
           this.textRenderers['canvas'] =
@@ -424,7 +422,9 @@ export class Stage {
     trProps: TrProps,
     textRendererOverride: keyof TextRendererMap | null = null,
   ): TextRenderer | null {
-    const fontCacheString = `${trProps.fontFamily}${trProps.fontStyle}${trProps.fontWeight}${trProps.fontStretch}`;
+    const fontCacheString = `${trProps.fontFamily}${trProps.fontStyle}${
+      trProps.fontWeight
+    }${trProps.fontStretch}${textRendererOverride ? textRendererOverride : ''}`;
 
     // check our resolve cache first
     if (this.fontResolveMap[fontCacheString] !== undefined) {

--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -533,7 +533,18 @@ export class Stage {
       shaderProps: null,
     };
 
-    return new CoreTextNode(this, resolvedProps);
+    const resolvedTextRenderer = this.resolveTextRenderer(
+      resolvedProps,
+      props.textRendererOverride,
+    );
+
+    if (!resolvedTextRenderer) {
+      throw new Error(
+        `No compatible text renderer found for ${resolvedProps.fontFamily}`,
+      );
+    }
+
+    return new CoreTextNode(this, resolvedProps, resolvedTextRenderer);
   }
 
   /**

--- a/src/core/text-rendering/renderers/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/renderers/CanvasTextRenderer.ts
@@ -90,6 +90,8 @@ export class CanvasTextRenderer extends TextRenderer<CanvasTextRendererState> {
   private fontFamilies: FontFamilyMap = {};
   private fontFamilyArray: FontFamilyMap[] = [this.fontFamilies];
 
+  public type: 'canvas' | 'sdf' = 'canvas';
+
   constructor(stage: Stage) {
     super(stage);
     if (typeof OffscreenCanvas !== 'undefined') {

--- a/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
+++ b/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
@@ -142,6 +142,8 @@ export class SdfTextRenderer extends TextRenderer<SdfTextRendererState> {
   private sdfShader: SdfShader;
   private rendererBounds: Bound;
 
+  public type: 'canvas' | 'sdf' = 'sdf';
+
   constructor(stage: Stage) {
     super(stage);
     this.sdfShader = this.stage.shManager.loadShader('SdfShader').shader;

--- a/src/core/text-rendering/renderers/TextRenderer.ts
+++ b/src/core/text-rendering/renderers/TextRenderer.ts
@@ -422,6 +422,7 @@ export abstract class TextRenderer<
   StateT extends TextRendererState = TextRendererState,
 > {
   readonly set: Readonly<TrPropSetters<StateT>>;
+  abstract type: 'canvas' | 'sdf';
 
   constructor(protected stage: Stage) {
     const propSetters = {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -225,19 +225,3 @@ export const getTimingFunction = (
 export function bytesToMb(bytes: number) {
   return (bytes / 1024 / 1024).toFixed(2);
 }
-
-/**
- * Serialize a property object to a string
- *
- * @param obj
- * @returns
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function serializeObjectValuesToString(obj: Record<string, any>) {
-  return (
-    Object.keys(obj)
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      .map((key) => `${obj[key]}`)
-      .join('')
-  );
-}

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -225,3 +225,19 @@ export const getTimingFunction = (
 export function bytesToMb(bytes: number) {
   return (bytes / 1024 / 1024).toFixed(2);
 }
+
+/**
+ * Serialize a property object to a string
+ *
+ * @param obj
+ * @returns
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function serializeObjectValuesToString(obj: Record<string, any>) {
+  return (
+    Object.keys(obj)
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      .map((key) => `${obj[key]}`)
+      .join('')
+  );
+}

--- a/src/main-api/Renderer.ts
+++ b/src/main-api/Renderer.ts
@@ -204,12 +204,12 @@ export interface RendererMainSettings {
    * WebGL is more performant and supports more features. Canvas is
    * supported on most platforms.
    *
-   * Note: When using `renderEngine=CanvasCoreRenderer` you can only use
-   * `CanvasTextRenderer`. The `renderEngine=WebGLCoreRenderer` supports
-   * both `CanvasTextRenderer` and `SdfTextRenderer` for TextRendering.
+   * Note: When using CanvasCoreRenderer you can only use
+   * CanvasTextRenderer. The WebGLCoreRenderer supports
+   * both CanvasTextRenderer and SdfTextRenderer for Text Rendering.
    *
    */
-  renderEngine: CanvasCoreRenderer | WebGlCoreRenderer;
+  renderEngine: typeof CanvasCoreRenderer | typeof WebGlCoreRenderer;
 
   /**
    * Quad buffer size in bytes
@@ -243,7 +243,7 @@ export interface RendererMainSettings {
    *
    *
    */
-  fontEngines: (CanvasTextRenderer | SdfTextRenderer)[];
+  fontEngines: (typeof CanvasTextRenderer | typeof SdfTextRenderer)[];
 }
 
 /**

--- a/src/main-api/Renderer.ts
+++ b/src/main-api/Renderer.ts
@@ -227,23 +227,26 @@ export interface RendererMainSettings {
    * When using `renderEngine=CanvasCoreRenderer` you can only use `CanvasTextRenderer`.
    * The `renderEngine=WebGLCoreRenderer` supports both `CanvasTextRenderer` and `SdfTextRenderer`.
    *
-   * This setting is used to enable tree shaking of non-used font engines. Please
-   * import your text font engine as follows:
+   * This setting is used to enable tree shaking of unused font engines. Please
+   * import your font engine(s) as follows:
    * ```
    * import { CanvasTextRenderer } from '@lightning/renderer/canvas';
    * import { SdfTextRenderer } from '@lightning/renderer/webgl';
    * ```
    *
-   * If both CanvasTextRenderer and SdfTextRenderer are provided, the CanvasTextRenderer
-   * will be used as fallback incase the SdfTextRenderer does not support the font.
+   * If both CanvasTextRenderer and SdfTextRenderer are provided, the first renderer
+   * provided will be asked first if it can render the font. If it cannot render the
+   * font, the next renderer will be asked. If no renderer can render the font, the
+   * text will not be rendered.
    *
-   * If no font engines are provided, CoreTextNodes will not be able to render text.
+   * **Note** that if you have fonts available in both engines the second font engine
+   * will not be used. This is because the first font engine will always be asked first.
    *
    * @defaultValue '[]'
    *
    *
    */
-  fontEngines: (typeof CanvasTextRenderer | typeof SdfTextRenderer)[];
+  fontEngines: (typeof SdfTextRenderer | typeof CanvasTextRenderer)[];
 }
 
 /**

--- a/src/main-api/Renderer.ts
+++ b/src/main-api/Renderer.ts
@@ -42,6 +42,8 @@ import type {
 import type { TextureMemoryManagerSettings } from '../core/TextureMemoryManager.js';
 import type { CanvasTextRenderer } from '../core/text-rendering/renderers/CanvasTextRenderer.js';
 import type { SdfTextRenderer } from '../core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.js';
+import type { WebGlCoreRenderer } from '../core/renderers/webgl/WebGlCoreRenderer.js';
+import type { CanvasCoreRenderer } from '../core/renderers/canvas/CanvasCoreRenderer.js';
 
 /**
  * An immutable reference to a specific Shader type
@@ -195,9 +197,19 @@ export interface RendererMainSettings {
   enableInspector?: boolean;
 
   /**
-   * Renderer mode
+   * Renderer Engine
+   *
+   * @remarks
+   * The renderer engine to use. Spawns a WebGL or Canvas renderer.
+   * WebGL is more performant and supports more features. Canvas is
+   * supported on most platforms.
+   *
+   * Note: When using `renderEngine=CanvasCoreRenderer` you can only use
+   * `CanvasTextRenderer`. The `renderEngine=WebGLCoreRenderer` supports
+   * both `CanvasTextRenderer` and `SdfTextRenderer` for TextRendering.
+   *
    */
-  renderMode?: 'webgl' | 'canvas';
+  renderEngine: CanvasCoreRenderer | WebGlCoreRenderer;
 
   /**
    * Quad buffer size in bytes
@@ -210,15 +222,16 @@ export interface RendererMainSettings {
    * Font Engines
    *
    * @remarks
-   * The font engines to use for text rendering. CanvasTextRenderer is the default
-   * and is supported on all platforms. SdfTextRenderer is a more performant renderer.
-   * When using `renderMode='canvas'` you can only use `CanvasTextRenderer`.
+   * The font engines to use for text rendering. CanvasTextRenderer is supported
+   * on all platforms. SdfTextRenderer is a more performant renderer.
+   * When using `renderEngine=CanvasCoreRenderer` you can only use `CanvasTextRenderer`.
+   * The `renderEngine=WebGLCoreRenderer` supports both `CanvasTextRenderer` and `SdfTextRenderer`.
    *
    * This setting is used to enable tree shaking of non-used font engines. Please
    * import your text font engine as follows:
    * ```
-   * import { CanvasTextRenderer } from '@lightning/renderer';
-   * import { SdfTextRenderer } from '@lightning/renderer';
+   * import { CanvasTextRenderer } from '@lightning/renderer/canvas';
+   * import { SdfTextRenderer } from '@lightning/renderer/webgl';
    * ```
    *
    * If both CanvasTextRenderer and SdfTextRenderer are provided, the CanvasTextRenderer
@@ -317,7 +330,7 @@ export class RendererMain extends EventEmitter {
         settings.numImageWorkers !== undefined ? settings.numImageWorkers : 2,
       enableContextSpy: settings.enableContextSpy ?? false,
       enableInspector: settings.enableInspector ?? false,
-      renderMode: settings.renderMode ?? 'webgl',
+      renderEngine: settings.renderEngine,
       quadBufferSize: settings.quadBufferSize ?? 4 * 1024 * 1024,
       fontEngines: settings.fontEngines,
     };
@@ -354,7 +367,7 @@ export class RendererMain extends EventEmitter {
       enableContextSpy: this.settings.enableContextSpy,
       fpsUpdateInterval: this.settings.fpsUpdateInterval,
       numImageWorkers: this.settings.numImageWorkers,
-      renderMode: this.settings.renderMode,
+      renderEngine: this.settings.renderEngine,
       textureMemory: resolvedTxSettings,
       eventBus: this,
       quadBufferSize: this.settings.quadBufferSize,

--- a/src/main-api/Renderer.ts
+++ b/src/main-api/Renderer.ts
@@ -40,6 +40,8 @@ import type {
   EffectDescUnion,
 } from '../core/renderers/webgl/shaders/effects/ShaderEffect.js';
 import type { TextureMemoryManagerSettings } from '../core/TextureMemoryManager.js';
+import type { CanvasTextRenderer } from '../core/text-rendering/renderers/CanvasTextRenderer.js';
+import type { SdfTextRenderer } from '../core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.js';
 
 /**
  * An immutable reference to a specific Shader type
@@ -203,6 +205,32 @@ export interface RendererMainSettings {
    * @defaultValue 4 * 1024 * 1024
    */
   quadBufferSize?: number;
+
+  /**
+   * Font Engines
+   *
+   * @remarks
+   * The font engines to use for text rendering. CanvasTextRenderer is the default
+   * and is supported on all platforms. SdfTextRenderer is a more performant renderer.
+   * When using `renderMode='canvas'` you can only use `CanvasTextRenderer`.
+   *
+   * This setting is used to enable tree shaking of non-used font engines. Please
+   * import your text font engine as follows:
+   * ```
+   * import { CanvasTextRenderer } from '@lightning/renderer';
+   * import { SdfTextRenderer } from '@lightning/renderer';
+   * ```
+   *
+   * If both CanvasTextRenderer and SdfTextRenderer are provided, the CanvasTextRenderer
+   * will be used as fallback incase the SdfTextRenderer does not support the font.
+   *
+   * If no font engines are provided, CoreTextNodes will not be able to render text.
+   *
+   * @defaultValue '[]'
+   *
+   *
+   */
+  fontEngines: (CanvasTextRenderer | SdfTextRenderer)[];
 }
 
 /**
@@ -291,6 +319,7 @@ export class RendererMain extends EventEmitter {
       enableInspector: settings.enableInspector ?? false,
       renderMode: settings.renderMode ?? 'webgl',
       quadBufferSize: settings.quadBufferSize ?? 4 * 1024 * 1024,
+      fontEngines: settings.fontEngines,
     };
     this.settings = resolvedSettings;
 
@@ -329,6 +358,7 @@ export class RendererMain extends EventEmitter {
       textureMemory: resolvedTxSettings,
       eventBus: this,
       quadBufferSize: this.settings.quadBufferSize,
+      fontEngines: this.settings.fontEngines,
     });
 
     // Extract the root node


### PR DESCRIPTION
* Expose Canvas and WebGL Core Renderers under `@lightningjs/renderer/webgl` and `@lightningjs/renderer/canvas` respectively
* Allow RendererMain config to accept a `renderEngine` parameter where the core renderers can be provided
* Expose SDF Text Renderer and CanvasTextRenderer under canvas/webgl exports.
* Allow RendererMain config to accept an array of `fontEngines` where you can provide 1 or 2 Font Engines.
* Fallback with Canvas still works IF Canvas Text Renderer is provided
* Drop memize dependency to reduce overall bundle size, apply simple caching instead

Todo:
- [x] Check tests, see if text renderer override still works
- [x] Run through some of the resolve code again to make sure we're not introducing new bottlenecks

In my tests the simple benchmark app went down by `20 kb` by just using 1 font engine to `40 kb` when only using canvas and canvas rendering.

Note: This is a breaking init change, handle with care.