### PR TITLE
Correct clipping of children in render-to-texture nodes

### DIFF
--- a/examples/tests/rtt-nested-clipping.ts
+++ b/examples/tests/rtt-nested-clipping.ts
@@ -1,0 +1,86 @@
+import type { ExampleSettings } from '../common/ExampleSettings.js';
+import rocko from '../assets/rocko.png';
+
+export async function automation(settings: ExampleSettings) {
+  const page = await test(settings);
+
+  const maxPages = 6;
+  for (let i = 0; i < maxPages; i++) {
+    page(i);
+    await settings.snapshot();
+  }
+}
+
+export default async function test({ renderer, testRoot }: ExampleSettings) {
+  const node = renderer.createNode({
+    x: 0,
+    y: 0,
+    width: 1920,
+    height: 1080,
+    color: 0x000000ff,
+    parent: testRoot,
+  });
+
+  // RTT Node 1
+  const rttNode = renderer.createNode({
+    x: 100,
+    y: 200,
+    width: 400,
+    height: 400,
+    parent: node,
+    rtt: true,
+    zIndex: 5,
+    colorTop: 0xfff00fff,
+    colorBottom: 0x00ffffff,
+  });
+
+  const rect = renderer.createNode({
+    x: 0,
+    y: 0,
+    width: 300,
+    height: 300,
+    parent: rttNode,
+    clipping: true,
+    color: 0xff0000ff,
+  });
+
+  renderer.createTextNode({
+    x: 0,
+    y: 0,
+    text: 'Render to texture',
+    parent: rttNode,
+    fontSize: 48,
+    color: 0xffffffff,
+    fontFamily: 'Ubuntu',
+  });
+
+  renderer.createNode({
+    x: 50,
+    y: 100,
+    width: 600,
+    height: 600,
+    parent: rttNode,
+    src: rocko,
+  });
+
+  window.addEventListener('keydown', (e) => {
+    if (e.key === 's') {
+      // rect.clipping = !rect.clipping;
+      rect
+        .animate(
+          {
+            x: 100, //going to render out of bounds as well
+          },
+          {
+            duration: 3000,
+            easing: 'ease-out',
+            loop: true,
+            stopMethod: 'reverse',
+          },
+        )
+        .start();
+    }
+  });
+
+  // Define the page function to configure different test scenarios
+}

--- a/examples/tests/rtt-nested-clipping.ts
+++ b/examples/tests/rtt-nested-clipping.ts
@@ -1,16 +1,6 @@
 import type { ExampleSettings } from '../common/ExampleSettings.js';
 import rocko from '../assets/rocko.png';
 
-export async function automation(settings: ExampleSettings) {
-  const page = await test(settings);
-
-  const maxPages = 6;
-  for (let i = 0; i < maxPages; i++) {
-    page(i);
-    await settings.snapshot();
-  }
-}
-
 export default async function test({ renderer, testRoot }: ExampleSettings) {
   const node = renderer.createNode({
     x: 0,

--- a/src/core/renderers/webgl/WebGlCoreRenderOp.ts
+++ b/src/core/renderers/webgl/WebGlCoreRenderOp.ts
@@ -93,7 +93,7 @@ export class WebGlCoreRenderOp extends CoreRenderOp {
     // Clipping
     if (this.clippingRect.valid) {
       const { x, y, width, height } = this.clippingRect;
-      const pixelRatio = this.parentHasRenderTexture ? 1 : options.pixelRatio;
+      const pixelRatio = options.pixelRatio;
       const canvasHeight = options.canvas.height;
 
       const clipX = Math.round(x * pixelRatio);

--- a/src/core/renderers/webgl/WebGlCoreRenderOp.ts
+++ b/src/core/renderers/webgl/WebGlCoreRenderOp.ts
@@ -93,7 +93,7 @@ export class WebGlCoreRenderOp extends CoreRenderOp {
     // Clipping
     if (this.clippingRect.valid) {
       const { x, y, width, height } = this.clippingRect;
-      const pixelRatio = options.pixelRatio;
+      const pixelRatio = this.parentHasRenderTexture ? 1 : options.pixelRatio;
       const canvasHeight = options.canvas.height;
 
       const clipX = Math.round(x * pixelRatio);
@@ -109,8 +109,8 @@ export class WebGlCoreRenderOp extends CoreRenderOp {
           : 0;
       }
 
-      glw.viewport(clipX, clipY, clipWidth, clipHeight);
       glw.setScissorTest(true);
+      glw.scissor(clipX, clipY, clipWidth, clipHeight);
     } else {
       glw.setScissorTest(false);
     }


### PR DESCRIPTION
This PR resolves an issue where children nodes rendered as part of a render-to-texture were not properly clipped according to the parent node's bounds. The fix ensures that clipping is correctly applied within the render-to-texture pipeline, maintaining visual consistency and expected behavior for nested scenes