### PR TITLE
reinstate w/h shorthand properties

### DIFF
--- a/examples/tests/width-height-shortcuts.ts
+++ b/examples/tests/width-height-shortcuts.ts
@@ -1,0 +1,134 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ExampleSettings } from '../common/ExampleSettings.js';
+
+export async function automation(settings: ExampleSettings) {
+  await test(settings);
+  await settings.snapshot();
+}
+
+/**
+ * Tests that w/h shorthand properties work identically to width/height
+ * on CoreNodes
+ *
+ * @param settings
+ * @returns
+ */
+export default async function test(settings: ExampleSettings) {
+  const { renderer, testRoot } = settings;
+
+  // Set test area
+  testRoot.width = 600;
+  testRoot.height = 270;
+  testRoot.color = 0x222222ff;
+
+  // Create header text
+  renderer.createTextNode({
+    x: 20,
+    y: 20,
+    color: 0xffffffff,
+    fontFamily: 'Ubuntu',
+    fontSize: 24,
+    text: 'Width/Height vs W/H Shorthand Test (CoreNodes)',
+    parent: testRoot,
+  });
+
+  // Test CoreNodes - using width/height
+  const nodeWithLongProps = renderer.createNode({
+    x: 50,
+    y: 80,
+    width: 120,
+    height: 80,
+    color: 0xff0000ff,
+    parent: testRoot,
+  });
+
+  // Test CoreNodes - using w/h shorthand
+  renderer.createNode({
+    x: 200,
+    y: 80,
+    w: 120,
+    h: 80,
+    color: 0x00ff00ff,
+    parent: testRoot,
+  });
+
+  // Additional test with different sizes
+  renderer.createNode({
+    x: 350,
+    y: 80,
+    width: 80,
+    height: 120,
+    color: 0x0080ffff,
+    parent: testRoot,
+  });
+
+  renderer.createNode({
+    x: 450,
+    y: 80,
+    w: 80,
+    h: 120,
+    color: 0xff8000ff,
+    parent: testRoot,
+  });
+
+  // Label for CoreNodes
+  renderer.createTextNode({
+    x: 50,
+    y: 170,
+    color: 0xffffffff,
+    fontFamily: 'Ubuntu',
+    fontSize: 14,
+    text: 'width: 120\nheight: 80',
+    parent: testRoot,
+  });
+
+  renderer.createTextNode({
+    x: 200,
+    y: 170,
+    color: 0xffffffff,
+    fontFamily: 'Ubuntu',
+    fontSize: 14,
+    text: 'w: 120\nh: 80',
+    parent: testRoot,
+  });
+
+  renderer.createTextNode({
+    x: 350,
+    y: 210,
+    color: 0xffffffff,
+    fontFamily: 'Ubuntu',
+    fontSize: 14,
+    text: 'width: 80\nheight: 120',
+    parent: testRoot,
+  });
+
+  renderer.createTextNode({
+    x: 450,
+    y: 210,
+    color: 0xffffffff,
+    fontFamily: 'Ubuntu',
+    fontSize: 14,
+    text: 'w: 80\nh: 120',
+    parent: testRoot,
+  });
+
+  return Promise.resolve();
+}

--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -231,16 +231,26 @@ export interface CoreNodeProps {
   y: number;
   /**
    * The width of the Node.
+   * @warning This will be deprecated in favor of `w` and `h` properties in the future.
    *
    * @default `0`
    */
   width: number;
   /**
    * The height of the Node.
+   * @warning This will be deprecated in favor of `w` and `h` properties in the future.
    *
    * @default `0`
    */
   height: number;
+  /**
+   * Short width of the Node.
+   */
+  w?: number;
+  /**
+   * Short height of the Node.
+   */
+  h?: number;
   /**
    * The alpha opacity of the Node.
    *
@@ -1797,6 +1807,28 @@ export class CoreNode extends EventEmitter {
     }
   }
 
+  get w(): number {
+    return this.props.width;
+  }
+
+  set w(value: number) {
+    if (this.props.width !== value) {
+      this.textureCoords = undefined;
+      this.props.width = value;
+      this.setUpdateType(UpdateType.Local);
+
+      if (this.props.rtt === true) {
+        this.framebufferDimensions!.width = value;
+        this.texture = this.stage.txManager.createTexture(
+          'RenderTexture',
+          this.framebufferDimensions!,
+        );
+
+        this.setUpdateType(UpdateType.RenderTexture);
+      }
+    }
+  }
+
   get width(): number {
     return this.props.width;
   }
@@ -1809,6 +1841,28 @@ export class CoreNode extends EventEmitter {
 
       if (this.props.rtt === true) {
         this.framebufferDimensions!.width = value;
+        this.texture = this.stage.txManager.createTexture(
+          'RenderTexture',
+          this.framebufferDimensions!,
+        );
+
+        this.setUpdateType(UpdateType.RenderTexture);
+      }
+    }
+  }
+
+  get h(): number {
+    return this.props.height;
+  }
+
+  set h(value: number) {
+    if (this.props.height !== value) {
+      this.textureCoords = undefined;
+      this.props.height = value;
+      this.setUpdateType(UpdateType.Local);
+
+      if (this.props.rtt === true) {
+        this.framebufferDimensions!.height = value;
         this.texture = this.stage.txManager.createTexture(
           'RenderTexture',
           this.framebufferDimensions!,

--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -800,6 +800,9 @@ export class Stage {
     const mount = props.mount ?? 0;
     const pivot = props.pivot ?? 0.5;
 
+    const width = props.w ?? props.width ?? 0;
+    const height = props.h ?? props.height ?? 0;
+
     const data = this.options.inspector
       ? santizeCustomDataMap(props.data ?? {})
       : {};
@@ -807,8 +810,8 @@ export class Stage {
     return {
       x: props.x ?? 0,
       y: props.y ?? 0,
-      width: props.width ?? 0,
-      height: props.height ?? 0,
+      width,
+      height,
       alpha: props.alpha ?? 1,
       autosize: props.autosize ?? false,
       boundsMargin: props.boundsMargin ?? null,


### PR DESCRIPTION
Originally L3 renderer had w/h as short hand properties - these got moved to `width` - `height`. This is reinstates the original `w` and `h` properties to match how we use them upstream.

`width` and `height` are still available but with a deprecation warning.

Events still report `width` / `height` for dimensions, do we want those to be updated as well @michielvandergeest ?