### PR TITLE
perf: performance changes to the canvas text renderer

### DIFF
--- a/src/core/text-rendering/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/CanvasTextRenderer.ts
@@ -19,18 +19,16 @@
 
 import { assertTruthy } from '../../utils.js';
 import type { Stage } from '../Stage.js';
-import type { TextLayout, TrProps } from './TextRenderer.js';
+import type {
+  TextLayout,
+  TrProps,
+  NormalizedFontMetrics,
+  TextBaseline,
+} from './TextRenderer.js';
 import * as CanvasFontHandler from './CanvasFontHandler.js';
 import { type LineType } from './canvas/calculateRenderInfo.js';
 import { calcHeight, measureText, wrapText, wrapWord } from './canvas/Utils.js';
 import { normalizeCanvasColor } from '../lib/colorCache.js';
-
-const DEFAULT_SHADOW_VALUES = {
-  color: 'black',
-  offsetX: 0,
-  offsetY: 0,
-  blur: 0,
-};
 
 const MAX_TEXTURE_DIMENSION = 4096;
 
@@ -42,12 +40,44 @@ let context:
   | OffscreenCanvasRenderingContext2D
   | null = null;
 
+// Separate canvas and context for text measurements
+let measureCanvas: HTMLCanvasElement | OffscreenCanvas | null = null;
+let measureContext:
+  | CanvasRenderingContext2D
+  | OffscreenCanvasRenderingContext2D
+  | null = null;
+
+// Cache for text layout calculations
+const layoutCache = new Map<
+  string,
+  {
+    lines: string[];
+    lineWidths: number[];
+    maxLineWidth: number;
+    remainingText: string;
+    moreTextLines: boolean;
+  }
+>();
+
 // Initialize the Text Renderer
 const init = (stage: Stage): void => {
+  // Drawing canvas and context
   canvas = stage.platform.createCanvas() as HTMLCanvasElement | OffscreenCanvas;
-  context = canvas.getContext('2d') as
+  context = canvas.getContext('2d', { willReadFrequently: true }) as
     | CanvasRenderingContext2D
     | OffscreenCanvasRenderingContext2D;
+
+  // Separate measuring canvas and context
+  measureCanvas = stage.platform.createCanvas() as
+    | HTMLCanvasElement
+    | OffscreenCanvas;
+  measureContext = measureCanvas.getContext('2d') as
+    | CanvasRenderingContext2D
+    | OffscreenCanvasRenderingContext2D;
+
+  // Set up a minimal size for the measuring canvas since we only use it for measurements
+  measureCanvas.width = 1;
+  measureCanvas.height = 1;
 
   CanvasFontHandler.init(context);
 };
