### PR TITLE
fix: Origin error when using Image() constructor

### DIFF
--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -134,6 +134,7 @@ export class ImageTexture extends Texture {
 
   async loadImageFallback(src: string, hasAlpha: boolean) {
     const img = new Image();
+    img.crossOrigin = 'anonymous';
 
     return new Promise<{ data: HTMLImageElement; premultiplyAlpha: boolean }>(
       (resolve) => {


### PR DESCRIPTION
This fixes the error:
net::ERR_BLOCKED_BY_RESPONSE.NotSameOriginAfterDefaultedToSameOriginByCoep 302 (Found)