### PR TITLE
fix: infinite retry loops on unresolved image props

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -1466,8 +1466,16 @@ export class CoreNode extends EventEmitter {
     }
 
     if (this.texture !== null) {
-      needsTextureOwnership = true;
+      // preemptive check for failed textures this will mark the current node as non-renderable
+      // and will prevent further checks until the texture is reloaded or retry is reset on the texture
+      if (this.texture.retryCount > this.texture.maxRetryCount) {
+        // texture has failed to load, we cannot render
+        this.updateTextureOwnership(false);
+        this.setRenderable(false);
+        return;
+      }
 
+      needsTextureOwnership = true;
       // we're only renderable if the texture state is loaded
       newIsRenderable = this.texture.state === 'loaded';
     } else if (

--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -138,7 +138,7 @@ export class ImageTexture extends Texture {
     const resolvedProps = ImageTexture.resolveDefaults(props);
     super(txManager);
     this.props = resolvedProps;
-    this.maxRetryCount = props.maxRetryCount as number;
+    this.maxRetryCount = resolvedProps.maxRetryCount ?? 5;
   }
 
   hasAlphaChannel(mimeType: string) {

--- a/src/core/textures/Texture.ts
+++ b/src/core/textures/Texture.ts
@@ -162,7 +162,7 @@ export abstract class Texture extends EventEmitter {
   public memUsed = 0;
 
   public retryCount = 0;
-  public maxRetryCount: number | null = null;
+  public maxRetryCount: number = 5;
 
   /**
    * Timestamp when texture was created (for startup grace period)
@@ -292,11 +292,7 @@ export abstract class Texture extends EventEmitter {
   }
 
   load(): void {
-    if (this.maxRetryCount === null && this.retryCount > 0) {
-      return;
-    }
-
-    if (this.maxRetryCount !== null && this.retryCount > this.maxRetryCount) {
+    if (this.retryCount > this.maxRetryCount) {
       // We've exceeded the max retry count, do not attempt to load again
       return;
     }


### PR DESCRIPTION
mistakes where made

```
 this.maxRetryCount = props.maxRetryCount as number;
```

Setting the maxRetryCount from an unresolved `props` instead of `resolvedProps` isn't a great idea. This could lead to `maxRetryCount` is `undefined` and it goes in an infinite loop.

Also put the stop to check for retries up in the `CoreNode` to toggle entire node visibility and take it out of the render tree entirely (== cleaner)