### PR TITLE
Prevent glClearColor when clear color is changed

### DIFF
--- a/src/core/renderers/webgl/WebGlRenderer.ts
+++ b/src/core/renderers/webgl/WebGlRenderer.ts
@@ -725,8 +725,7 @@ export class WebGlRenderer extends CoreRenderer {
   }
 
   /**
-   * Updates the WebGL context's clear color and clears the color buffer.
-   *
+   * Sets the glClearColor to the specified color.   *
    * @param color - The color to set as the clear color, represented as a 32-bit integer.
    */
   updateClearColor(color: number) {
@@ -745,6 +744,5 @@ export class WebGlRenderer extends CoreRenderer {
       raw: color,
       normalized: normalizedColor,
     };
-    glw.clear();
   }
 }


### PR DESCRIPTION
Updating the `glClearColor` also triggers a `glClear`, this can lead to unwanted behaviour in the case where the render is idle.