### PR TITLE
fix: image size on browsers without createImageBitmap

### DIFF
--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -168,8 +168,8 @@ export class ImageTexture extends Texture {
         premultiplyAlpha: hasAlphaChannel,
       };
     } else {
-      const img = new Image(width || undefined, height || undefined);
-      if (!(src.substr(0, 5) === 'data:')) {
+      const img = new Image();
+      if (!src.startsWith('data:')) {
         img.crossOrigin = 'Anonymous';
       }
       img.src = src;


### PR DESCRIPTION
This PR addresses an issue specific to 2017 Samsung TVs, which do not support the createImageBitmap method.

**Testing**

Tested on 2017 Samsung TVs with renderer+solid.