### PR TITLE
Include node dimensions to shader value key + minor refactor

### DIFF
--- a/examples/tests/shader-rounded.ts
+++ b/examples/tests/shader-rounded.ts
@@ -44,21 +44,6 @@ export default async function test({ renderer, testRoot }: ExampleSettings) {
     parent: testRoot,
   });
 
-  const RedRect3 = renderer.createNode({
-    x: 480,
-    y: 20,
-    width: 8,
-    height: 8,
-    color: 0xff0000ff,
-    shader: renderer.createShader('Rounded', { radius: 12 }),
-    parent: testRoot,
-  });
-
-  setTimeout(() => {
-    RedRect3.width = 400;
-    RedRect3.height = 400;
-  }, 2000);
-
   const GreenRect = renderer.createNode({
     x: 20,
     y: 250,

--- a/examples/tests/shader-rounded.ts
+++ b/examples/tests/shader-rounded.ts
@@ -44,6 +44,21 @@ export default async function test({ renderer, testRoot }: ExampleSettings) {
     parent: testRoot,
   });
 
+  const RedRect3 = renderer.createNode({
+    x: 480,
+    y: 20,
+    width: 8,
+    height: 8,
+    color: 0xff0000ff,
+    shader: renderer.createShader('Rounded', { radius: 12 }),
+    parent: testRoot,
+  });
+
+  setTimeout(() => {
+    RedRect3.width = 400;
+    RedRect3.height = 400;
+  }, 2000);
+
   const GreenRect = renderer.createNode({
     x: 20,
     y: 250,

--- a/src/core/renderers/CoreShaderNode.ts
+++ b/src/core/renderers/CoreShaderNode.ts
@@ -150,6 +150,16 @@ export class CoreShaderNode<Props extends object = Record<string, unknown>> {
     this.node = node;
   }
 
+  createValueKey() {
+    let valueKey = '';
+    for (const key in this.resolvedProps) {
+      valueKey += `${key}:${this.resolvedProps[key]!};`;
+    }
+    valueKey += `node-width:${this.node!.width}`;
+    valueKey += `node-height:${this.node!.height}`;
+    return valueKey;
+  }
+
   get props(): Props | undefined {
     return this.definedProps;
   }

--- a/src/core/renderers/canvas/CanvasShaderNode.ts
+++ b/src/core/renderers/canvas/CanvasShaderNode.ts
@@ -67,10 +67,7 @@ export class CanvasShaderNode<
 
       this.update = () => {
         const prevKey = this.valueKey;
-        this.valueKey = '';
-        for (const key in this.resolvedProps) {
-          this.valueKey += `${key}:${this.resolvedProps[key]!};`;
-        }
+        this.valueKey = this.createValueKey();
 
         if (prevKey === this.valueKey) {
           return;

--- a/src/core/renderers/webgl/WebGlShaderNode.ts
+++ b/src/core/renderers/webgl/WebGlShaderNode.ts
@@ -90,11 +90,9 @@ export class WebGlShaderNode<
           this.updater!(this.node as CoreNode, this.props);
           return;
         }
+
         const prevKey = this.valueKey;
-        this.valueKey = '';
-        for (const key in this.resolvedProps) {
-          this.valueKey += `${key}:${this.resolvedProps[key]!};`;
-        }
+        this.valueKey = this.createValueKey();
 
         if (prevKey === this.valueKey) {
           return;

--- a/src/core/shaders/templates/BorderTemplate.ts
+++ b/src/core/shaders/templates/BorderTemplate.ts
@@ -17,7 +17,7 @@
 
 import type { CoreShaderType } from '../../renderers/CoreShaderNode.js';
 import type { Vec4 } from '../../renderers/webgl/internal/ShaderUtils.js';
-import { validateArrayLength4, type PrefixedType } from './shaderUtils.js';
+import { validateArrayLength4, type PrefixedType } from '../utils.js';
 
 /**
  * Properties of the {@link Border} shader

--- a/src/core/shaders/templates/HolePunchTemplate.ts
+++ b/src/core/shaders/templates/HolePunchTemplate.ts
@@ -16,7 +16,7 @@
  */
 
 import type { CoreShaderType } from '../../renderers/CoreShaderNode.js';
-import { validateArrayLength4 } from './shaderUtils.js';
+import { validateArrayLength4 } from '../utils.js';
 
 /**
  * Properties of the {@link HolePunch} shader

--- a/src/core/shaders/templates/RoundedTemplate.ts
+++ b/src/core/shaders/templates/RoundedTemplate.ts
@@ -17,7 +17,7 @@
 
 import type { CoreShaderType } from '../../renderers/CoreShaderNode.js';
 import type { Vec4 } from '../../renderers/webgl/internal/ShaderUtils.js';
-import { validateArrayLength4 } from './shaderUtils.js';
+import { validateArrayLength4 } from '../utils.js';
 
 /**
  * Properties of the {@link RoundedRectangle} shader

--- a/src/core/shaders/templates/RoundedWithBorderAndShadowTemplate.ts
+++ b/src/core/shaders/templates/RoundedWithBorderAndShadowTemplate.ts
@@ -18,7 +18,7 @@
 import type { CoreShaderType } from '../../renderers/CoreShaderNode.js';
 import { getBorderProps, type BorderProps } from './BorderTemplate.js';
 import { RoundedTemplate, type RoundedProps } from './RoundedTemplate.js';
-import type { PrefixedType } from './shaderUtils.js';
+import type { PrefixedType } from '../utils.js';
 import { getShadowProps, type ShadowProps } from './ShadowTemplate.js';
 
 export type RoundedWithBorderAndShadowProps = RoundedProps &

--- a/src/core/shaders/templates/RoundedWithBorderTemplate.ts
+++ b/src/core/shaders/templates/RoundedWithBorderTemplate.ts
@@ -18,7 +18,7 @@
 import type { CoreShaderType } from '../../renderers/CoreShaderNode.js';
 import { getBorderProps, type BorderProps } from './BorderTemplate.js';
 import { RoundedTemplate, type RoundedProps } from './RoundedTemplate.js';
-import type { PrefixedType } from './shaderUtils.js';
+import type { PrefixedType } from '../utils.js';
 
 export type RoundedWithBorderProps = RoundedProps &
   PrefixedType<BorderProps, 'border'>;

--- a/src/core/shaders/templates/RoundedWithShadowTemplate.ts
+++ b/src/core/shaders/templates/RoundedWithShadowTemplate.ts
@@ -17,7 +17,7 @@
 
 import type { CoreShaderType } from '../../renderers/CoreShaderNode.js';
 import { RoundedTemplate, type RoundedProps } from './RoundedTemplate.js';
-import type { PrefixedType } from './shaderUtils.js';
+import type { PrefixedType } from '../utils.js';
 import { getShadowProps, type ShadowProps } from './ShadowTemplate.js';
 
 export type RoundedWithShadowProps = RoundedProps &

--- a/src/core/shaders/templates/ShadowTemplate.ts
+++ b/src/core/shaders/templates/ShadowTemplate.ts
@@ -16,7 +16,7 @@
  */
 
 import type { CoreShaderType } from '../../renderers/CoreShaderNode.js';
-import type { PrefixedType } from './shaderUtils.js';
+import type { PrefixedType } from '../utils.js';
 
 export interface ShadowProps {
   /**

--- a/src/core/shaders/utils.ts
+++ b/src/core/shaders/utils.ts
@@ -14,9 +14,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { assertTruthy } from '../../../utils.js';
-import type { Vec4 } from '../../renderers/webgl/internal/ShaderUtils.js';
+import { assertTruthy } from '../../utils.js';
+import type { Vec4 } from '../renderers/webgl/internal/ShaderUtils.js';
 
 export const validateArrayLength4 = (value: number | number[]): Vec4 => {
   if (!Array.isArray(value)) {


### PR DESCRIPTION
- fixed an issue(#568) where node width / height changes were not checked during shader update.

- moved shaderUtils.ts to shaders folder and renamed to utils.