### PR TITLE
Fix transitional texture changes

### DIFF
--- a/examples/tests/texture-alpha-switching.ts
+++ b/examples/tests/texture-alpha-switching.ts
@@ -1,0 +1,106 @@
+import type { RendererMainSettings } from '@lightningjs/renderer';
+import type { ExampleSettings } from '../common/ExampleSettings.js';
+
+export function customSettings(): Partial<RendererMainSettings> {
+  return {
+    textureMemory: {
+      cleanupInterval: 5000,
+      criticalThreshold: 13e6,
+      baselineMemoryAllocation: 5e6,
+      doNotExceedCriticalThreshold: true,
+      debugLogging: false,
+    },
+  };
+}
+
+export default async function ({ renderer, testRoot }: ExampleSettings) {
+  const holder1 = renderer.createNode({
+    x: 150,
+    y: 150,
+    parent: testRoot,
+    // src: 'https://images.unsplash.com/photo-1690360994204-3d10cc73a08d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=300&q=80',
+    alpha: 0,
+  });
+
+  const nodeWidth = 200;
+  const nodeHeight = 200;
+  const gap = 10; // Define the gap between items
+
+  const spawnRow = function (rowIndex = 0, amount = 8) {
+    const y = rowIndex * (nodeHeight + gap);
+
+    const rowNode = renderer.createNode({
+      x: 0,
+      y: y,
+      parent: holder1,
+      color: 0x000000ff,
+    });
+
+    for (let i = 0; i < amount; i++) {
+      const id = rowIndex * amount + i;
+
+      const childNode = renderer.createNode({
+        x: i * nodeWidth, // Adjust position by subtracting the gap
+        y: 0,
+        width: nodeWidth, // Width of the green node
+        height: nodeHeight, // Slightly smaller height
+        parent: rowNode,
+      });
+
+      const imageNode = renderer.createNode({
+        x: 0,
+        y: 0,
+        width: nodeWidth,
+        height: nodeHeight,
+        parent: childNode,
+        src: `https://picsum.photos/id/${id}/${nodeWidth}/${nodeHeight}`, // Random images
+      });
+
+      imageNode.on('failed', () => {
+        console.log(`Image failed to load for node ${id}`);
+        childNode.color = 0xffff00ff; // Change color to yellow on error
+      });
+
+      const textNode = renderer.createTextNode({
+        x: 0,
+        y: 0,
+        autosize: true,
+        parent: childNode,
+        text: `Card ${id}`,
+        fontSize: 20,
+        color: 0xffffffff,
+      });
+    }
+  };
+
+  spawnRow(0);
+  spawnRow(1);
+  spawnRow(2);
+  spawnRow(3);
+
+  const holder2 = renderer.createNode({
+    parent: testRoot,
+    // src: 'https://images.unsplash.com/photo-1690360994204-3d10cc73a08d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=300&q=80',
+    alpha: 1,
+  });
+
+  const img = renderer.createNode({
+    width: 300,
+    height: 300,
+    parent: holder2,
+    src: 'https://images.unsplash.com/photo-1690360994204-3d10cc73a08d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=300&q=80',
+    alpha: 1,
+  });
+
+  window.addEventListener('keypress', (e) => {
+    if (e.key === 'Enter') {
+      if (holder1.alpha === 1) {
+        holder1.alpha = 0;
+        holder2.alpha = 1;
+      } else {
+        holder1.alpha = 1;
+        holder2.alpha = 0;
+      }
+    }
+  });
+}

--- a/examples/tests/texture-alpha-switching.ts
+++ b/examples/tests/texture-alpha-switching.ts
@@ -1,4 +1,4 @@
-import type { RendererMainSettings } from '@lightningjs/renderer';
+import type { INode, RendererMainSettings } from '@lightningjs/renderer';
 import type { ExampleSettings } from '../common/ExampleSettings.js';
 
 export function customSettings(): Partial<RendererMainSettings> {
@@ -61,7 +61,7 @@ export default async function ({ renderer, testRoot }: ExampleSettings) {
         childNode.color = 0xffff00ff; // Change color to yellow on error
       });
 
-      const textNode = renderer.createTextNode({
+      renderer.createTextNode({
         x: 0,
         y: 0,
         autosize: true,
@@ -101,6 +101,29 @@ export default async function ({ renderer, testRoot }: ExampleSettings) {
         holder1.alpha = 1;
         holder2.alpha = 0;
       }
+    } else if (e.key === 'r' || e.key === 'R') {
+      // Reset all squares in holder1 to white
+      const resetSquares = (node: INode) => {
+        // If this node has children, process each child
+        if (node.children && node.children.length > 0) {
+          for (let i = 0; i < node.children.length; i++) {
+            const child = node.children[i];
+            if (child) {
+              // Set the color to white
+              if (!child.src) {
+                // Only change color of non-image nodes
+                child.color = 0xffffffff; // White with full alpha
+              }
+              // Recursively process this child's children
+              resetSquares(child);
+            }
+          }
+        }
+      };
+
+      // Process all rows in holder1
+      resetSquares(holder1 as INode);
+      console.log('Reset all squares in holder1 to white');
     }
   });
 }

--- a/src/core/CoreTextureManager.ts
+++ b/src/core/CoreTextureManager.ts
@@ -355,6 +355,11 @@ export class CoreTextureManager extends EventEmitter {
       return;
     }
 
