### PR TITLE
Feat/refactor texture coords

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -897,10 +897,6 @@ export class CoreNode extends EventEmitter {
         type: 'texture',
         dimensions,
       } satisfies NodeTextureLoadedPayload);
-
-      if (this.stage.renderer.getTextureCoords !== undefined) {
-        this.textureCoords = this.stage.renderer.getTextureCoords(this);
-      }
     }
 
     // Trigger a local update if the texture is loaded and the resizeMode is 'contain'
@@ -1261,6 +1257,14 @@ export class CoreNode extends EventEmitter {
       this.sortChildren();
     }
 
+    if (
+      this.stage.renderer.getTextureCoords !== undefined &&
+      this.textureCoords === undefined &&
+      this.isRenderable === true
+    ) {
+      this.textureCoords = this.stage.renderer.getTextureCoords(this);
+    }
+
     // If we're out of bounds, apply the render state now
     // this is done so nodes can finish their entire update loop before
     // being marked as out of bounds
@@ -1290,15 +1294,6 @@ export class CoreNode extends EventEmitter {
       rttNode = rttNode.parent;
     }
     return rttNode;
-  }
-
-  private getRTTParentRenderState(): CoreNodeRenderState | null {
-    const rttNode = this.rttParent || this.findParentRTTNode();
-    if (!rttNode) {
-      return null;
-    }
-
-    return rttNode.renderState;
   }
 
   private notifyChildrenRTTOfUpdate(renderState: CoreNodeRenderState) {
@@ -2440,6 +2435,7 @@ export class CoreNode extends EventEmitter {
       this.unloadTexture();
     }
 
+    this.textureCoords = undefined;
     this.props.texture = value;
     if (value !== null) {
       value.setRenderableOwner(this, this.isRenderable);

--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -28,6 +28,7 @@ import type { CoreRenderer } from './renderers/CoreRenderer.js';
 import type { Stage } from './Stage.js';
 import {
   type Texture,
+  type TextureCoords,
   type TextureFailedEventHandler,
   type TextureFreedEventHandler,
   type TextureLoadedEventHandler,
@@ -750,6 +751,7 @@ export class CoreNode extends EventEmitter {
     height: 0,
     valid: false,
   };
+  public textureCoords?: TextureCoords;
   public isRenderable = false;
   public renderState: CoreNodeRenderState = CoreNodeRenderState.Init;
 
@@ -895,6 +897,10 @@ export class CoreNode extends EventEmitter {
         type: 'texture',
         dimensions,
       } satisfies NodeTextureLoadedPayload);
+
+      if (this.stage.renderer.getTextureCoords !== undefined) {
+        this.textureCoords = this.stage.renderer.getTextureCoords(this);
+      }
     }
 
     // Trigger a local update if the texture is loaded and the resizeMode is 'contain'
@@ -1752,6 +1758,7 @@ export class CoreNode extends EventEmitter {
       // this assumes any renderable node is either a distinct texture or a ColorTexture
       texture: this.texture || this.stage.defaultTexture,
       textureOptions: this.textureOptions,
+      textureCoords: this.textureCoords,
       zIndex: this.zIndex,
       shader: this.props.shader as CoreShaderNode<any>,
       alpha: this.worldAlpha,

--- a/src/core/renderers/CoreRenderer.ts
+++ b/src/core/renderers/CoreRenderer.ts
@@ -25,7 +25,7 @@ import type { ContextSpy } from '../lib/ContextSpy.js';
 import type { RenderCoords } from '../lib/RenderCoords.js';
 import type { RectWithValid } from '../lib/utils.js';
 import type { CoreShaderProgram } from './CoreShaderProgram.js';
-import type { Texture } from '../textures/Texture.js';
+import type { Texture, TextureCoords } from '../textures/Texture.js';
 import { CoreContextTexture } from './CoreContextTexture.js';
 import type { CoreShaderType, CoreShaderNode } from './CoreShaderNode.js';
 
@@ -38,6 +38,7 @@ export interface QuadOptions {
   colorBr: number;
   texture: Texture | null;
   textureOptions: TextureOptions | null;
+  textureCoords: TextureCoords | undefined;
   zIndex: number;
   shader: CoreShaderNode | null;
   alpha: number;
@@ -104,4 +105,5 @@ export abstract class CoreRenderer {
   abstract getBufferInfo(): BufferInfo | null;
   abstract getQuadCount(): number | null;
   abstract updateClearColor(color: number): void;
+  abstract getTextureCoords?(node: CoreNode): TextureCoords | undefined;
 }

--- a/src/core/renderers/CoreRenderer.ts
+++ b/src/core/renderers/CoreRenderer.ts
@@ -105,5 +105,5 @@ export abstract class CoreRenderer {
   abstract getBufferInfo(): BufferInfo | null;
   abstract getQuadCount(): number | null;
   abstract updateClearColor(color: number): void;
-  abstract getTextureCoords?(node: CoreNode): TextureCoords | undefined;
+  getTextureCoords?(node: CoreNode): TextureCoords;
 }

--- a/src/core/renderers/canvas/CanvasRenderer.ts
+++ b/src/core/renderers/canvas/CanvasRenderer.ts
@@ -292,7 +292,7 @@ export class CanvasRenderer extends CoreRenderer {
     this.clearColor = this.getParsedColor(color);
   }
 
-  override getDefaultShaderNode() {
+  getDefaultShaderNode() {
     return null;
   }
 }

--- a/src/core/textures/Texture.ts
+++ b/src/core/textures/Texture.ts
@@ -100,6 +100,11 @@ export interface TextureData {
    */
   premultiplyAlpha?: boolean | null;
 }
+/**
+ * TextureCoords generally numbers between 0 - 1
+ * [x1, y1, x2, y2]
+ */
+export type TextureCoords = [number, number, number, number];
 
 export type TextureState =
   | 'initial' // Before anything is loaded

--- a/src/core/textures/Texture.ts
+++ b/src/core/textures/Texture.ts
@@ -22,6 +22,7 @@ import type { SubTextureProps } from './SubTexture.js';
 import type { Dimensions } from '../../common/CommonTypes.js';
 import { EventEmitter } from '../../common/EventEmitter.js';
 import type { CoreContextTexture } from '../renderers/CoreContextTexture.js';
+import type { Bound } from '../lib/utils.js';
 
 /**
  * Event handler for when a Texture is freed
@@ -102,9 +103,8 @@ export interface TextureData {
 }
 /**
  * TextureCoords generally numbers between 0 - 1
- * [x1, y1, x2, y2]
  */
-export type TextureCoords = [number, number, number, number];
+export type TextureCoords = Bound;
 
 export type TextureState =
   | 'initial' // Before anything is loaded


### PR DESCRIPTION
Refactored the way textureCoords are calculated for the WebGlRenderer.

Before these were calculated every time a node was passed to the addQuad function of the renderer.

Now it's processed every time a texture is changed or when a node is created and is renderable.