### PR TITLE
fix: Exclude Base64 images from image worker handling

### DIFF
--- a/src/core/lib/ImageWorker.ts
+++ b/src/core/lib/ImageWorker.ts
@@ -68,64 +68,71 @@ function createImageWorker() {
       var supportsOptionsCreateImageBitmap =
         options.supportsOptionsCreateImageBitmap;
       var supportsFullCreateImageBitmap = options.supportsFullCreateImageBitmap;
+      var xhr = new XMLHttpRequest();
+      xhr.open('GET', src, true);
+      xhr.responseType = 'blob';
 
-      fetch(src)
-        .then((response) => response.blob())
-        .then((blob) => {
-          var withAlphaChannel =
-            premultiplyAlpha !== undefined
-              ? premultiplyAlpha
-              : hasAlphaChannel(blob.type);
+      xhr.onload = function () {
+        if (xhr.status !== 200) {
+          return reject(new Error('Failed to load image: ' + xhr.statusText));
+        }
 
-          // createImageBitmap with crop and options
-          if (
-            supportsFullCreateImageBitmap === true &&
-            width !== null &&
-            height !== null
-          ) {
-            createImageBitmap(blob, x || 0, y || 0, width, height, {
-              premultiplyAlpha: withAlphaChannel ? 'premultiply' : 'none',
-              colorSpaceConversion: 'none',
-              imageOrientation: 'none',
+        var blob = xhr.response;
+        var withAlphaChannel =
+          premultiplyAlpha !== undefined
+            ? premultiplyAlpha
+            : hasAlphaChannel(blob.type);
+
+        // createImageBitmap with crop and options
+        if (
+          supportsFullCreateImageBitmap === true &&
+          width !== null &&
+          height !== null
+        ) {
+          createImageBitmap(blob, x || 0, y || 0, width, height, {
+            premultiplyAlpha: withAlphaChannel ? 'premultiply' : 'none',
+            colorSpaceConversion: 'none',
+            imageOrientation: 'none',
+          })
+            .then(function (data) {
+              resolve({ data, premultiplyAlpha: premultiplyAlpha });
             })
-              .then(function (data) {
-                resolve({ data, premultiplyAlpha: premultiplyAlpha });
-              })
-              .catch(function (error) {
-                reject(error);
-              });
-            return;
-          } else if (supportsOptionsCreateImageBitmap === true) {
-            createImageBitmap(blob, {
-              premultiplyAlpha: withAlphaChannel ? 'premultiply' : 'none',
-              colorSpaceConversion: 'none',
-              imageOrientation: 'none',
+            .catch(function (error) {
+              reject(error);
+            });
+          return;
+        } else if (supportsOptionsCreateImageBitmap === true) {
+          createImageBitmap(blob, {
+            premultiplyAlpha: withAlphaChannel ? 'premultiply' : 'none',
+            colorSpaceConversion: 'none',
+            imageOrientation: 'none',
+          })
+            .then(function (data) {
+              resolve({ data, premultiplyAlpha: premultiplyAlpha });
             })
-              .then(function (data) {
-                resolve({ data, premultiplyAlpha: premultiplyAlpha });
-              })
-              .catch(function (error) {
-                reject(error);
-              });
-          } else {
-            // Fallback for browsers that do not support createImageBitmap with options
-            // this is supported for Chrome v50 to v52/54 that doesn't support options
-            createImageBitmap(blob)
-              .then(function (data) {
-                resolve({ data, premultiplyAlpha: premultiplyAlpha });
-              })
-              .catch(function (error) {
-                reject(error);
-              });
-          }
-        })
-        .catch((error) => {
-          reject(
-            new Error(
-              'Network error occurred while trying to fetch the image.',
-            ),
-          );
-        });
+            .catch(function (error) {
+              reject(error);
+            });
+        } else {
+          // Fallback for browsers that do not support createImageBitmap with options
+          // this is supported for Chrome v50 to v52/54 that doesn't support options
+          createImageBitmap(blob)
+            .then(function (data) {
+              resolve({ data, premultiplyAlpha: premultiplyAlpha });
+            })
+            .catch(function (error) {
+              reject(error);
+            });
+        }
+      };
+
+      xhr.onerror = function () {
+        reject(
+          new Error('Network error occurred while trying to fetch the image.'),
+        );
+      };
+
+      xhr.send();
     });
   }
 

--- a/src/core/lib/utils.ts
+++ b/src/core/lib/utils.ts
@@ -304,3 +304,7 @@ export function convertUrlToAbsolute(url: string): string {
   const absoluteUrl = new URL(url, self.location.href);
   return absoluteUrl.href;
 }
+
+export function isBase64Image(src: string) {
+  return src.startsWith('data:') === true;
+}

--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -135,7 +135,7 @@ export class ImageTexture extends Texture {
   async loadImageFallback(src: string, hasAlpha: boolean) {
     const img = new Image();
 
-    if (!isBase64Image(src)) {
+    if (isBase64Image(src) === false) {
       img.crossOrigin = 'anonymous';
     }
 
@@ -206,7 +206,7 @@ export class ImageTexture extends Texture {
 
     if (this.txManager.hasCreateImageBitmap === true) {
       if (
-        !isBase64Image(src) &&
+        isBase64Image(src) === false &&
         this.txManager.hasWorker === true &&
         this.txManager.imageWorkerManager !== null
       ) {

--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -23,7 +23,7 @@ import {
   isCompressedTextureContainer,
   loadCompressedTexture,
 } from '../lib/textureCompression.js';
-import { convertUrlToAbsolute } from '../lib/utils.js';
+import { convertUrlToAbsolute, isBase64Image } from '../lib/utils.js';
 import { isSvgImage, loadSvg } from '../lib/textureSvg.js';
 
 /**
@@ -135,7 +135,7 @@ export class ImageTexture extends Texture {
   async loadImageFallback(src: string, hasAlpha: boolean) {
     const img = new Image();
 
-    if (!src.startsWith('data:')) {
+    if (!isBase64Image(src)) {
       img.crossOrigin = 'anonymous';
     }
 
@@ -206,6 +206,7 @@ export class ImageTexture extends Texture {
 
     if (this.txManager.hasCreateImageBitmap === true) {
       if (
+        !isBase64Image(src) &&
         this.txManager.hasWorker === true &&
         this.txManager.imageWorkerManager !== null
       ) {


### PR DESCRIPTION
In Chrome versions before 67, data: URLs were treated as uncertain-origin resources for security reasons. In this context:

XMLHttpRequest did not allow access to base64 (data:) URLs because it violated CORS (Cross-Origin Resource Sharing) policies. Even though a data: URL is "local," it was still considered a different origin from the domain where the request was made.