+    // If the texture is already loading, we don't need to do anything
+    if (texture.state === 'loading') {
+      return;
+    }
+
     // if the texture is already loaded, don't load it again
     if (
       texture.ctxTexture !== undefined &&

--- a/src/core/CoreTextureManager.ts
+++ b/src/core/CoreTextureManager.ts
@@ -24,7 +24,7 @@ import { ImageTexture } from './textures/ImageTexture.js';
 import { NoiseTexture } from './textures/NoiseTexture.js';
 import { SubTexture } from './textures/SubTexture.js';
 import { RenderTexture } from './textures/RenderTexture.js';
-import { TextureType, type Texture } from './textures/Texture.js';
+import { Texture, TextureType } from './textures/Texture.js';
 import { EventEmitter } from '../common/EventEmitter.js';
 import { getTimeStamp } from './platform.js';
 import type { Stage } from './Stage.js';
@@ -355,32 +355,13 @@ export class CoreTextureManager extends EventEmitter {
       return;
     }
 
-    // If the texture is already loading, we don't need to do anything
-    if (texture.state === 'loading') {
+    if (texture.state === 'loaded') {
+      // if the texture is already loaded, just return
       return;
     }
 
-    // if the texture is already loaded, don't load it again
-    if (
-      texture.ctxTexture !== undefined &&
-      texture.ctxTexture.state === 'loaded'
-    ) {
-      texture.setState('loaded');
+    if (Texture.TRANSITIONAL_TEXTURE_STATES.includes(texture.state)) {
       return;
-    }
-
-    // if the texture is already being processed, don't load it again
-    if (this.uploadTextureQueue.includes(texture) === true) {
-      return;
-    }
-
-    // if the texture is already loading, free it, this can happen if the texture is
-    // orphaned and then reloaded
-    if (
-      texture.ctxTexture !== undefined &&
-      texture.ctxTexture.state === 'loading'
-    ) {
-      texture.free();
     }
 
     // if we're not initialized, just queue the texture into the priority queue

--- a/src/core/TextureMemoryManager.ts
+++ b/src/core/TextureMemoryManager.ts
@@ -19,11 +19,7 @@
 import { isProductionEnvironment } from '../utils.js';
 import { getTimeStamp } from './platform.js';
 import type { Stage } from './Stage.js';
-import {
-  TextureType,
-  type Texture,
-  type TextureState,
-} from './textures/Texture.js';
+import { Texture, TextureType, type TextureState } from './textures/Texture.js';
 import { bytesToMb } from './utils.js';
 
 export interface TextureMemoryManagerSettings {
@@ -119,12 +115,6 @@ export interface MemoryInfo {
  * scene is idle for a certain amount of time (`cleanupInterval`).
  */
 export class TextureMemoryManager {
-  /**
-   * Texture states that are considered transitional and should be skipped during cleanup
-   */
-  private static readonly TRANSITIONAL_TEXTURE_STATES: readonly TextureState[] =
-    ['initial', 'fetching', 'fetched', 'loading'];
-
   private memUsed = 0;
   private loadedTextures: Map<Texture, number> = new Map();
   private orphanedTextures: Texture[] = [];
@@ -280,9 +270,7 @@ export class TextureMemoryManager {
 
       // Skip textures that are in transitional states - we only want to clean up
       // textures that are in a stable state (loaded, failed, or freed)
-      if (
-        TextureMemoryManager.TRANSITIONAL_TEXTURE_STATES.includes(texture.state)
-      ) {
+      if (Texture.TRANSITIONAL_TEXTURE_STATES.includes(texture.state)) {
         continue;
       }
 
@@ -353,9 +341,7 @@ export class TextureMemoryManager {
 
       // Skip textures that are in transitional states - we only want to clean up
       // textures that are in a stable state (loaded, failed, or freed)
-      if (
-        TextureMemoryManager.TRANSITIONAL_TEXTURE_STATES.includes(texture.state)
-      ) {
+      if (Texture.TRANSITIONAL_TEXTURE_STATES.includes(texture.state)) {
         break;
       }
 

--- a/src/core/textures/Texture.ts
+++ b/src/core/textures/Texture.ts
@@ -139,6 +139,12 @@ export abstract class Texture extends EventEmitter {
   private _dimensions: Dimensions | null = null;
   private _error: Error | null = null;
 
+  /**
+   * Texture states that are considered transitional and should be skipped during cleanup
+   */
+  public static readonly TRANSITIONAL_TEXTURE_STATES: readonly TextureState[] =
+    ['fetching', 'fetched', 'loading'];
+
   // aggregate state
   public state: TextureState = 'initial';
 

--- a/src/core/textures/Texture.ts
+++ b/src/core/textures/Texture.ts
@@ -253,10 +253,13 @@ export abstract class Texture extends EventEmitter {
    * cleaned up.
    */
   destroy(): void {
-    this.removeAllListeners();
-    this.free();
+    // Only free GPU resources if we're in a state where they exist
+    if (this.state === 'loaded') {
+      this.free();
+    }
+
+    // Always free texture data regardless of state
     this.freeTextureData();
-    this.renderableOwners.clear();
   }
 
   /**


### PR DESCRIPTION
If we made really quick changes to an image node (e.g. alpha 0 to 1 back 0) you could end up with race conditions that caused a duplicate cleanup of the texture. Resulting in the issues seen (and guarded) with #597 

This change addresses the root cause by avoiding duplicate `load` of textures and cleaning up textures that are in an transitional state (`fetching` / `fetched` / `loading` etc).

This avoids a race condition where the memory manager tries to cleanup a texture that is still `loading` or similar, which is especially prevalent on CPU starved devices with heavy transitions.