### PR TITLE
fix: add get / set for data object

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -1387,6 +1387,14 @@ export class CoreNode extends EventEmitter {
     return this._id;
   }
 
+  get data(): CustomDataMap | undefined {
+    return this.props.data;
+  }
+
+  set data(d: CustomDataMap | undefined) {
+    this.props.data = d;
+  }
+
   get x(): number {
     return this.props.x;
   }


### PR DESCRIPTION
The inspector allows setting a custom data object. However some also use it for `data` from API. Adding the get / set to allow devs to access the data that they set.