### PR TITLE
Set gl.clearColor to transparent for render-to-texture nodes

### DIFF
--- a/src/core/renderers/webgl/WebGlCoreRenderer.ts
+++ b/src/core/renderers/webgl/WebGlCoreRenderer.ts
@@ -655,6 +655,8 @@ export class WebGlCoreRenderer extends CoreRenderer {
       glw.bindFramebuffer(ctxTexture.framebuffer);
 
       glw.viewport(0, 0, ctxTexture.w, ctxTexture.h);
+      // Set the clear color to transparent
+      glw.clearColor(0, 0, 0, 0);
       glw.clear();
 
       // Render all associated quads to the texture
@@ -682,6 +684,10 @@ export class WebGlCoreRenderer extends CoreRenderer {
       this.renderOps.length = 0;
       node.hasRTTupdates = false;
     }
+
+    const color = getNormalizedRgbaComponents(this.stage.options.clearColor);
+    // Restore the default clear color
+    glw.clearColor(color[0]!, color[1]!, color[2]!, color[3]!);
 
     // Bind the default framebuffer
     glw.bindFramebuffer(null);


### PR DESCRIPTION
**Issue**: When rendering parts on the render tree to a texture ( RTT ) and the `clearColor` is set to a solid color rather than being transparent, this color is used to clear the colorbuffer of the texture's framebuffer. This results in render textures displaying a solid background color instead of being transparent.

This PR addresses this issues by setting the `gl.clearColor` to transparent before the render to texture pass begins and restoring it when the pass is complete.

Before: 

![before](https://github.com/user-attachments/assets/868a7665-cd46-4712-97f6-76f0d428b2b6)

After:

![after](https://github.com/user-attachments/assets/ae554fe7-cc18-40d5-a17c-c7784e00d0db)

