### PR TITLE
Fix memory allocations

### DIFF
--- a/examples/common/MemMonitor.ts
+++ b/examples/common/MemMonitor.ts
@@ -155,7 +155,7 @@ export class MemMonitor extends Component {
       mount: 0.5,
     });
 
-    const numLines = 9;
+    const numLines = 11;
     const infoTextY =
       this.node.height - MARGIN - INFO_TEXT_LINEHEIGHT * numLines;
 
@@ -194,7 +194,7 @@ export class MemMonitor extends Component {
 
     this.renderableMemUsedText = renderer.createTextNode({
       x: MARGIN,
-      y: infoTextY + INFO_TEXT_LINEHEIGHT * 5,
+      y: infoTextY + INFO_TEXT_LINEHEIGHT * 6,
       text: '',
       fontFamily: 'Ubuntu',
       parent: this.node,
@@ -205,7 +205,7 @@ export class MemMonitor extends Component {
 
     this.cacheInfoText = renderer.createTextNode({
       x: MARGIN,
-      y: infoTextY + INFO_TEXT_LINEHEIGHT * 8,
+      y: infoTextY + INFO_TEXT_LINEHEIGHT * 9,
       text: '',
       fontFamily: 'Ubuntu',
       parent: this.node,
@@ -229,7 +229,12 @@ export class MemMonitor extends Component {
 
   update() {
     const payload = this.renderer.stage.txMemManager.getMemoryInfo();
-    const { criticalThreshold, memUsed, renderableMemUsed } = payload;
+    const {
+      criticalThreshold,
+      memUsed,
+      renderableMemUsed,
+      baselineMemoryAllocation,
+    } = payload;
     const renderableMemoryFraction = renderableMemUsed / criticalThreshold;
     const memUsedFraction = memUsed / criticalThreshold;
     this.memUsedBar.height = BAR_HEIGHT * memUsedFraction;
@@ -237,7 +242,8 @@ export class MemMonitor extends Component {
     this.renderableMemBar.y = BAR_HEIGHT - this.renderableMemBar.height;
     this.memUsedBar.y = BAR_HEIGHT - this.memUsedBar.height;
     this.memUsedText.text = `
-Textures Loaded
+Memory Used
+- Base: ${bytesToMb(baselineMemoryAllocation)} mb
 - Size: ${bytesToMb(memUsed)} mb (${(memUsedFraction * 100).toFixed(1)}%)
 - Count: ${payload.loadedTextures}
 `.trim();

--- a/src/core/lib/textureSvg.ts
+++ b/src/core/lib/textureSvg.ts
@@ -29,7 +29,7 @@ import { type TextureData } from '../textures/Texture.js';
  * @returns
  */
 export function isSvgImage(url: string): boolean {
-  return /\.(svg)$/.test(url);
+  return /\.(svg)(\?.*)?$/.test(url);
 }
 
 /**

--- a/src/core/renderers/canvas/CanvasCoreRenderer.ts
+++ b/src/core/renderers/canvas/CanvasCoreRenderer.ts
@@ -126,7 +126,8 @@ export class CanvasCoreRenderer extends CoreRenderer {
     if (
       textureType !== TextureType.image &&
       textureType !== TextureType.color &&
-      textureType !== TextureType.subTexture
+      textureType !== TextureType.subTexture &&
+      textureType !== TextureType.noise
     ) {
       return;
     }
@@ -188,7 +189,8 @@ export class CanvasCoreRenderer extends CoreRenderer {
 
     if (
       (textureType === TextureType.image ||
-        textureType === TextureType.subTexture) &&
+        textureType === TextureType.subTexture ||
+        textureType === TextureType.noise) &&
       ctxTexture
     ) {
       const image = ctxTexture.getImage(color);

--- a/src/core/renderers/webgl/WebGlCoreCtxTexture.ts
+++ b/src/core/renderers/webgl/WebGlCoreCtxTexture.ts
@@ -146,8 +146,9 @@ export class WebGlCoreCtxTexture extends CoreContextTexture {
     glw.activeTexture(0);
 
     const tdata = textureData.data;
-    const format = textureData.premultiplyAlpha ? glw.RGBA : glw.RGB;
-    const formatBytes = format === glw.RGBA ? 4 : 3;
+    const format = glw.RGBA;
+    const formatBytes = 4;
+    const memoryPadding = 1.1; // Add padding to account for GPU Padding
 
     // If textureData is null, the texture is empty (0, 0) and we don't need to
     // upload any data to the GPU.
@@ -166,12 +167,8 @@ export class WebGlCoreCtxTexture extends CoreContextTexture {
       );
 
       glw.texImage2D(0, format, format, glw.UNSIGNED_BYTE, tdata);
-      this.setTextureMemUse(width * height * formatBytes);
 
-      // generate mipmaps for power-of-2 textures or in WebGL2RenderingContext
-      if (glw.isWebGl2() || (isPowerOfTwo(width) && isPowerOfTwo(height))) {
-        glw.generateMipmap();
-      }
+      this.setTextureMemUse(height * width * formatBytes * memoryPadding);
     } else if (tdata === null) {
       width = 0;
       height = 0;

--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -264,7 +264,7 @@ export class ImageTexture extends Texture {
 
     return {
       data: resp.data,
-      premultiplyAlpha: resp.premultiplyAlpha ?? true,
+      premultiplyAlpha: this.props.premultiplyAlpha ?? true,
     };
   }
 

--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -264,7 +264,7 @@ export class ImageTexture extends Texture {
 
     return {
       data: resp.data,
-      premultiplyAlpha: this.props.premultiplyAlpha ?? true,
+      premultiplyAlpha: resp.premultiplyAlpha ?? true,
     };
   }
 

--- a/src/main-api/Renderer.ts
+++ b/src/main-api/Renderer.ts
@@ -354,12 +354,16 @@ export class RendererMain extends EventEmitter {
    */
   constructor(settings: RendererMainSettings, target: string | HTMLElement) {
     super();
+
     const resolvedTxSettings: TextureMemoryManagerSettings = {
       criticalThreshold: settings.textureMemory?.criticalThreshold || 124e6,
       targetThresholdLevel: settings.textureMemory?.targetThresholdLevel || 0.5,
       cleanupInterval: settings.textureMemory?.cleanupInterval || 30000,
       debugLogging: settings.textureMemory?.debugLogging || false,
+      baselineMemoryAllocation:
+        settings.textureMemory?.baselineMemoryAllocation || 26e6,
     };
+
     const resolvedSettings: Required<RendererMainSettings> = {
       appWidth: settings.appWidth || 1920,
       appHeight: settings.appHeight || 1080,


### PR DESCRIPTION
# Why?

The Renderer was _off_ in its GFX Memory allocation, most cases it would report 50 Mb GFX usage while the real usage was >150 Mb.

This was due to:
- mipmaps being incorrectly enabled
- no baseline, calculations started at 0
- no texture padding

## What changed?

Introduced `baselineMemoryAllocation` memory setting to set a baseline usage of your device. For example on my test device (RPI3b+ with WPEWebKit 2.46) an empty Canvas with a WebGL1 context uses 25 Mb. Every device you have will have a base allocation for just the WebGL context alone, adjust this setting to set that immutable baseline.

All textures subsequently loaded will go on top of that baseline.

Removed mipmap's on Textures - we're using fixed scale textures and are not making use of Level-Of-Detail. Enabling mipmap's on textures generates a 33% extra memory allocation while we're never going to use that functionality. This PR thus _reduces_ memory usage of textures allocated on the GPU that had a power of two for height & width.

Locked textures to 4 bytes, regardless of alpha channel. This was introduced in the assumption it would save memory, in tests on my device it didn't matter and all textures where aligned on a 4 byte anyway. So might as well use it, this allows the Renderer to more accurately estimate the memory usage. With 3 bytes in the non-alpha channel the calculation was always way off.

Added a default 10% texture padding, now this is a guesstimate sometimes its 5%, sometimes its more and very much depends on the texture that you're loading. With WebGL 1 there is no way to read the actual texture width/height or do any metrics on the allocation of the texture on the GPU. So this is an unfortunate side effect that we have to "guess" our allocations at all times and never 100% accurately know what the gfx memory usage is. If I missed something or you have a way, please let me know.

plus some random bits:
* Noise texture support in Canvas2D (useful for testing)
* .svg detection will now also work with `bla.svg?query=string` which I used for loading up unique SVGs and test

Tested on an RPI3b + with WPEWebKit and Thunder:

prior to these changes:
![image](https://github.com/user-attachments/assets/68dc0dcf-b6b6-42db-bf03-9775d7553118)

Renderer assumed we where using 76 Mb of GFX memory while in reality this was 109 Mb.

![image](https://github.com/user-attachments/assets/a65dad0c-7a7b-45b1-bc16-f788902c5d34)

calculated memory by the renderer on the left and actual device GPU usage on the right with 500 textures.

Now it gets worse if we use textures with a power of two with mipmap's, prior to these changes:
![image](https://github.com/user-attachments/assets/17cf83ff-04a4-49fb-af7b-67f43aee2481)

with these changes:
![image](https://github.com/user-attachments/assets/2360476e-ba5a-48af-b46b-c0cc7ab4fb04)

