### PR TITLE
fix: prevent cleanup of SDF Font Face textures for now

### DIFF
--- a/src/core/text-rendering/font-face-types/SdfTrFontFace/SdfTrFontFace.ts
+++ b/src/core/text-rendering/font-face-types/SdfTrFontFace/SdfTrFontFace.ts
@@ -89,7 +89,14 @@ export class SdfTrFontFace<
     // Load the texture
     stage.txManager.loadTexture(this.texture, true);
 
-    this.texture.once('loaded', () => {
+    // FIXME This is a stop-gap solution to avoid Font Face textures to be cleaned up
+    // Ideally we do want to clean up the textures if they're not being used to save as much memory as possible
+    // However, we need to make sure that the font face is reloaded if the texture is cleaned up and needed again
+    // and make sure the SdfFontRenderer is properly guarded against textures being reloaded
+    // for now this will do the trick and the increase on memory is not that big
+    this.texture.preventCleanup = true;
+
+    this.texture.on('loaded', () => {
       this.checkLoaded();
       // Make sure we mark the stage for a re-render (in case the font's texture was freed and reloaded)
       stage.requestRender();


### PR DESCRIPTION
Stop gap solution, ideally we do want SDF Font Face textures cleaned up if we can detect they have no renderable owners anymore to save as much memory as we can in case we hit critical levels.

However for now prevent Font Face textures from being cleaned up until we have proper guards/reloads in the SDF Font Renderer at the expense of keeping the Font atlas always in memory regardless if its being used.