### PR TITLE
fix: [Inspector] drop Proxies, set selective Object.defineProperties traps

### DIFF
--- a/src/main-api/Inspector.ts
+++ b/src/main-api/Inspector.ts
@@ -270,13 +270,6 @@ export class Inspector {
     node: CoreNode | CoreTextNode,
     div: HTMLElement,
   ): CoreNode | CoreTextNode {
-    const updateNodePropertyWrapper = (
-      property: keyof CoreNodeProps,
-      value: any,
-    ) => {
-      queueMicrotask(() => this.updateNodeProperty(div, property, value));
-    };
-
     // Define traps for each property in knownProperties
     knownProperties.forEach((property) => {
       const originalProp = Object.getOwnPropertyDescriptor(node, property);
@@ -292,7 +285,8 @@ export class Inspector {
           },
           set(value) {
             originalProp.set?.call(node, value);
-            updateNodePropertyWrapper(property as keyof CoreNodeProps, value);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+            this.updateNodeProperty(div, property, value);
           },
           configurable: true,
           enumerable: true,


### PR DESCRIPTION
Proxies introduce a delay and differences in update graph behaviour which break the RTT parent/child updates on nodes itself, to avoid the issue only enable traps for inspector elements that we're actually interested in.

Fixes #429 