### PR TITLE
Add maxRetryCount setting for texture loading

### DIFF
--- a/src/core/CoreTextureManager.ts
+++ b/src/core/CoreTextureManager.ts
@@ -64,6 +64,7 @@ export interface TextureManagerDebugInfo {
 export interface TextureManagerSettings {
   numImageWorkers: number;
   createImageBitmapSupport: 'auto' | 'basic' | 'options' | 'full';
+  maxRetryCount: number;
 }
 
 export type ResizeModeOptions =
@@ -192,6 +193,7 @@ export class CoreTextureManager extends EventEmitter {
    */
   txConstructors: Partial<TextureMap> = {};
 
+  public maxRetryCount: number;
   private priorityQueue: Array<Texture> = [];
   private uploadTextureQueue: Array<Texture> = [];
   private initialized = false;
@@ -230,9 +232,11 @@ export class CoreTextureManager extends EventEmitter {
   constructor(stage: Stage, settings: TextureManagerSettings) {
     super();
 
-    const { numImageWorkers, createImageBitmapSupport } = settings;
+    const { numImageWorkers, createImageBitmapSupport, maxRetryCount } =
+      settings;
     this.stage = stage;
     this.numImageWorkers = numImageWorkers;
+    this.maxRetryCount = maxRetryCount;
 
     if (createImageBitmapSupport === 'auto') {
       validateCreateImageBitmap()

--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -85,6 +85,7 @@ export interface StageOptions {
   strictBounds: boolean;
   textureProcessingTimeLimit: number;
   createImageBitmapSupport: 'auto' | 'basic' | 'options' | 'full';
+  maxRetryCount: number;
 }
 
 export type StageFpsUpdateHandler = (
@@ -174,6 +175,7 @@ export class Stage {
       renderEngine,
       fontEngines,
       createImageBitmapSupport,
+      maxRetryCount,
     } = options;
 
     this.eventBus = options.eventBus;
@@ -184,6 +186,7 @@ export class Stage {
     this.txManager = new CoreTextureManager(this, {
       numImageWorkers,
       createImageBitmapSupport,
+      maxRetryCount,
     });
 
     // Wait for the Texture Manager to initialize

--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -138,7 +138,8 @@ export class ImageTexture extends Texture {
     const resolvedProps = ImageTexture.resolveDefaults(props);
     super(txManager);
     this.props = resolvedProps;
-    this.maxRetryCount = resolvedProps.maxRetryCount ?? 5;
+    this.maxRetryCount =
+      resolvedProps.maxRetryCount ?? this.txManager.maxRetryCount;
   }
 
   hasAlphaChannel(mimeType: string) {
@@ -407,7 +408,7 @@ export class ImageTexture extends Texture {
       sy: props.sy ?? null,
       sw: props.sw ?? null,
       sh: props.sh ?? null,
-      maxRetryCount: props.maxRetryCount ?? 5,
+      maxRetryCount: props.maxRetryCount ?? null,
     };
   }
 

--- a/src/core/textures/Texture.ts
+++ b/src/core/textures/Texture.ts
@@ -162,7 +162,7 @@ export abstract class Texture extends EventEmitter {
   public memUsed = 0;
 
   public retryCount = 0;
-  public maxRetryCount: number = 5;
+  public maxRetryCount: number;
 
   /**
    * Timestamp when texture was created (for startup grace period)
@@ -182,6 +182,7 @@ export abstract class Texture extends EventEmitter {
 
   constructor(protected txManager: CoreTextureManager) {
     super();
+    this.maxRetryCount = txManager.maxRetryCount;
   }
 
   get dimensions(): Dimensions | null {

--- a/src/main-api/Renderer.ts
+++ b/src/main-api/Renderer.ts
@@ -329,6 +329,20 @@ export interface RendererMainSettings {
    * @defaultValue `full`
    */
   createImageBitmapSupport?: 'auto' | 'basic' | 'options' | 'full';
+
+  /**
+   * Number of times to retry loading a failed texture
+   *
+   * @remarks
+   * When a texture fails to load, Lightning will retry up to this many times
+   * before permanently giving up. Each retry will clear the texture ownership
+   * and then re-establish it to trigger a new load attempt.
+   *
+   * Set to null to disable retries. Set to 0 to always try once and never retry.
+   * This is typically only used on ImageTexture instances.
+   *
+   */
+  maxRetryCount?: number;
 }
 
 /**
@@ -432,6 +446,7 @@ export class RendererMain extends EventEmitter {
       textureProcessingTimeLimit: settings.textureProcessingTimeLimit || 42,
       canvas: settings.canvas || document.createElement('canvas'),
       createImageBitmapSupport: settings.createImageBitmapSupport || 'full',
+      maxRetryCount: settings.maxRetryCount ?? 5,
     };
     this.settings = resolvedSettings;
 
@@ -477,6 +492,7 @@ export class RendererMain extends EventEmitter {
       strictBounds: this.settings.strictBounds,
       textureProcessingTimeLimit: this.settings.textureProcessingTimeLimit,
       createImageBitmapSupport: this.settings.createImageBitmapSupport,
+      maxRetryCount: this.settings.maxRetryCount,
     });
 
     // Extract the root node


### PR DESCRIPTION
Introduce a maxRetryCount renderer setting to control the number of retry attempts for loading failed textures.