### PR TITLE
feat: Add bound status to a div state attribute in the Inspector

### DIFF
--- a/src/main-api/Inspector.ts
+++ b/src/main-api/Inspector.ts
@@ -246,6 +246,18 @@ export class Inspector {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
     (node as any).div = div;
 
+    node.on('inViewport', () => {
+      div.setAttribute('state', 'inViewport');
+    });
+
+    node.on('inBounds', () => {
+      div.setAttribute('state', 'inBounds');
+    });
+
+    node.on('outOfBounds', () => {
+      div.setAttribute('state', 'outOfBounds');
+    });
+
     return this.createProxy(node, div);
   }
 


### PR DESCRIPTION
Adds the bound state in an attribute:
<img width="392" alt="image" src="https://github.com/user-attachments/assets/df8ff2cf-54f3-4113-a812-3776bffa37f8">

This makes it easier to debug if nodes marked out of bounds when they're not suppose to due to positioning issues.