### PR TITLE
Add 'failedm' state for texture memory failure handling

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -857,6 +857,9 @@ export class CoreNode extends EventEmitter {
       } else if (texture.state === 'failed') {
         assertTruthy(texture.error);
         this.onTextureFailed(texture, texture.error);
+      } else if (texture.state === 'failedm') {
+        assertTruthy(texture.error);
+        this.onTextureFailed(texture, texture.error);
       } else if (texture.state === 'freed') {
         this.onTextureFreed(texture);
       }
@@ -921,6 +924,7 @@ export class CoreNode extends EventEmitter {
     // only emit failed outward if we've exhausted all retry attempts
     if (
       this.texture !== null &&
+      this.texture.state === 'failedm' &&
       this.texture.retryCount > this.texture.maxRetryCount
     ) {
       this.emit('failed', {

--- a/src/core/CoreTextureManager.ts
+++ b/src/core/CoreTextureManager.ts
@@ -421,7 +421,7 @@ export class CoreTextureManager extends EventEmitter {
     ) {
       // we're at a critical memory threshold, don't upload textures
       texture.setState(
-        'failed',
+        'failedm',
         new TextureError(TextureErrorCode.MEMORY_THRESHOLD_EXCEEDED),
       );
       return;

--- a/src/core/renderers/webgl/WebGlCoreCtxTexture.ts
+++ b/src/core/renderers/webgl/WebGlCoreCtxTexture.ts
@@ -129,6 +129,7 @@ export class WebGlCoreCtxTexture extends CoreContextTexture {
       this.state = 'loaded';
       this._w = width;
       this._h = height;
+      this.textureSource.retryCount = 1;
       // Update the texture source's width and height so that it can be used
       // for rendering.
       this.textureSource.setState('loaded', { width, height });

--- a/src/main-api/Inspector.ts
+++ b/src/main-api/Inspector.ts
@@ -310,6 +310,7 @@ export class Inspector {
       {
         onLoaded: () => void;
         onFailed: () => void;
+        onFailedm: () => void;
         onFreed: () => void;
       }
     >();
@@ -358,6 +359,17 @@ export class Inspector {
           }
           this.updateTextureAttributes(div, texture);
         };
+        const onFailedm = () => {
+          const metrics = this.textureMetrics.get(texture);
+          if (metrics) {
+            metrics.previousState =
+              metrics.previousState !== texture.state
+                ? metrics.previousState
+                : 'loading';
+            metrics.failedCount++;
+          }
+          this.updateTextureAttributes(div, texture);
+        };
         const onFreed = () => {
           const metrics = this.textureMetrics.get(texture);
           if (metrics) {
@@ -372,9 +384,15 @@ export class Inspector {
 
         texture.on('loaded', onLoaded);
         texture.on('failed', onFailed);
+        texture.on('failedm', onFailedm);
         texture.on('freed', onFreed);
 
-        textureListeners.set(texture, { onLoaded, onFailed, onFreed });
+        textureListeners.set(texture, {
+          onLoaded,
+          onFailed,
+          onFailedm,
+          onFreed,
+        });
       }
     };
     // Define traps for each property in knownProperties
@@ -426,6 +444,7 @@ export class Inspector {
         textureListeners.forEach((listeners, texture) => {
           texture.off('loaded', listeners.onLoaded);
           texture.off('failed', listeners.onFailed);
+          texture.off('failedm', listeners.onFailedm);
           texture.off('freed', listeners.onFreed);
           // Clean up metrics for this texture
           this.textureMetrics.delete(texture);


### PR DESCRIPTION
Introduce a new 'failedm' state to manage texture loading failures due to memory constraints, enhancing error handling and retry logic.