### PR TITLE
Scheduled state for animations with delay

### DIFF
--- a/src/common/IAnimationController.ts
+++ b/src/common/IAnimationController.ts
@@ -18,7 +18,11 @@
  */
 import type { IEventEmitter } from './IEventEmitter.js';
 
-export type AnimationControllerState = 'running' | 'paused' | 'stopped';
+export type AnimationControllerState =
+  | 'scheduled'
+  | 'running'
+  | 'paused'
+  | 'stopped';
 
 /**
  * Animation Controller interface

--- a/src/core/animations/CoreAnimationController.ts
+++ b/src/core/animations/CoreAnimationController.ts
@@ -53,10 +53,10 @@ export class CoreAnimationController
   }
 
   start(): IAnimationController {
-    if (this.state !== 'running') {
+    if (this.state !== 'running' && this.state !== 'scheduled') {
       this.makeStoppedPromise();
       this.registerAnimation();
-      this.state = 'running';
+      this.state = 'scheduled';
     }
     return this;
   }
@@ -139,6 +139,7 @@ export class CoreAnimationController
   }
 
   private onAnimating(this: CoreAnimationController): void {
+    this.state = 'running';
     this.emit('animating', this);
   }
 }


### PR DESCRIPTION
Added `scheduled` state for animations with delay. `scheduled` will change to `running` as soon as the  animation _really_ starts (triggered by the `onAnimating` hook).

This allows to make a distinction between an animation that is actually in the process of animating (i.e. `running`) and animations that are awaiting the delay to start animating (i.e. `scheduled`).