### PR TITLE
feat: updated the way the compressed textures are detected

### DIFF
--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -265,7 +265,7 @@ export class ImageTexture extends Texture {
     };
   }
 
-  determineImageTypeAndLoadImage() {
+  async determineImageTypeAndLoadImage() {
     const { src, premultiplyAlpha, type } = this.props;
     if (src === null) {
       return {
@@ -315,12 +315,9 @@ export class ImageTexture extends Texture {
       );
     }
 
-    if (type === 'compressed') {
-      return loadCompressedTexture(absoluteSrc);
-    }
-
-    if (isCompressedTextureContainer(src) === true) {
-      return loadCompressedTexture(absoluteSrc);
+    const containerBuffer = await isCompressedTextureContainer(absoluteSrc);
+    if (containerBuffer !== null) {
+      return loadCompressedTexture(containerBuffer);
     }
 
     // default


### PR DESCRIPTION
Instead of checking file extension for ktx and pvr image formats.
Load the file and check the file header to detect the format.
This makes it less brittle and allows urls without a file extension to work