### PR TITLE
v2: Prevent rendering of broken image icon when Image fallback loading fails

### DIFF
--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -144,24 +144,25 @@ export class ImageTexture extends Texture {
       img.crossOrigin = 'anonymous';
     }
 
-    return new Promise<{ data: HTMLImageElement; premultiplyAlpha: boolean }>(
-      (resolve) => {
-        img.onload = () => {
-          resolve({ data: img, premultiplyAlpha: hasAlpha });
-        };
+    return new Promise<{
+      data: HTMLImageElement | null;
+      premultiplyAlpha: boolean;
+    }>((resolve) => {
+      img.onload = () => {
+        resolve({ data: img, premultiplyAlpha: hasAlpha });
+      };
 
-        img.onerror = () => {
-          console.warn('Image loading failed, returning fallback object.');
-          resolve({ data: img, premultiplyAlpha: hasAlpha });
-        };
+      img.onerror = () => {
+        console.warn('Image loading failed, returning fallback object.');
+        resolve({ data: null, premultiplyAlpha: hasAlpha });
+      };
 
-        if (src instanceof Blob) {
-          img.src = URL.createObjectURL(src);
-        } else {
-          img.src = src;
-        }
-      },
-    );
+      if (src instanceof Blob) {
+        img.src = URL.createObjectURL(src);
+      } else {
+        img.src = src;
+      }
+    });
   }
 
   async createImageBitmap(


### PR DESCRIPTION
Backport of https://github.com/lightning-js/renderer/pull/580