### PR TITLE
Fix inspector is enabled even though it isn't

### DIFF
--- a/src/main-api/Renderer.ts
+++ b/src/main-api/Renderer.ts
@@ -441,7 +441,7 @@ export class RendererMain extends EventEmitter {
       eventBus: this,
       quadBufferSize: this.settings.quadBufferSize,
       fontEngines: this.settings.fontEngines,
-      inspector: this.settings.inspector !== null,
+      inspector: this.settings.inspector !== false,
       strictBounds: this.settings.strictBounds,
       textureProcessingTimeLimit: this.settings.textureProcessingTimeLimit,
       createImageBitmapSupport: this.settings.createImageBitmapSupport,


### PR DESCRIPTION
settings.inspector is a boolean, so it's never null