### PR TITLE
Boundary detection fixes

### DIFF
--- a/src/core/lib/utils.ts
+++ b/src/core/lib/utils.ts
@@ -237,10 +237,8 @@ export function compareRect(a: Rect | null, b: Rect | null): boolean {
 
 export function boundInsideBound(bound1: Bound, bound2: Bound) {
   return (
-    bound1.x1 <= bound2.x2 &&
-    bound1.y1 <= bound2.y2 &&
-    bound1.x2 >= bound2.x1 &&
-    bound1.y2 >= bound2.y1
+    (bound1.x1 > bound2.x1 && bound1.y1 > bound2.y1) ||
+    (bound1.x2 < bound2.x2 && bound1.y2 < bound2.y2)
   );
 }
 

--- a/src/core/lib/utils.ts
+++ b/src/core/lib/utils.ts
@@ -237,8 +237,19 @@ export function compareRect(a: Rect | null, b: Rect | null): boolean {
 
 export function boundInsideBound(bound1: Bound, bound2: Bound) {
   return (
-    (bound1.x1 > bound2.x1 && bound1.y1 > bound2.y1) ||
-    (bound1.x2 < bound2.x2 && bound1.y2 < bound2.y2)
+    bound1.x1 <= bound2.x2 &&
+    bound1.y1 <= bound2.y2 &&
+    bound1.x2 >= bound2.x1 &&
+    bound1.y2 >= bound2.y1
+  );
+}
+
+export function boundLargeThanBound(bound1: Bound, bound2: Bound) {
+  return (
+    bound1.x1 < bound2.x1 &&
+    bound1.x2 > bound2.x2 &&
+    bound1.y1 < bound2.y1 &&
+    bound1.y2 > bound2.y2
   );
 }
 


### PR DESCRIPTION
Fixes #371 and various other parent/child updates with Bounds detection.

Changes:
* children update state, whenever the branch becomes active again they will be propagated accordingly
* Alpha and clipping now properly trigger children updates when active again
* Larger then bound detection, for full width child nodes (one of the clipping VRT tests)
* Ability to handle dimension-less "holder" nodes with boundary checks
* Small child iteration loop optimizations

Small sacrifices on performance as more parts of the tree will remain active (though still 125 -> 650k ops/s) , the original 2.1.0 release was a bit too aggressive marking part of the render tree "dead" due to not being able to handle "holder" nodes who do not have dimensions and once marked inactive would discard children updates.