### PR TITLE
refactor(textures): replace defrag system with a slot reuse system

### DIFF
--- a/src/core/platform.ts
+++ b/src/core/platform.ts
@@ -66,10 +66,6 @@ export const startLoop = (stage: Stage) => {
         stage.txMemManager.cleanup();
       }
 
-      if (stage.txMemManager.checkDefrag() === true) {
-        stage.txMemManager.defragment();
-      }
-
       stage.flushFrameEvents();
       return;
     }


### PR DESCRIPTION
The defrag system was introduced to avoid endlessly growing the `this.loadedTextures` however this introduced:
* Additional function calls
* Idle processing
* Potential race conditions when the defrag ran inbetween operations (like 1 frame idle)

Having a memory allocation with potentially lots of `null` items isn't going to affect memory usage much. Since we want low-latency, zero-copy, texture memory placement this PR replaces the defrag system with a Slot Reuse system.

It simply does:
* On texture delete, `null` the place in the texture array
* On texture creation, pick a previously `null` spot or `append` if there are none

This avoids potential race conditions and the extra overhead of a defragmentation system while keeping the textures neatly packed at the beginning.

The only downside is the `this.loadedTextures` array never shrinks, but this is deemed neglible because it will be just `null` entries and only be as large as the largest scene supported while rendering in L3. Which is a tradeoff against zero copy low latency texture memory allocation.