### PR TITLE
Remove deprecated preventCleanup flag

### DIFF
--- a/src/core/CoreNode.test.ts
+++ b/src/core/CoreNode.test.ts
@@ -62,7 +62,6 @@ describe('set color()', () => {
     y: 0,
     zIndex: 0,
     zIndexLocked: 0,
-    preventCleanup: false,
     strictBounds: false,
   };
 

--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -426,15 +426,6 @@ export interface CoreNodeProps {
   texture: Texture | null;
 
   /**
-   * [Deprecated]: Prevents the texture from being cleaned up when the Node is removed
-   *
-   * @remarks
-   * Please use the `preventCleanup` property on {@link TextureOptions} instead.
-   *
-   * @default false
-   */
-  preventCleanup: boolean;
-  /**
    * Options to associate with the Node's Texture
    */
   textureOptions: TextureOptions;
@@ -802,12 +793,6 @@ export class CoreNode extends EventEmitter {
         UpdateType.RenderBounds |
         UpdateType.RenderState,
     );
-
-    if (isProductionEnvironment() === false && props.preventCleanup === true) {
-      console.warn(
-        'CoreNode.preventCleanup: Is deprecated and will be removed in upcoming release, please use textureOptions.preventCleanup instead',
-      );
-    }
 
     // if the default texture isn't loaded yet, wait for it to load
     // this only happens when the node is created before the stage is ready
@@ -2210,20 +2195,6 @@ export class CoreNode extends EventEmitter {
 
     // fetch render bounds from parent
     this.setUpdateType(UpdateType.RenderBounds | UpdateType.Children);
-  }
-
-  get preventCleanup(): boolean {
-    return this.props.textureOptions.preventCleanup || false;
-  }
-
-  set preventCleanup(value: boolean) {
-    if (isProductionEnvironment() === false) {
-      console.warn(
-        'CoreNode.preventCleanup: Is deprecated and will be removed in upcoming release, please use textureOptions.preventCleanup instead',
-      );
-    }
-
-    this.props.textureOptions.preventCleanup = value;
   }
 
   get rtt(): boolean {

--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -290,7 +290,6 @@ export class Stage {
       rtt: false,
       src: null,
       scale: 1,
-      preventCleanup: false,
       strictBounds: this.strictBounds,
     });
 
@@ -330,7 +329,6 @@ export class Stage {
    * Create default PixelTexture
    */
   createDefaultTexture() {
-    console.log('Creating default texture');
     (this.defaultTexture as ColorTexture) = this.txManager.createTexture(
       'ColorTexture',
       {
@@ -726,7 +724,6 @@ export class Stage {
       rotation: props.rotation ?? 0,
       rtt: props.rtt ?? false,
       data: data,
-      preventCleanup: props.preventCleanup ?? false,
       imageType: props.imageType,
       strictBounds: props.strictBounds ?? this.strictBounds,
     };


### PR DESCRIPTION
Flag was deprecated in #486 and released in 2.9.0 with a warning/messaging.
This is moved to texture Options for better clarity.

This PR will drop it entirely from 3.0.