### PR TITLE
Fix first frame with RTT

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -2159,10 +2159,6 @@ export class CoreNode extends EventEmitter {
   }
 
   setRTTUpdates(type: number) {
-    if (this.hasRTTupdates === true) {
-      return;
-    }
-
     this.hasRTTupdates = true;
     this.parent?.setRTTUpdates(type);
   }


### PR DESCRIPTION
Removing a redundant check that was introduced with the recursive update loop fix. This prevented the first frame of an RTT scene to render all RTT textures correctly.