### PR TITLE
compat: Remove fromEntries for older browser support

### DIFF
--- a/src/core/text-rendering/renderers/TextRenderer.ts
+++ b/src/core/text-rendering/renderers/TextRenderer.ts
@@ -431,23 +431,24 @@ export abstract class TextRenderer<
     };
     // For each prop setter add a wrapper method that checks if the prop is
     // different before calling the setter
-    this.set = Object.freeze(
-      Object.entries(propSetters).reduce((acc, [key, setter]) => {
-        acc[key as keyof TrProps] = (
-          state: StateT,
-          value: TrProps[keyof TrProps],
-        ) => {
+    const propSet = {};
+    Object.keys(propSetters).forEach((key) => {
+      Object.defineProperty(propSet, key, {
+        value: (state: StateT, value: TrProps[keyof TrProps]) => {
+          // Check if the current prop value is different before calling the setter
           if (state.props[key as keyof TrProps] !== value) {
-            setter(state, value as never);
+            propSetters[key as keyof TrPropSetters](state, value as never);
+
             // Assume any prop change will require a render
-            // This is required because otherwise a paused RAF will result
-            // in renders when text props are changed.
+            // This ensures that renders are triggered appropriately even with RAF paused
             this.stage.requestRender();
           }
-        };
-        return acc;
-      }, {} as TrPropSetters<StateT>),
-    );
+        },
+        writable: false, // Prevents property from being changed
+        configurable: false, // Prevents property from being deleted
+      });
+    });
+    this.set = propSet as Readonly<TrPropSetters<StateT>>;
   }
 
   setStatus(state: StateT, status: StateT['status'], error?: Error) {


### PR DESCRIPTION
Functionally the same thing - fromEntries requires Chrome 73. This will allow renderer to work on older devices a bit easier without vite needing to transpile it away.