### PR TITLE
fix: fallback when fetch does not supports URL scheme "data"

### DIFF
--- a/src/core/lib/utils.ts
+++ b/src/core/lib/utils.ts
@@ -285,3 +285,42 @@ export function convertUrlToAbsolute(url: string): string {
   const absoluteUrl = new URL(url, self.location.href);
   return absoluteUrl.href;
 }
+
+export function base64DataFromSrc(src: string): [string, string] {
+  const matches = src.match(/^data:(.*?);base64,(.*)$/);
+
+  let mimeType;
+  let base64Content;
+
+  if (matches) {
+    mimeType = matches[1];
+    base64Content = matches[2];
+  }
+
+  mimeType = mimeType ?? 'image/png';
+  base64Content = base64Content ?? src;
+  base64Content = base64Content.replace(/-/g, '+').replace(/_/g, '/');
+
+  return [base64Content, mimeType];
+}
+
+export function base64toBlob(base64Data: string, contentType: string) {
+  contentType = contentType || '';
+  const sliceSize = 1024;
+  const byteCharacters = atob(base64Data);
+  const bytesLength = byteCharacters.length;
+  const slicesCount = Math.ceil(bytesLength / sliceSize);
+  const byteArrays = new Array(slicesCount);
+
+  for (let sliceIndex = 0; sliceIndex < slicesCount; ++sliceIndex) {
+    const begin = sliceIndex * sliceSize;
+    const end = Math.min(begin + sliceSize, bytesLength);
+
+    const bytes = new Array(end - begin);
+    for (let offset = begin, i = 0; offset < end; ++i, ++offset) {
+      bytes[i] = byteCharacters[offset]?.charCodeAt(0);
+    }
+    byteArrays[sliceIndex] = new Uint8Array(bytes);
+  }
+  return new Blob(byteArrays, { type: contentType });
+}

--- a/src/core/lib/utils.ts
+++ b/src/core/lib/utils.ts
@@ -286,7 +286,7 @@ export function convertUrlToAbsolute(url: string): string {
   return absoluteUrl.href;
 }
 
-export function base64DataFromSrc(src: string): [string, string] {
+export function base64DataFromSrc(src: string): [string, string] | undefined {
   const matches = src.match(/^data:(.*?);base64,(.*)$/);
 
   let mimeType;
@@ -297,8 +297,10 @@ export function base64DataFromSrc(src: string): [string, string] {
     base64Content = matches[2];
   }
 
-  mimeType = mimeType ?? 'image/png';
-  base64Content = base64Content ?? src;
+  if (!mimeType || !base64Content) {
+    return undefined;
+  }
+
   base64Content = base64Content.replace(/-/g, '+').replace(/_/g, '/');
 
   return [base64Content, mimeType];

--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -152,8 +152,12 @@ export class ImageTexture extends Texture {
         const response = await fetch(src);
         blob = await response.blob();
       } catch (error) {
-        const base64data = base64DataFromSrc(src);
-        blob = base64toBlob(base64data[0], base64data[1]);
+        if (src.startsWith('data:')) {
+          const base64data = base64DataFromSrc(src);
+          blob = base64toBlob(base64data[0], base64data[1]);
+        } else {
+          throw error;
+        }
       }
 
       const hasAlphaChannel =

--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -154,7 +154,11 @@ export class ImageTexture extends Texture {
       } catch (error) {
         if (src.startsWith('data:')) {
           const base64data = base64DataFromSrc(src);
-          blob = base64toBlob(base64data[0], base64data[1]);
+          if (base64data) {
+            blob = base64toBlob(base64data[0], base64data[1]);
+          } else {
+            throw error;
+          }
         } else {
           throw error;
         }


### PR DESCRIPTION
This PR implements a fallback for cases where createImageBitmap is supported but the fetch fails because does not supports URL scheme "data" (for example when using a polyfill).