### PR TITLE
fix: update upload-artifact action to version 4 in Github Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload failed-results as artifact
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: failed-results
           path: visual-regression/failed-results/


### PR DESCRIPTION
Its not quite Jan 30th yet but seems GHA is a bit early with disabling v3