### PR TITLE
Fix failed event on retry exhausted

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -918,10 +918,16 @@ export class CoreNode extends EventEmitter {
       this.notifyParentRTTOfUpdate();
     }
 
-    this.emit('failed', {
-      type: 'texture',
-      error,
-    } satisfies NodeTextureFailedPayload);
+    // only emit failed outward if we've exhausted all retry attempts
+    if (
+      this.texture !== null &&
+      this.texture.retryCount > this.texture.maxRetryCount
+    ) {
+      this.emit('failed', {
+        type: 'texture',
+        error,
+      } satisfies NodeTextureFailedPayload);
+    }
   };
 
   private onTextureFreed: TextureFreedEventHandler = () => {

--- a/src/core/textures/SubTexture.ts
+++ b/src/core/textures/SubTexture.ts
@@ -137,6 +137,8 @@ export class SubTexture extends Texture {
   };
 
   private onParentTxFailed: TextureFailedEventHandler = (target, error) => {
+    //decrement with 1 because in the failed state it will do +1 again.
+    this.retryCount = this.parentTexture.retryCount - 1;
     this.forwardParentTxState('failed', error);
   };
 


### PR DESCRIPTION
On send the failed event from the `CoreNode` when the `retry` count has exhausted and we've stopped retrying.