### PR TITLE
Fixed LinearGradient/RadialGradient effect for DynamicShader 

### DIFF
--- a/src/core/renderers/webgl/shaders/effects/LinearGradientEffect.ts
+++ b/src/core/renderers/webgl/shaders/effects/LinearGradientEffect.ts
@@ -22,6 +22,7 @@ import {
   type DefaultEffectProps,
   ShaderEffect,
   type ShaderEffectUniforms,
+  type ShaderEffectValueMap,
 } from './ShaderEffect.js';
 
 /**
@@ -54,6 +55,12 @@ export class LinearGradientEffect extends ShaderEffect {
   override readonly name = 'linearGradient';
 
   static override getEffectKey(props: LinearGradientEffectProps): string {
+    if ((props.colors as unknown as ShaderEffectValueMap).value as number[]) {
+      return `linearGradient${
+        ((props.colors as unknown as ShaderEffectValueMap).value as number[])
+          .length
+      }`;
+    }
     return `linearGradient${props.colors!.length}`;
   }
 

--- a/src/core/renderers/webgl/shaders/effects/RadialGradientEffect.ts
+++ b/src/core/renderers/webgl/shaders/effects/RadialGradientEffect.ts
@@ -25,6 +25,7 @@ import {
   type DefaultEffectProps,
   ShaderEffect,
   type ShaderEffectUniforms,
+  type ShaderEffectValueMap,
 } from './ShaderEffect.js';
 
 /**
@@ -62,7 +63,13 @@ export class RadialGradientEffect extends ShaderEffect {
   override readonly name = 'radialGradient';
 
   static override getEffectKey(props: RadialGradientEffectProps): string {
-    return `radialGradient${props.colors!.length}`;
+    if ((props.colors as unknown as ShaderEffectValueMap).value as number[]) {
+      return `linearGradient${
+        ((props.colors as unknown as ShaderEffectValueMap).value as number[])
+          .length
+      }`;
+    }
+    return `linearGradient${props.colors!.length}`;
   }
 
   static override resolveDefaults(


### PR DESCRIPTION
Resolved an issue where the linearGradient didn't return the proper effect key that it need to differentiate between two different linearGradient effects. Since the radialGradient had the same issue I fixed it for that effect too.

Resolves issue #411 