### PR TITLE
fix: update texture cleanup logic

### DIFF
--- a/src/core/CoreTextureManager.ts
+++ b/src/core/CoreTextureManager.ts
@@ -427,7 +427,7 @@ export class CoreTextureManager extends EventEmitter {
       this.stage.txMemManager.criticalCleanupRequested === true
     ) {
       // we're at a critical memory threshold, don't upload textures
-      this.enqueueUploadTexture(texture);
+      texture.setState('failed');
       return;
     }
 

--- a/src/core/TextureMemoryManager.ts
+++ b/src/core/TextureMemoryManager.ts
@@ -239,7 +239,10 @@ export class TextureMemoryManager {
 
       // Skip textures that are in transitional states - we only want to clean up
       // textures that are in a stable state (loaded, failed, or freed)
-      if (Texture.TRANSITIONAL_TEXTURE_STATES.includes(texture.state)) {
+      if (
+        texture.state === 'initial' ||
+        Texture.TRANSITIONAL_TEXTURE_STATES.includes(texture.state)
+      ) {
         continue;
       }
 
@@ -272,46 +275,26 @@ export class TextureMemoryManager {
     // Free non-renderable textures until we reach the target threshold
     const memTarget = critical ? this.criticalThreshold : this.targetThreshold;
 
-    // sort by renderability
-    const filteredAndSortedTextures: Texture[] = [];
-    const textures = [...this.loadedTextures.keys()];
-    for (let i = 0; i < textures.length; i++) {
-      const texture = textures[i];
+    // Filter for textures that are candidates for cleanup
+    // note: This is an expensive operation, so we only do it in deep cleanup
+    const cleanupCandidates = [...this.loadedTextures.keys()].filter(
+      (texture) => {
+        return (
+          (texture.type === TextureType.image ||
+            texture.type === TextureType.noise ||
+            texture.type === TextureType.renderToTexture) &&
+          texture.renderable === false &&
+          texture.preventCleanup === false &&
+          texture.state !== 'initial' &&
+          !Texture.TRANSITIONAL_TEXTURE_STATES.includes(texture.state)
+        );
+      },
+    );
+
+    while (this.memUsed >= memTarget && cleanupCandidates.length > 0) {
+      const texture = cleanupCandidates.shift();
       if (texture === undefined) {
         continue;
-      }
-
-      if (
-        texture.type === TextureType.image ||
-        texture.type === TextureType.noise ||
-        texture.type === TextureType.renderToTexture
-      ) {
-        if (texture.renderable === true) {
-          filteredAndSortedTextures.push(texture);
-        } else {
-          filteredAndSortedTextures.unshift(texture);
-        }
-      }
-    }
-
-    while (this.memUsed >= memTarget && filteredAndSortedTextures.length > 0) {
-      const texture = filteredAndSortedTextures.shift();
-      if (texture === undefined) {
-        continue;
-      }
-
-      if (texture.preventCleanup === true) {
-        continue;
-      }
-
-      if (texture.renderable === true) {
-        break;
-      }
-
-      // Skip textures that are in transitional states - we only want to clean up
-      // textures that are in a stable state (loaded, failed, or freed)
-      if (Texture.TRANSITIONAL_TEXTURE_STATES.includes(texture.state)) {
-        break;
       }
 
       this.destroyTexture(texture);


### PR DESCRIPTION
# Warning change in behaviour

Previously texture that couldn't be uploaded due to `doNotExceedCriticalThreshold: true` would be re-added in the queue, resulting in "stuck" textures.

This change will put textures to `failed` if they can't be uploaded due to `doNotExceedCriticalThreshold: true`. This will allow the engine/application to handle the failure and re-attempt to upload the texture (or apply fallback logic in the app). 

The setting `doNotExceedCriticalThreshold` should only be used when the memory is extremely tight, otherwise setting it to `false` and a lower threshold to have a little headroom will mimick the same behaviour as Lightning 2.

Other changes:
* Doing a sort to then break at the first renderable is inefficient, its faster to just filter once and only clean whats passed in the filter
* Add initial to a transitional state, so that freshly created textures won't get deleted.
* Set textures that we can't upload to `failed` if `doNotExceedCriticalThreshold: true`
