### PR TITLE
fix: re-evaluate isRenderable on alpha change

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -1027,6 +1027,20 @@ export class CoreNode extends EventEmitter {
       }
     }
 
+    if (this.updateType & UpdateType.WorldAlpha) {
+      if (parent) {
+        this.worldAlpha = parent.worldAlpha * this.props.alpha;
+      } else {
+        this.worldAlpha = this.props.alpha;
+      }
+      this.setUpdateType(
+        UpdateType.Children |
+          UpdateType.PremultipliedColors |
+          UpdateType.IsRenderable,
+      );
+      this.childUpdateType |= UpdateType.WorldAlpha;
+    }
+
     if (this.updateType & UpdateType.IsRenderable) {
       this.updateIsRenderable();
     }
@@ -1041,20 +1055,6 @@ export class CoreNode extends EventEmitter {
 
       this.childUpdateType |= UpdateType.Clipping;
       this.childUpdateType |= UpdateType.RenderBounds;
-    }
-
-    if (this.updateType & UpdateType.WorldAlpha) {
-      if (parent) {
-        this.worldAlpha = parent.worldAlpha * this.props.alpha;
-      } else {
-        this.worldAlpha = this.props.alpha;
-      }
-      this.setUpdateType(
-        UpdateType.Children |
-          UpdateType.PremultipliedColors |
-          UpdateType.IsRenderable,
-      );
-      this.childUpdateType |= UpdateType.WorldAlpha;
     }
 
     if (this.updateType & UpdateType.PremultipliedColors) {
@@ -1739,9 +1739,10 @@ export class CoreNode extends EventEmitter {
     this.setUpdateType(
       UpdateType.PremultipliedColors |
         UpdateType.WorldAlpha |
-        UpdateType.Children,
+        UpdateType.Children |
+        UpdateType.IsRenderable,
     );
-    this.childUpdateType |= UpdateType.Global;
+    this.childUpdateType |= UpdateType.WorldAlpha;
   }
 
   get autosize(): boolean {


### PR DESCRIPTION
On low powered devices / heavy operation UI's there might be a race condition where the animation/transition is ends prior to the update loop finishing its first run. This causes the isRenderable to not be evaluated in time for the alpha changes to take affect.

This PR ensures isRenderable is always re-evaluated on an alpha change and moves the worldAlpha calculation slightly up to ensure it gets handled in the correct order if its a 1 shot update. 

Also save a little processing by ensuring on alpha change the children only re-evaluate the worldAlpha and not a global, reducing child update processing.

Fixes #388 
Might fix #372  - though cant reproduce to validate on my setup (even with 20x slowdown).