### PR TITLE
Resolved sans-serif font issue for firefox browser

### DIFF
--- a/src/core/text-rendering/TrFontManager.ts
+++ b/src/core/text-rendering/TrFontManager.ts
@@ -46,6 +46,7 @@ function resolveFontToUse(
 
   for (const fontFamiles of familyMapsByPriority) {
     const fontFaces = fontFamiles[family];
+
     if (!fontFaces) {
       continue;
     }

--- a/src/core/text-rendering/font-face-types/TrFontFace.ts
+++ b/src/core/text-rendering/font-face-types/TrFontFace.ts
@@ -154,7 +154,6 @@ export class TrFontFace extends EventEmitter {
         lineGap: metrics.lineGap / metrics.unitsPerEm,
       };
     }
-
     this.fontFamily = fontFamily;
     this.descriptors = {
       style: 'normal',

--- a/src/core/text-rendering/renderers/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/renderers/CanvasTextRenderer.ts
@@ -242,28 +242,22 @@ export class CanvasTextRenderer extends TextRenderer<CanvasTextRendererState> {
     // the `isFontFaceSupported` check)
     assertTruthy(fontFace instanceof WebTrFontFace);
 
+    const fontFamily = fontFace.fontFamily;
+
     // Add the font face to the document
     // Except for the 'sans-serif' font family, which the Renderer provides
     // as a special default fallback.
-    if (fontFace.fontFamily !== 'sans-serif') {
+    if (fontFamily !== 'sans-serif') {
       // @ts-expect-error `add()` method should be available from a FontFaceSet
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       globalFontSet.add(fontFace.fontFace);
     }
 
-    const { fontFamilies } = this;
-
-    let familyName = fontFace.fontFace.family;
-    if (familyName === '') {
-      familyName = fontFace.fontFamily;
-    }
-
-    let faceSet = fontFamilies[familyName];
+    let faceSet = this.fontFamilies[fontFamily];
     if (!faceSet) {
       faceSet = new Set();
-      fontFamilies[familyName] = faceSet;
+      this.fontFamilies[fontFamily] = faceSet;
     }
-
     faceSet.add(fontFace);
   }
 

--- a/src/core/text-rendering/renderers/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/renderers/CanvasTextRenderer.ts
@@ -252,7 +252,11 @@ export class CanvasTextRenderer extends TextRenderer<CanvasTextRendererState> {
     }
 
     const { fontFamilies } = this;
-    const familyName = fontFace.fontFace.family;
+
+    let familyName = fontFace.fontFace.family;
+    if (familyName === '') {
+      familyName = fontFace.fontFamily;
+    }
 
     let faceSet = fontFamilies[familyName];
     if (!faceSet) {
@@ -384,6 +388,7 @@ export class CanvasTextRenderer extends TextRenderer<CanvasTextRendererState> {
 
   loadFont = (state: CanvasTextRendererState): void => {
     const cssString = getFontCssString(state.props);
+
     const trFontFace = this.stage.fontManager.resolveFontFace(
       this.fontFamilyArray,
       state.props,


### PR DESCRIPTION
The FireFox browser was throwing an error when using the default font for canvas. 

When the canvas text renderer tries to add the default font (fallback font).  However during the creation of the WebFont (line: 120 CanvasTextRenderer) it creates a FontFace which creates a family property which is an empty string in FireFox. This is where we run into problems because that empty string is used as a key later on. 

I have resolved the issue by building in a fallback that in case the family returns an empty string it falls back to the fontFamily property of its super class.