### PR TITLE
Fix failed textures getting stuck

### DIFF
--- a/examples/tests/texture-memory-allocation.ts
+++ b/examples/tests/texture-memory-allocation.ts
@@ -24,9 +24,10 @@ export function customSettings(): Partial<RendererMainSettings> {
   return {
     textureMemory: {
       cleanupInterval: 5000,
-      criticalThreshold: 25e6,
+      criticalThreshold: 13e6,
       baselineMemoryAllocation: 5e6,
-      debugLogging: true,
+      doNotExceedCriticalThreshold: true,
+      debugLogging: false,
     },
   };
 }
@@ -139,6 +140,11 @@ export default async function test({ renderer, testRoot }: ExampleSettings) {
         height: nodeHeight,
         parent: childNode,
         src: `https://picsum.photos/id/${id}/${nodeWidth}/${nodeHeight}`, // Random images
+      });
+
+      imageNode.on('failed', () => {
+        console.log(`Image failed to load for node ${id}`);
+        childNode.color = 0xffff00ff; // Change color to yellow on error
       });
 
       const textNode = renderer.createTextNode({

--- a/src/core/CoreTextureManager.ts
+++ b/src/core/CoreTextureManager.ts
@@ -394,6 +394,7 @@ export class CoreTextureManager extends EventEmitter {
       // if the texture has texture data, queue it for upload
       if (texture.textureData !== null) {
         this.enqueueUploadTexture(texture);
+        return;
       }
 
       // else we will have to re-download the texture
@@ -404,6 +405,12 @@ export class CoreTextureManager extends EventEmitter {
     if (this.initialized === false) {
       this.priorityQueue.push(texture);
       return;
+    }
+
+    // If the texture failed to load, we need to re-download it.
+    if (texture.state === 'failed') {
+      texture.free();
+      texture.freeTextureData();
     }
 
     // these types of textures don't need to be downloaded

--- a/src/core/lib/ImageWorker.ts
+++ b/src/core/lib/ImageWorker.ts
@@ -75,7 +75,13 @@ function createImageWorker() {
       xhr.onload = function () {
         // On most devices like WebOS and Tizen, the file protocol returns 0 while http(s) protocol returns 200
         if (xhr.status !== 200 && xhr.status !== 0) {
-          return reject(new Error('Failed to load image: ' + xhr.statusText));
+          return reject(
+            new Error(
+              `Image loading failed. HTTP status code: ${
+                xhr.status || 'N/A'
+              }. URL: ${src}`,
+            ),
+          );
         }
 
         var blob = xhr.response;

--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -31,6 +31,7 @@ import {
 import { isSvgImage, loadSvg } from '../lib/textureSvg.js';
 import { fetchJson } from '../text-rendering/font-face-types/utils.js';
 import type { Platform } from '../platforms/Platform.js';
+import { isProductionEnvironment } from '../../utils.js';
 
 /**
  * Properties of the {@link ImageTexture}
@@ -256,6 +257,12 @@ export class ImageTexture extends Texture {
       resp = await this.determineImageTypeAndLoadImage();
     } catch (e) {
       this.setState('failed', e as Error);
+
+      // log error only in development
+      if (isProductionEnvironment === false) {
+        console.error('ImageTexture:', e);
+      }
+
       return {
         data: null,
       };


### PR DESCRIPTION
If during texture load the source was unavailable (e.g. 404 or temp network issue) the texture would never get reloaded.

This change enables reloading the texture if it goes in bound again, forcing a redownload. If the network error was temporarily it should resolve on the second attempt.  If the error is permanent the UI should do a fallback image instead based on the `failed` event.

Additionally fixed a race condition that if an texture was yanked out of the throttle queue while it was uploading, it would immediately get uploaded again on subsequent texture load.

Also enabled logging of failed images when in dev mode.