### PR TITLE
Fail gracefully createNativeCtxTexture in WebGlCoreCtxTexture load

### DIFF
--- a/src/core/renderers/webgl/WebGlCoreCtxTexture.ts
+++ b/src/core/renderers/webgl/WebGlCoreCtxTexture.ts
@@ -85,12 +85,12 @@ export class WebGlCoreCtxTexture extends CoreContextTexture {
     }
     this._state = 'loading';
     this.textureSource.setState('loading');
-    try {
-      this._nativeCtxTexture = this.createNativeCtxTexture();
-    } catch (err: any) {
+    this._nativeCtxTexture = this.createNativeCtxTexture();
+    if (this._nativeCtxTexture === null) {
       this._state = 'failed';
-      this.textureSource.setState('failed', err);
-      console.error(err);
+      this.textureSource.setState('failed', new Error('Could not create WebGL Texture'));
+      console.error('Could not create WebGL Texture');
+      return;
     }
     this.onLoadRequest()
       .then(({ width, height }) => {
@@ -251,7 +251,7 @@ export class WebGlCoreCtxTexture extends CoreContextTexture {
     const { glw } = this;
     const nativeTexture = glw.createTexture();
     if (!nativeTexture) {
-      throw new Error('Could not create WebGL Texture');
+      return null;
     }
 
     // On initial load request, create a 1x1 transparent texture to use until

--- a/src/core/renderers/webgl/WebGlCoreCtxTexture.ts
+++ b/src/core/renderers/webgl/WebGlCoreCtxTexture.ts
@@ -86,28 +86,34 @@ export class WebGlCoreCtxTexture extends CoreContextTexture {
     this._state = 'loading';
     this.textureSource.setState('loading');
     this._nativeCtxTexture = this.createNativeCtxTexture();
-    this.onLoadRequest()
-      .then(({ width, height }) => {
-        // If the texture has been freed while loading, return early.
-        if (this._state === 'freed') {
-          return;
-        }
-        this._state = 'loaded';
-        this._w = width;
-        this._h = height;
-        // Update the texture source's width and height so that it can be used
-        // for rendering.
-        this.textureSource.setState('loaded', { width, height });
-      })
-      .catch((err) => {
-        // If the texture has been freed while loading, return early.
-        if (this._state === 'freed') {
-          return;
-        }
-        this._state = 'failed';
+    try {
+      this.onLoadRequest()
+        .then(({ width, height }) => {
+          // If the texture has been freed while loading, return early.
+          if (this._state === 'freed') {
+            return;
+          }
+          this._state = 'loaded';
+          this._w = width;
+          this._h = height;
+          // Update the texture source's width and height so that it can be used
+          // for rendering.
+          this.textureSource.setState('loaded', { width, height });
+        })
+        .catch((err) => {
+          // If the texture has been freed while loading, return early.
+          if (this._state === 'freed') {
+            return;
+          }
+          this._state = 'failed';
+          this.textureSource.setState('failed', err);
+          console.error(err);
+        });
+    } catch(err: any) {
+      this._state = 'failed';
         this.textureSource.setState('failed', err);
         console.error(err);
-      });
+    }
   }
 
   /**

--- a/src/core/renderers/webgl/WebGlCoreCtxTexture.ts
+++ b/src/core/renderers/webgl/WebGlCoreCtxTexture.ts
@@ -109,10 +109,10 @@ export class WebGlCoreCtxTexture extends CoreContextTexture {
           this.textureSource.setState('failed', err);
           console.error(err);
         });
-    } catch(err: any) {
+    } catch (err: any) {
       this._state = 'failed';
-        this.textureSource.setState('failed', err);
-        console.error(err);
+      this.textureSource.setState('failed', err);
+      console.error(err);
     }
   }
 

--- a/src/core/renderers/webgl/WebGlCoreCtxTexture.ts
+++ b/src/core/renderers/webgl/WebGlCoreCtxTexture.ts
@@ -85,35 +85,35 @@ export class WebGlCoreCtxTexture extends CoreContextTexture {
     }
     this._state = 'loading';
     this.textureSource.setState('loading');
-    this._nativeCtxTexture = this.createNativeCtxTexture();
     try {
-      this.onLoadRequest()
-        .then(({ width, height }) => {
-          // If the texture has been freed while loading, return early.
-          if (this._state === 'freed') {
-            return;
-          }
-          this._state = 'loaded';
-          this._w = width;
-          this._h = height;
-          // Update the texture source's width and height so that it can be used
-          // for rendering.
-          this.textureSource.setState('loaded', { width, height });
-        })
-        .catch((err) => {
-          // If the texture has been freed while loading, return early.
-          if (this._state === 'freed') {
-            return;
-          }
-          this._state = 'failed';
-          this.textureSource.setState('failed', err);
-          console.error(err);
-        });
+      this._nativeCtxTexture = this.createNativeCtxTexture();
     } catch (err: any) {
       this._state = 'failed';
       this.textureSource.setState('failed', err);
       console.error(err);
     }
+    this.onLoadRequest()
+      .then(({ width, height }) => {
+        // If the texture has been freed while loading, return early.
+        if (this._state === 'freed') {
+          return;
+        }
+        this._state = 'loaded';
+        this._w = width;
+        this._h = height;
+        // Update the texture source's width and height so that it can be used
+        // for rendering.
+        this.textureSource.setState('loaded', { width, height });
+      })
+      .catch((err) => {
+        // If the texture has been freed while loading, return early.
+        if (this._state === 'freed') {
+          return;
+        }
+        this._state = 'failed';
+        this.textureSource.setState('failed', err);
+        console.error(err);
+      });
   }
 
   /**


### PR DESCRIPTION
- Add try/catch block in WebGlCoreCtxTexture `load` method to manage the error thrown by `createNativeCtxTexture`
- Set the texture state to failed on error thrown