### PR TITLE
fix issue when running canvas renderMode

### DIFF
--- a/src/core/CoreShaderManager.ts
+++ b/src/core/CoreShaderManager.ts
@@ -198,7 +198,7 @@ export class CoreShaderManager {
 
     if (shType === 'DynamicShader') {
       return this.loadDynamicShader(
-        props!,
+        props as DynamicShaderProps,
       ) as unknown as ShaderController<Type>;
     }
 

--- a/src/core/renderers/webgl/shaders/SdfShader.ts
+++ b/src/core/renderers/webgl/shaders/SdfShader.ts
@@ -79,6 +79,8 @@ export class SdfShader extends WebGlCoreShader {
     });
   }
 
+  static z$__type__Props: SdfShaderProps;
+
   override bindTextures(textures: WebGlCoreCtxTexture[]) {
     const { glw } = this;
     glw.activeTexture(0);

--- a/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
+++ b/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
@@ -146,7 +146,14 @@ export class SdfTextRenderer extends TextRenderer<SdfTextRendererState> {
 
   constructor(stage: Stage) {
     super(stage);
-    this.sdfShader = this.stage.shManager.loadShader('SdfShader').shader;
+    this.sdfShader = this.stage.shManager.loadShader('SdfShader', {
+      transform: new Float32Array(),
+      color: 0,
+      size: 0,
+      scrollY: 0,
+      distanceRange: 0,
+      debug: false,
+    }).shader;
     this.rendererBounds = {
       x1: 0,
       y1: 0,

--- a/src/main-api/ShaderController.ts
+++ b/src/main-api/ShaderController.ts
@@ -55,7 +55,6 @@ export class ShaderController<S extends keyof ShaderMap>
     stage: Stage,
   ) {
     this.resolvedProps = props;
-
     const keys = Object.keys(props);
     const l = keys.length;
 


### PR DESCRIPTION
Fixed an issue where running the examples test with renderMode as canvas. Upon loading the SdfShader no properties are passed as parameter causing issues with when creating the UnsupportedShader for canvas.

This is mostly a temporary solution as the shaders are resolved differently in the shader rework i'm working on.