### PR TITLE
fix: Ignore loading SDF fonts in Canvas mode rather than throwing

### DIFF
--- a/src/core/text-rendering/font-face-types/SdfTrFontFace/SdfTrFontFace.ts
+++ b/src/core/text-rendering/font-face-types/SdfTrFontFace/SdfTrFontFace.ts
@@ -71,10 +71,12 @@ export class SdfTrFontFace<
     const { atlasUrl, atlasDataUrl, stage } = options;
     this.type = type;
     const renderer = stage.renderer;
-    assertTruthy(
-      renderer instanceof WebGlCoreRenderer,
-      'SDF Font Faces can only be used with the WebGL Renderer',
-    );
+    if (!(renderer instanceof WebGlCoreRenderer)) {
+      console.warn(
+        'SDF Font Faces can only be used with the WebGL Renderer. Skipping.',
+      );
+      return;
+    }
 
     // Load image
     this.texture = stage.txManager.loadTexture('ImageTexture', {


### PR DESCRIPTION
If you're in canvas mode and try to load an SDF font, the renderer will throw an error and break. Rather it should just ignore loading those files with a log making it so users don't have to check which mode the renderer is in and offer different font files.