### PR TITLE
Prevent rendering of broken image icon when Image fallback loading fails

### DIFF
--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -149,24 +149,25 @@ export class ImageTexture extends Texture {
       img.crossOrigin = 'anonymous';
     }
 
-    return new Promise<{ data: HTMLImageElement; premultiplyAlpha: boolean }>(
-      (resolve) => {
-        img.onload = () => {
-          resolve({ data: img, premultiplyAlpha: hasAlpha });
-        };
+    return new Promise<{
+      data: HTMLImageElement | null;
+      premultiplyAlpha: boolean;
+    }>((resolve) => {
+      img.onload = () => {
+        resolve({ data: img, premultiplyAlpha: hasAlpha });
+      };
 
-        img.onerror = () => {
-          console.warn('Image loading failed, returning fallback object.');
-          resolve({ data: img, premultiplyAlpha: hasAlpha });
-        };
+      img.onerror = () => {
+        console.warn('Image loading failed, returning fallback object.');
+        resolve({ data: null, premultiplyAlpha: hasAlpha });
+      };
 
-        if (src instanceof Blob) {
-          img.src = URL.createObjectURL(src);
-        } else {
-          img.src = src;
-        }
-      },
-    );
+      if (src instanceof Blob) {
+        img.src = URL.createObjectURL(src);
+      } else {
+        img.src = src;
+      }
+    });
   }
 
   async createImageBitmap(


### PR DESCRIPTION
In old Chrome versions with WebGL enabled but no support for `createImageBitmap`, image textures are loaded using `HTMLImageElement` as fallback. When the image fails to load, the promise handling the loading still resolves the Image object as it is.

This behavior causes WebGL to render the default Chrome _broken image icon_ on some older Chrome versions (tested on Chromium 38 using Windows.)

I'm attaching a reference for the _broken image icon_ to be clear on what I mean by that. This is what is shown by Chrome when an img tag fails to load the provided src in a DOM context:
<img width="128" alt="broken image icon" src="https://github.com/user-attachments/assets/ba4e61a9-e98f-4644-876e-23a6a174aaac" />


This PR prevents the icon from being rendered in the WebGL context by resolving `null` instead of the Image object in its broken state. The _broken image icon_ doesn't appear this way, and nothing is rendered in its place. The texture will be moved to the `"failed"` state by the method `getTextureSource`.

I'm not sure why rejecting the promise or returning null data has never been part of the logic, but I think that the unnecessary upload to WebGL (width and height set to 0, no significant image data) should be prevented nonetheless.