### PR TITLE
updated typedoc config

### DIFF
--- a/exports/canvas.ts
+++ b/exports/canvas.ts
@@ -30,6 +30,8 @@
  * import { CanvasTextRenderer } from '@lightning/renderer';
  * ```
  *
+ * @module Canvas
+ *
  * @packageDocumentation
  */
 

--- a/exports/index.ts
+++ b/exports/index.ts
@@ -34,7 +34,7 @@
  * capabilities of the Renderer. The Main API code always runs from the main
  * thread.
  *
- * @module
+ * @module Renderer
  */
 
 export * from '../src/main-api/INode.js';

--- a/exports/inspector.ts
+++ b/exports/inspector.ts
@@ -17,4 +17,8 @@
  * limitations under the License.
  */
 
+/**
+ * @module Inspector
+ */
+
 export { Inspector } from '../src/main-api/Inspector.js';

--- a/exports/utils.ts
+++ b/exports/utils.ts
@@ -36,6 +36,8 @@
  * Lightning Renderer, and not specific to any particular platform.
  *
  * @packageDocumentation
+ *
+ * @module Utils
  */
 export { assertTruthy, mergeColorAlpha, deg2Rad } from '../src/utils.js';
 export { getNormalizedRgbaComponents } from '../src/core/lib/utils.js';

--- a/typedoc.config.cjs
+++ b/typedoc.config.cjs
@@ -2,8 +2,9 @@
 /** @type {import('typedoc').TypeDocOptions} */
 module.exports = {
   entryPoints: [
-    './exports/main-api.ts',
-    './exports/core-api.ts',
+    './exports/index.ts',
+    './exports/webgl.ts',
+    './exports/canvas.ts',
     './exports/utils.ts',
   ],
   out: 'typedocs',


### PR DESCRIPTION
I noticed the current typedoc config was not up to date since the split from threadx, and the canvas/webgl changes. This fix exposes all the good stuff again.