### PR TITLE
fix: deprecate CoreNode.preventCleanup and re-introduce preload option

### DIFF
--- a/src/core/CoreTextureManager.ts
+++ b/src/core/CoreTextureManager.ts
@@ -108,6 +108,32 @@ export type ResizeModeOptions =
  */
 export interface TextureOptions {
   /**
+   * Preload the texture immediately even if it's not being rendered to the
+   * screen.
+   *
+   * @remarks
+   * This allows the texture to be used immediately without any delay when it
+   * is first needed for rendering. Otherwise the loading process will start
+   * when the texture is first rendered, which may cause a delay in that texture
+   * being shown properly.
+   *
+   * @defaultValue `false`
+   */
+  preload?: boolean;
+
+  /**
+   * Prevent clean up of the texture when it is no longer being used.
+   *
+   * @remarks
+   * This is useful when you want to keep the texture in memory for later use.
+   * Regardless of whether the texture is being used or not, it will not be
+   * cleaned up.
+   *
+   * @defaultValue `false`
+   */
+  preventCleanup?: boolean;
+
+  /**
    * Flip the texture horizontally when rendering
    *
    * @defaultValue `false`


### PR DESCRIPTION
The `textureOptions.preload` was removed during the Texture Throttling refactor, reintroduced it even though its loading will be throttled.

While looking at the properties, decided to move `preventCleanup` to `textureOptions` instead of as a property on the `CoreNode`. Technically this controls the behaviour of the texture, not the core node. Hence it better belongs on `textureOptions`.

Will throw a deprecation warning in dev mode for a couple of releases and then we'll drop it.