### PR TITLE
Simplify ImageWorkerManager initialization

### DIFF
--- a/src/core/CoreTextureManager.ts
+++ b/src/core/CoreTextureManager.ts
@@ -209,21 +209,16 @@ export class CoreTextureManager extends EventEmitter {
           this.hasWorker &&
           numImageWorkers > 0
         ) {
-          const imageWorkers = new ImageWorkerManager(numImageWorkers, result);
-
-          // wait for the image worker manager to be initialized
-          imageWorkers.once('initialized', () => {
-            // enable image worker manager
-            this.imageWorkerManager = imageWorkers;
-          });
+          this.imageWorkerManager = new ImageWorkerManager(
+            numImageWorkers,
+            result,
+          );
         } else {
           console.warn(
             '[Lightning] Imageworker is 0 or not supported on this browser. Image loading will be slower.',
           );
         }
 
-        // Do an early init event, we don't need to wait for the image worker manager to be initialized.
-        // Loading textures will be done on the main thread from this point on until the image worker manager is ready.
         this.emit('initialized');
       })
       .catch((e) => {


### PR DESCRIPTION
Instead of using an additional postMessage init flow, directly set the variables in the JS Blob before instantiating the worker.

Note:
CI will fail because of a race condition with 2 tests where the createImageBitmap detection is still happening and an image request is already being made, this will need to be addressed with texture throttling instead of trying to jump through hoops with the current texture source download + ctxCoreContext construction.