### PR TITLE
perf: Replace forEach with for loops

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -40,7 +40,7 @@ const config = {
     '@typescript-eslint/no-unsafe-assignment': 'warn',
     '@typescript-eslint/no-unsafe-return': 'warn',
     '@typescript-eslint/no-unsafe-call': 'warn',
-    '@typescript-eslint/no-non-null-assertion': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'warn',
     '@typescript-eslint/no-unsafe-member-access': 'warn',
     '@typescript-eslint/restrict-template-expressions': [
       'warn',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -40,6 +40,7 @@ const config = {
     '@typescript-eslint/no-unsafe-assignment': 'warn',
     '@typescript-eslint/no-unsafe-return': 'warn',
     '@typescript-eslint/no-unsafe-call': 'warn',
+    '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'warn',
     '@typescript-eslint/restrict-template-expressions': [
       'warn',

--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -976,9 +976,9 @@ export class CoreNode extends EventEmitter {
       this.updateType ^ UpdateType.All &&
       this.updateType & UpdateType.RenderTexture
     ) {
-      this.children.forEach((child) => {
-        child.setUpdateType(UpdateType.All);
-      });
+      for (let i = 0, length = this.children.length; i < length; i++) {
+        this.children[i]!.setUpdateType(UpdateType.All);
+      }
     }
 
     if (this.updateType & UpdateType.Global) {
@@ -1452,8 +1452,7 @@ export class CoreNode extends EventEmitter {
     this.props.shader = this.stage.defShaderCtr;
 
     const children = [...this.children];
-    for (let i = 0; i < children.length; i++) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    for (let i = 0, length = children.length; i < length; i++) {
       children[i]!.destroy();
     }
     // This very action will also remove the node from the parent's children array
@@ -1879,9 +1878,9 @@ export class CoreNode extends EventEmitter {
   set zIndexLocked(value: number) {
     this.props.zIndexLocked = value;
     this.setUpdateType(UpdateType.CalculatedZIndex | UpdateType.Children);
-    this.children.forEach((child) => {
-      child.setUpdateType(UpdateType.CalculatedZIndex);
-    });
+    for (let i = 0, length = this.children.length; i < length; i++) {
+      this.children[i]!.setUpdateType(UpdateType.CalculatedZIndex);
+    }
   }
 
   get zIndex(): number {
@@ -1891,9 +1890,9 @@ export class CoreNode extends EventEmitter {
   set zIndex(value: number) {
     this.props.zIndex = value;
     this.setUpdateType(UpdateType.CalculatedZIndex | UpdateType.Children);
-    this.children.forEach((child) => {
-      child.setUpdateType(UpdateType.CalculatedZIndex);
-    });
+    for (let i = 0, length = this.children.length; i < length; i++) {
+      this.children[i]!.setUpdateType(UpdateType.CalculatedZIndex);
+    }
   }
 
   get parent(): CoreNode | null {
@@ -1956,11 +1955,9 @@ export class CoreNode extends EventEmitter {
       if (value === false && this.texture !== null) {
         this.unloadTexture();
         this.setUpdateType(UpdateType.All);
-
-        this.children.forEach((child) => {
-          child.parentHasRenderTexture = false;
-        });
-
+        for (let i = 0, length = this.children.length; i < length; i++) {
+          this.children[i]!.parentHasRenderTexture = false;
+        }
         this.stage.renderer?.removeRTTNode(this);
         return;
       }
@@ -1982,9 +1979,9 @@ export class CoreNode extends EventEmitter {
     this.hasRTTupdates = true;
     this.setUpdateType(UpdateType.All);
 
-    this.children.forEach((child) => {
-      child.setUpdateType(UpdateType.All);
-    });
+    for (let i = 0, length = this.children.length; i < length; i++) {
+      this.children[i]!.setUpdateType(UpdateType.All);
+    }
 
     // Store RTT nodes in a separate list
     this.stage.renderer?.renderToTexture(this);

--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -1105,11 +1105,8 @@ export class CoreNode extends EventEmitter {
       this.children.length > 0 &&
       this.rtt === false
     ) {
-      for (let i = 0; i < this.children.length; i++) {
-        const child = this.children[i];
-        if (child === undefined) {
-          continue;
-        }
+      for (let i = 0, length = this.children.length; i < length; i++) {
+        const child = this.children[i] as CoreNode;
 
         child.setUpdateType(this.childUpdateType);
 

--- a/src/core/renderers/webgl/WebGlCoreRenderer.ts
+++ b/src/core/renderers/webgl/WebGlCoreRenderer.ts
@@ -619,12 +619,13 @@ export class WebGlCoreRenderer extends CoreRenderer {
       console.log('renderOps', this.renderOps.length);
     }
 
-    this.renderOps.forEach((renderOp, i) => {
+    for (let i = 0, length = this.renderOps.length; i < length; i++) {
+      const renderOp = this.renderOps[i] as WebGlCoreRenderOp;
       if (doLog) {
         console.log('Quads per operation', renderOp.numQuads);
       }
       renderOp.draw();
-    });
+    }
     this.quadBufferUsage = this.curBufferIdx * arr.BYTES_PER_ELEMENT;
   }
 


### PR DESCRIPTION
Hopefully reduces a bit of garbage collection. Only removing forEach on most used areas of the code. Also updated eslint to disable the no null assertion so typescript doesn't complain about undefined children.