@@ -71,86 +101,234 @@ const renderText = (
   assertTruthy(canvas, 'Canvas is not initialized');
   assertTruthy(context, 'Canvas context is not available');
 
-  let text = props.text,
-    precision = 1,
-    fontFamily = props.fontFamily,
-    fontStyle = props.fontStyle,
-    textAlign = props.textAlign,
-    lineHeight = props.lineHeight || 0,
-    maxLines = props.maxLines,
-    textBaseline = props.textBaseline,
-    verticalAlign = props.verticalAlign,
-    overflowSuffix = props.overflowSuffix,
-    wordBreak = props.wordBreak,
-    wordWrap = props.contain !== 'none',
-    wordWrapWidth = props.contain === 'none' ? 0 : props.width || 0,
-    width = props.contain !== 'none' ? props.width : 0,
-    w = width,
-    height = props.height,
-    maxHeight =
-      props.contain === 'both'
-        ? (props.height || 0) - (props.offsetY || 0)
-        : null,
-    textOverflow = overflowSuffix ? 'ellipsis' : null,
-    fontSize = props.fontSize * precision,
-    offsetY = props.offsetY * precision,
-    letterSpacing = props.letterSpacing * precision,
-    paddingLeft = 0,
-    paddingRight = 0,
-    textColor = 0xffffffff,
-    shadow: boolean = false,
-    shadowColor = 0xff000000,
-    shadowOffsetX = 0,
-    shadowOffsetY = 0,
-    shadowBlur = 0,
-    highlight: boolean = false,
-    highlightHeight = 0,
-    highlightColor = 0x80ffff00,
-    highlightOffset = 0,
-    highlightPaddingLeft = 0,
-    highlightPaddingRight = 0,
-    textIndent = 0,
-    cutSx = 0,
-    cutSy = 0,
-    cutEx = 0,
-    cutEy = 0,
-    advancedRenderer = false,
-    textRenderIssueMargin = 0;
+  // Extract and normalize properties
+  const {
+    text = '',
+    fontFamily = 'Arial',
+    fontStyle = 'normal',
+    fontSize = 16,
+    textAlign = 'left',
+    lineHeight: propLineHeight = 0,
+    maxLines = 0,
+    textBaseline = 'alphabetic',
+    verticalAlign = 'top',
+    overflowSuffix = '',
+    contain = 'none',
+    width: propWidth = 0,
+    height: propHeight = 0,
+    offsetY = 0,
+    letterSpacing = 0,
+  } = props;
 
-  context.font = `${fontStyle} ${fontSize}px ${fontFamily}`;
+  // Performance optimization constants
+  const precision = 1;
+  const paddingLeft = 0;
+  const paddingRight = 0;
+  const textIndent = 0;
+  const textRenderIssueMargin = 0;
+  const textColor = 0xffffffff;
+
+  // Determine word wrap behavior
+  const wordWrap = contain !== 'none';
+  const wordWrapWidth = contain === 'none' ? 0 : propWidth || 0;
+  const maxHeight = contain === 'both' ? (propHeight || 0) - offsetY : null;
+  const textOverflow = overflowSuffix ? 'ellipsis' : null;
+
+  // Calculate scaled values
+  const scaledFontSize = fontSize * precision;
+  const scaledOffsetY = offsetY * precision;
+  const scaledLetterSpacing = letterSpacing * precision;
+
+  // Get font metrics and calculate line height
+  context.font = `${fontStyle} ${scaledFontSize}px ${fontFamily}`;
   context.textBaseline = textBaseline;
 
-  const metrics = CanvasFontHandler.getFontMetrics(fontFamily, fontSize);
+  const metrics = CanvasFontHandler.getFontMetrics(fontFamily, scaledFontSize);
+  const lineHeight =
+    propLineHeight === 0
+      ? scaledFontSize *
+        (metrics.ascender - metrics.descender + metrics.lineGap) *
+        precision
+      : propLineHeight;
 
-  if (lineHeight === 0) {
-    lineHeight =
-      fontSize *
-      (metrics.ascender - metrics.descender + metrics.lineGap) *
-      precision;
-  }
-
+  // Calculate max lines constraint
   const containedMaxLines =
     maxHeight !== null ? Math.floor(maxHeight / lineHeight) : 0;
+  const computedMaxLines = calculateMaxLines(containedMaxLines, maxLines);
 
-  let computedMaxLines: number;
-  if (containedMaxLines > 0 && maxLines > 0) {
-    computedMaxLines =
-      containedMaxLines < maxLines ? containedMaxLines : maxLines;
-  } else {
-    computedMaxLines =
-      containedMaxLines > maxLines ? containedMaxLines : maxLines;
-  }
-
-  width = w || 2048 / precision;
+  // Calculate initial width and inner width
+  let width = propWidth || 2048 / precision;
   let innerWidth = width - paddingLeft;
   if (innerWidth < 10) {
     width += 10 - innerWidth;
     innerWidth = 10;
   }
-  if (wordWrapWidth === 0) {
-    wordWrapWidth = innerWidth;
+  const finalWordWrapWidth = wordWrapWidth === 0 ? innerWidth : wordWrapWidth;
+
+  // Calculate text layout using cached helper function
+  const layout = calculateTextLayout(
+    text,
+    fontFamily,
+    scaledFontSize,
+    fontStyle,
+    wordWrap,
+    finalWordWrapWidth,
+    scaledLetterSpacing,
+    textIndent,
+    computedMaxLines,
+    overflowSuffix,
+    textOverflow,
+  );
+
+  // Calculate final dimensions
+  const dimensions = calculateTextDimensions(
+    layout,
+    paddingLeft,
+    paddingRight,
+    textBaseline as TextBaseline,
+    scaledFontSize,
+    lineHeight,
+    scaledOffsetY,
+    propWidth,
+    propHeight,
+    wordWrap,
+    textAlign,
+  );
+
+  // Set up canvas dimensions
+  canvas.width = Math.min(
+    Math.ceil(dimensions.width + textRenderIssueMargin),
+    MAX_TEXTURE_DIMENSION,
+  );
+  canvas.height = Math.min(Math.ceil(dimensions.height), MAX_TEXTURE_DIMENSION);
+
+  // Reset font context after canvas resize
+  context.font = `${fontStyle} ${scaledFontSize}px ${fontFamily}`;
+  context.textBaseline = textBaseline;
+
+  // Performance optimization for large fonts
+  if (scaledFontSize >= 128) {
+    context.globalAlpha = 0.01;
+    context.fillRect(0, 0, 0.01, 0.01);
+    context.globalAlpha = 1.0;
   }
 
+  // Calculate drawing positions
+  const drawLines = calculateDrawPositions(
+    layout.lines,
+    layout.lineWidths,
+    textAlign,
+    verticalAlign,
+    innerWidth,
+    paddingLeft,
+    textIndent,
+    lineHeight,
+    metrics,
+    scaledFontSize,
+  );
+
+  // Render text to canvas
+  renderTextToCanvas(
+    context,
+    drawLines,
+    scaledLetterSpacing,
+    textColor,
+    fontStyle,
+    scaledFontSize,
+    fontFamily,
+  );
+
+  // Extract image data
+  let imageData: ImageData | null = null;
+  if (canvas.width > 0 && canvas.height > 0) {
+    imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+  }
+
+  return {
+    imageData,
+    width: dimensions.width,
+    height: lineHeight * layout.lines.length,
+  };
+};
+
+/**
+ * Calculate the effective max lines constraint
+ */
+function calculateMaxLines(
+  containedMaxLines: number,
+  maxLines: number,
+): number {
+  if (containedMaxLines > 0 && maxLines > 0) {
+    return containedMaxLines < maxLines ? containedMaxLines : maxLines;
+  } else {
+    return containedMaxLines > maxLines ? containedMaxLines : maxLines;
+  }
+}
+
+/**
+ * Generate a cache key for text layout calculations
+ */
+function generateLayoutCacheKey(
+  text: string,
+  fontFamily: string,
+  fontSize: number,
+  fontStyle: string,
+  wordWrap: boolean,
+  wordWrapWidth: number,
+  letterSpacing: number,
+  maxLines: number,
+  overflowSuffix: string,
+): string {
+  return `${text}-${fontFamily}-${fontSize}-${fontStyle}-${wordWrap}-${wordWrapWidth}-${letterSpacing}-${maxLines}-${overflowSuffix}`;
+}
+
+/**
+ * Calculate text dimensions and wrapping
+ */
+function calculateTextLayout(
+  text: string,
+  fontFamily: string,
+  fontSize: number,
+  fontStyle: string,
+  wordWrap: boolean,
+  wordWrapWidth: number,
+  letterSpacing: number,
+  textIndent: number,
+  maxLines: number,
+  overflowSuffix: string,
+  textOverflow: string | null,
+): {
+  lines: string[];
+  lineWidths: number[];
+  maxLineWidth: number;
+  remainingText: string;
+  moreTextLines: boolean;
+} {
+  assertTruthy(measureContext, 'Measure context is not available');
+
+  // Check cache first
+  const cacheKey = generateLayoutCacheKey(
+    text,
+    fontFamily,
+    fontSize,
+    fontStyle,
+    wordWrap,
+    wordWrapWidth,
+    letterSpacing,
+    maxLines,
+    overflowSuffix,
+  );
+
+  const cached = layoutCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  // Set font context for measurements on the dedicated measuring context
+  measureContext.font = `${fontStyle} ${fontSize}px ${fontFamily}`;
+
+  // Handle text overflow for non-wrapped text
+  let processedText = text;
   if (textOverflow !== null && wordWrap === false) {
     let suffix: string;
     if (textOverflow === 'clip') {
@@ -160,8 +338,8 @@ const renderText = (
     } else {
       suffix = textOverflow;
     }
-    text = wrapWord(
-      context,
+    processedText = wrapWord(
+      measureContext,
       text,
       wordWrapWidth - textIndent,
       suffix,
@@ -173,14 +351,14 @@ const renderText = (
   let linesInfo: { n: number[]; l: string[] };
   if (wordWrap === true) {
     linesInfo = wrapText(
-      context,
-      text,
+      measureContext,
+      processedText,
       wordWrapWidth,
       letterSpacing,
       textIndent,
     );
   } else {
-    linesInfo = { l: text.split(/(?:\r\n|\r|\n)/), n: [] };
+    linesInfo = { l: processedText.split(/(?:\r\n|\r|\n)/), n: [] };
     const n = linesInfo.l.length;
     for (let i = 0; i < n - 1; i++) {
       linesInfo.n.push(i);
@@ -190,29 +368,32 @@ const renderText = (
 
   let remainingText = '';
   let moreTextLines = false;
-  if (computedMaxLines > 0 && lines.length > computedMaxLines) {
-    const usedLines = lines.slice(0, computedMaxLines);
+
+  // Handle max lines constraint
+  if (maxLines > 0 && lines.length > maxLines) {
+    const usedLines = lines.slice(0, maxLines);
     let otherLines: string[] = [];
     if (overflowSuffix.length > 0) {
-      const w = measureText(context, overflowSuffix, letterSpacing);
+      const w = measureText(measureContext, overflowSuffix, letterSpacing);
       const al = wrapText(
-        context,
-        usedLines[usedLines.length - 1]!,
+        measureContext,
+        usedLines[usedLines.length - 1] || '',
         wordWrapWidth - w,
         letterSpacing,
         textIndent,
       );
-      usedLines[usedLines.length - 1] = `${al.l[0]!}${overflowSuffix}`;
-      otherLines = [al.l.length > 1 ? al.l[1]! : ''];
+      usedLines[usedLines.length - 1] = `${al.l[0] || ''}${overflowSuffix}`;
+      otherLines = [al.l.length > 1 ? al.l[1] || '' : ''];
     } else {
       otherLines = [''];
     }
+
     // Re-assemble the remaining text
     let i: number;
     const n = lines.length;
     let j = 0;
     const m = linesInfo.n.length;
-    for (i = computedMaxLines; i < n; i++) {
+    for (i = maxLines; i < n; i++) {
       otherLines[j] += `${otherLines[j] ? ' ' : ''}${lines[i] ?? ''}`;
       if (i + 1 < m && linesInfo.n[i + 1] !== undefined) {
         j++;
@@ -223,172 +404,186 @@ const renderText = (
     lines = usedLines;
   }
 
-  // Calculate text width
+  // Calculate line widths using the dedicated measuring context
   let maxLineWidth = 0;
   const lineWidths: number[] = [];
   for (let i = 0; i < lines.length; i++) {
     const lineWidth =
-      measureText(context, lines[i]!, letterSpacing) +
+      measureText(measureContext, lines[i] || '', letterSpacing) +
       (i === 0 ? textIndent : 0);
     lineWidths.push(lineWidth);
     maxLineWidth = Math.max(maxLineWidth, lineWidth);
   }
 
-  if (w === 0) {
-    width = maxLineWidth + paddingLeft + paddingRight;
-    innerWidth = maxLineWidth;
-  }
-  if (
-    wordWrap === true &&
-    width > maxLineWidth &&
-    textAlign === 'left' &&
-    lines.length === 1
-  ) {
-    width = maxLineWidth + paddingLeft + paddingRight;
+  const result = {
+    lines,
+    lineWidths,
+    maxLineWidth,
+    remainingText,
+    moreTextLines,
+  };
+
+  // Cache the result
+  layoutCache.set(cacheKey, result);
+
+  return result;
+}
+
+/**
+ * Calculate text dimensions based on layout
+ */
+function calculateTextDimensions(
+  layout: {
+    lines: string[];
+    lineWidths: number[];
+    maxLineWidth: number;
+  },
+  paddingLeft: number,
+  paddingRight: number,
+  textBaseline: TextBaseline,
+  fontSize: number,
+  lineHeight: number,
+  offsetY: number,
+  initialWidth: number,
+  initialHeight: number,
+  wordWrap: boolean,
+  textAlign: string,
+): { width: number; height: number } {
+  let width = initialWidth;
+  let height = initialHeight;
+
+  // Calculate width
+  if (initialWidth === 0) {
+    width = layout.maxLineWidth + paddingLeft + paddingRight;
   }
 
+  // Adjust width for single-line left-aligned wrapped text
+  if (
+    wordWrap === true &&
+    width > layout.maxLineWidth &&
+    textAlign === 'left' &&
+    layout.lines.length === 1
+  ) {
+    width = layout.maxLineWidth + paddingLeft + paddingRight;
+  }
+
+  // Calculate height if not provided
   if (height === 0) {
     height = calcHeight(
       textBaseline,
       fontSize,
       lineHeight,
-      lines.length,
+      layout.lines.length,
       offsetY,
     );
   }
 
-  if (offsetY === null) {
-    offsetY = fontSize;
-  }
+  return { width, height };
+}
 
-  canvas.width = Math.min(
-    Math.ceil(width + textRenderIssueMargin),
-    MAX_TEXTURE_DIMENSION,
-  );
-  canvas.height = Math.min(Math.ceil(height), MAX_TEXTURE_DIMENSION);
-
-  context.font = `${fontStyle} ${fontSize}px ${fontFamily}`;
-  context.textBaseline = textBaseline;
-
-  if (fontSize >= 128) {
-    context.globalAlpha = 0.01;
-    context.fillRect(0, 0, 0.01, 0.01);
-    context.globalAlpha = 1.0;
-  }
-
-  //TODO never happens see notes below
-  // if (cutSx || cutSy) {
-  //   context.translate(-renderInfo.cutSx, -renderInfo.cutSy);
-  // }
-
-  let linePositionX: number;
-  let linePositionY: number;
+/**
+ * Calculate drawing positions for text lines
+ */
+function calculateDrawPositions(
+  lines: string[],
+  lineWidths: number[],
+  textAlign: string,
+  verticalAlign: string,
+  innerWidth: number,
+  paddingLeft: number,
+  textIndent: number,
+  lineHeight: number,
+  metrics: NormalizedFontMetrics,
+  fontSize: number,
+): LineType[] {
   const drawLines: LineType[] = [];
   const ascenderPx = metrics.ascender * fontSize;
   const bareLineHeightPx = (metrics.ascender - metrics.descender) * fontSize;
 
   for (let i = 0, n = lines.length; i < n; i++) {
-    linePositionX = i === 0 ? textIndent : 0;
-    linePositionY = i * lineHeight + ascenderPx;
+    let linePositionX = i === 0 ? textIndent : 0;
+    let linePositionY = i * lineHeight + ascenderPx;
+
+    // Vertical alignment
     if (verticalAlign == 'middle') {
       linePositionY += (lineHeight - bareLineHeightPx) / 2;
     } else if (verticalAlign == 'bottom') {
       linePositionY += lineHeight - bareLineHeightPx;
     }
-    if (textAlign === 'right') {
-      linePositionX += innerWidth - lineWidths[i]!;
-    } else if (textAlign === 'center') {
-      linePositionX += (innerWidth - lineWidths[i]!) / 2;
+
+    // Horizontal alignment
+    const lineWidth = lineWidths[i];
+    if (lineWidth !== undefined) {
+      if (textAlign === 'right') {
+        linePositionX += innerWidth - lineWidth;
+      } else if (textAlign === 'center') {
+        linePositionX += (innerWidth - lineWidth) / 2;
+      }
     }
+
     linePositionX += paddingLeft;
-    drawLines.push({
-      text: lines[i]!,
-      x: linePositionX,
-      y: linePositionY,
-      w: lineWidths[i]!,
-    });
+
+    const lineText = lines[i];
+    if (lineText !== undefined) {
+      drawLines.push({
+        text: lineText,
+        x: linePositionX,
+        y: linePositionY,
+        w: lineWidth || 0,
+      });
+    }
   }
 
-  // if (highlight === true) {
-  //   const color = highlightColor;
-  //   const hlHeight = highlightHeight * precision || fontSize * 1.5;
-  //   const offset = highlightOffset * precision;
-  //   const hlPaddingLeft =
-  //     highlightPaddingLeft !== null
-  //       ? highlightPaddingLeft * precision
-  //       : paddingLeft;
-  //   const hlPaddingRight =
-  //     highlightPaddingRight !== null
-  //       ? highlightPaddingRight * precision
-  //       : paddingRight;
-  //   context.fillStyle = normalizeCanvasColor(color);
-  //   for (let i = 0; i < drawLines.length; i++) {
-  //     const drawLine = drawLines[i]!;
-  //     context.fillRect(
-  //       drawLine.x - hlPaddingLeft,
-  //       drawLine.y - offsetY + offset,
-  //       drawLine.w + hlPaddingRight + hlPaddingLeft,
-  //       hlHeight,
-  //     );
-  //   }
-  // }
+  return drawLines;
+}
 
-  // if (shadow === true) {
-  //   context.shadowColor = normalizeCanvasColor(renderInfo.shadowColor);
-  //   context.shadowOffsetX = renderInfo.shadowOffsetX * precision;
-  //   context.shadowOffsetY = renderInfo.shadowOffsetY * precision;
-  //   context.shadowBlur = renderInfo.shadowBlur * precision;
-  // }
+/**
+ * Render text lines to canvas
+ */
+function renderTextToCanvas(
+  context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  drawLines: LineType[],
+  letterSpacing: number,
+  textColor: number,
+  fontStyle: string,
+  fontSize: number,
+  fontFamily: string,
+): void {
+  assertTruthy(measureContext, 'Measure context is not available');
 
   context.fillStyle = normalizeCanvasColor(textColor);
+
+  // Sync font settings to measure context if we need to use it for letter spacing
+  if (letterSpacing > 0) {
+    measureContext.font = `${fontStyle} ${fontSize}px ${fontFamily}`;
+  }
+
   for (let i = 0, n = drawLines.length; i < n; i++) {
-    const drawLine = drawLines[i]!;
-    if (letterSpacing === 0) {
-      context.fillText(drawLine.text, drawLine.x, drawLine.y);
-    } else {
-      const textSplit = drawLine.text.split('');
-      let x = drawLine.x;
-      for (let i = 0, j = textSplit.length; i < j; i++) {
-        context.fillText(textSplit[i]!, x, drawLine.y);
-        x += measureText(context, textSplit[i]!, letterSpacing);
+    const drawLine = drawLines[i];
+    if (drawLine) {
+      if (letterSpacing === 0) {
+        context.fillText(drawLine.text, drawLine.x, drawLine.y);
+      } else {
+        const textSplit = drawLine.text.split('');
+        let x = drawLine.x;
+        for (let j = 0, k = textSplit.length; j < k; j++) {
+          const char = textSplit[j];
+          if (char) {
+            context.fillText(char, x, drawLine.y);
+            // Use the dedicated measuring context for letter spacing calculations
+            x += measureText(measureContext, char, letterSpacing);
+          }
+        }
       }
     }
   }
+}
 
-  //never happens
-  // if(shadow === true) {
-  //   context.shadowColor = DEFAULT_SHADOW_VALUES.color;
-  //   context.shadowOffsetX = DEFAULT_SHADOW_VALUES.offsetX;
-  //   context.shadowOffsetY = DEFAULT_SHADOW_VALUES.offsetY;
-  //   context.shadowBlur = DEFAULT_SHADOW_VALUES.blur;
-  // }
-
-  //never happens
-  // if (renderInfo.cutSx || renderInfo.cutSy) {
-  //   context.translate(renderInfo.cutSx, renderInfo.cutSy);
-  // }
-
-  /**
-   * TO DO notes to check out
-   * -  textOverflow
-   * - maxHeight
-   * - padding left / right ? always 0
-   * - cutSx, Sy, Ex, Ey always 0
-   * - textIndent always 0
-   * - lines override ?
-   * - textRenderIssueMargin always 0
-   */
-
-  let imageData: ImageData | null = null;
-  if (canvas.width > 0 && canvas.height > 0) {
-    imageData = context.getImageData(0, 0, canvas.width, canvas.height);
-  }
-
-  return {
-    imageData,
-    width: width,
-    height: lineHeight * lines.length,
-  };
+/**
+ * Clear layout cache for memory management
+ */
+const clearLayoutCache = (): void => {
+  layoutCache.clear();
 };
 
 /**
@@ -418,6 +613,7 @@ const CanvasTextRenderer = {
   addQuads,
   renderQuads,
   init,
+  clearLayoutCache,
 };
 
 export default CanvasTextRenderer;


### PR DESCRIPTION
6x slowdown:

with this PR: create: 268.96ms ±18.12
without: create: 743.60ms ±38.26

for reference:
beta 9: create: 426.59ms ±40.61

This does include `{ willReadFrequently: true }` as it did have a serious impact on perf in Chrome - we will need to test on a WPE device to get the impact on a real device. I'd imagine GPU vs CPU rendering to be of a bigger impact there.