### PR TITLE
Update framebufferDimensions handling to support null values based on parentHasRenderTexture

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -1757,7 +1757,10 @@ export class CoreNode extends EventEmitter {
       renderCoords: this.renderCoords,
       rtt: this.rtt,
       parentHasRenderTexture: this.parentHasRenderTexture,
-      framebufferDimensions: this.framebufferDimensions,
+      framebufferDimensions:
+        this.parentHasRenderTexture === true
+          ? this.parentFramebufferDimensions
+          : null,
     });
   }
 
@@ -2370,16 +2373,15 @@ export class CoreNode extends EventEmitter {
   }
 
   /**
-   * Returns the framebuffer dimensions of the node.
-   * If the node has a render texture, the dimensions are the same as the node's dimensions.
-   * If the node does not have a render texture, the dimensions are inherited from the parent.
-   * If the node parent has a render texture and the node is a render texture, the nodes dimensions are used.
+   * Returns the framebuffer dimensions of the RTT parent
    */
-  get framebufferDimensions(): Dimensions {
-    if (this.parentHasRenderTexture && !this.rtt && this.parent) {
-      return this.parent.framebufferDimensions;
-    }
-    return { width: this.width, height: this.height };
+  get parentFramebufferDimensions(): Dimensions {
+    const rttParent = this.rttParent || this.findParentRTTNode();
+
+    return {
+      width: rttParent!.width,
+      height: rttParent!.height,
+    };
   }
 
   /**

--- a/src/core/renderers/CoreRenderer.ts
+++ b/src/core/renderers/CoreRenderer.ts
@@ -52,7 +52,7 @@ export interface QuadOptions {
   renderCoords?: RenderCoords;
   rtt: boolean;
   parentHasRenderTexture: boolean;
-  framebufferDimensions: Dimensions;
+  framebufferDimensions: Dimensions | null;
 }
 
 export interface CoreRendererOptions {

--- a/src/core/renderers/webgl/WebGlRenderOp.ts
+++ b/src/core/renderers/webgl/WebGlRenderOp.ts
@@ -62,7 +62,7 @@ export class WebGlRenderOp extends CoreRenderOp {
   readonly clippingRect: RectWithValid;
   readonly rtt: boolean;
   readonly parentHasRenderTexture: boolean;
-  readonly framebufferDimensions?: Dimensions;
+  readonly framebufferDimensions?: Dimensions | null;
   readonly alpha: number;
   readonly pixelRatio: number;
 

--- a/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
+++ b/src/core/text-rendering/renderers/SdfTextRenderer/SdfTextRenderer.ts
@@ -708,7 +708,10 @@ export class SdfTextRenderer extends TextRenderer<SdfTextRendererState> {
         width: textW,
         rtt: false,
         parentHasRenderTexture: node.parentHasRenderTexture,
-        framebufferDimensions: node.framebufferDimensions,
+        framebufferDimensions:
+          node.parentHasRenderTexture === true
+            ? node.parentFramebufferDimensions
+            : null,
       },
       0,
     );


### PR DESCRIPTION
Builds upon #549 - the framebuffer dimensions are only relevant for nodes with an RTT parent.

* Limit getting the frame buffer dimensions only when `hasRTTParent`
* Get cached value from rttParent if available
* Return null if otherwise for normal nodes