### PR TITLE
Improve memory cleanup performance

### DIFF
--- a/examples/tests/texture-cleanup-critical.ts
+++ b/examples/tests/texture-cleanup-critical.ts
@@ -78,5 +78,5 @@ See docs/ManualRegressionTests.md for more information.
       cacheId: Math.floor(Math.random() * 100000),
     });
     screen.textureOptions.preload = true;
-  }, 10);
+  }, 100);
 }

--- a/src/core/CoreTextureManager.ts
+++ b/src/core/CoreTextureManager.ts
@@ -27,6 +27,7 @@ import { RenderTexture } from './textures/RenderTexture.js';
 import type { Texture } from './textures/Texture.js';
 import { EventEmitter } from '../common/EventEmitter.js';
 import { getTimeStamp } from './platform.js';
+import type { Stage } from './Stage.js';
 
 /**
  * Augmentable map of texture class types
@@ -178,6 +179,7 @@ export class CoreTextureManager extends EventEmitter {
   private priorityQueue: Array<Texture> = [];
   private uploadTextureQueue: Array<Texture> = [];
   private initialized = false;
+  private stage: Stage;
 
   imageWorkerManager: ImageWorkerManager | null = null;
   hasCreateImageBitmap = !!self.createImageBitmap;
@@ -208,8 +210,9 @@ export class CoreTextureManager extends EventEmitter {
    */
   frameTime = 0;
 
-  constructor(numImageWorkers: number) {
+  constructor(stage: Stage, numImageWorkers: number) {
     super();
+    this.stage = stage;
     this.validateCreateImageBitmap()
       .then((result) => {
         this.hasCreateImageBitmap =
@@ -387,6 +390,10 @@ export class CoreTextureManager extends EventEmitter {
     return texture as InstanceType<TextureMap[Type]>;
   }
 
+  orphanTexture(texture: Texture): void {
+    this.stage.txMemManager.addToOrphanedTextures(texture);
+  }
+
   /**
    * Override loadTexture to use the batched approach.
    *
@@ -394,6 +401,8 @@ export class CoreTextureManager extends EventEmitter {
    * @param immediate - Whether to prioritize the texture for immediate loading
    */
   loadTexture(texture: Texture, priority?: boolean): void {
+    this.stage.txMemManager.removeFromOrphanedTextures(texture);
+
     if (texture.state === 'loaded' || texture.state === 'loading') {
       return;
     }

--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -151,7 +151,7 @@ export class Stage {
     } = options;
 
     this.eventBus = options.eventBus;
-    this.txManager = new CoreTextureManager(numImageWorkers);
+    this.txManager = new CoreTextureManager(this, numImageWorkers);
 
     // Wait for the Texture Manager to initialize
     // once it does, request a render

--- a/src/core/textures/Texture.ts
+++ b/src/core/textures/Texture.ts
@@ -170,8 +170,6 @@ export abstract class Texture extends EventEmitter {
 
   readonly renderable: boolean = false;
 
-  readonly lastRenderableChangeTime = 0;
-
   public type: TextureType = TextureType.generic;
 
   public preventCleanup = false;
@@ -210,7 +208,6 @@ export abstract class Texture extends EventEmitter {
       const newSize = this.renderableOwners.size;
       if (newSize > oldSize && newSize === 1) {
         (this.renderable as boolean) = true;
-        (this.lastRenderableChangeTime as number) = this.txManager.frameTime;
         this.onChangeIsRenderable?.(true);
         this.load();
       }
@@ -219,7 +216,6 @@ export abstract class Texture extends EventEmitter {
       const newSize = this.renderableOwners.size;
       if (newSize < oldSize && newSize === 0) {
         (this.renderable as boolean) = false;
-        (this.lastRenderableChangeTime as number) = this.txManager.frameTime;
         this.onChangeIsRenderable?.(false);
         this.txManager.orphanTexture(this);
       }

--- a/src/core/textures/Texture.ts
+++ b/src/core/textures/Texture.ts
@@ -221,6 +221,7 @@ export abstract class Texture extends EventEmitter {
         (this.renderable as boolean) = false;
         (this.lastRenderableChangeTime as number) = this.txManager.frameTime;
         this.onChangeIsRenderable?.(false);
+        this.txManager.orphanTexture(this);
       }
     }
   }


### PR DESCRIPTION
# Why?

The memory cleanup routine would resort on every run, this is quite expensive to do during frame generation time. Instead keep a list of orphaned textures, once we need to clean up pick the first one added to that list until we reach our threshold using a simple while loop.



