### PR TITLE
added nodeCoordinates to shaders

### DIFF
--- a/src/core/lib/WebGlContextWrapper.ts
+++ b/src/core/lib/WebGlContextWrapper.ts
@@ -704,6 +704,53 @@ export class WebGlContextWrapper {
   }
 
   /**
+   * Returns object with Attribute names as key and numbers as location values
+   *
+   * @param program
+   * @returns object with numbers
+   */
+  getUniformLocations(
+    program: WebGLProgram,
+  ): Record<string, WebGLUniformLocation> {
+    const gl = this.gl;
+    const length = gl.getProgramParameter(
+      program,
+      gl.ACTIVE_UNIFORMS,
+    ) as number;
+    const result = {} as Record<string, WebGLUniformLocation>;
+    for (let i = 0; i < length; i++) {
+      const info = gl.getActiveUniform(program, i) as WebGLActiveInfo;
+      //remove bracket + value from uniform name;
+      let name = info.name.replace(/\[.*?\]/g, '');
+      result[name] = gl.getUniformLocation(
+        program,
+        name,
+      ) as WebGLUniformLocation;
+    }
+    return result;
+  }
+
+  /**
+   * Returns object with Attribute names as key and numbers as location values
+   * @param program
+   * @returns object with numbers
+   */
+  getAttributeLocations(program: WebGLProgram): string[] {
+    const gl = this.gl;
+    const length = gl.getProgramParameter(
+      program,
+      gl.ACTIVE_ATTRIBUTES,
+    ) as number;
+
+    const result: string[] = [];
+    for (let i = 0; i < length; i++) {
+      const { name } = gl.getActiveAttrib(program, i) as WebGLActiveInfo;
+      result[gl.getAttribLocation(program, name)] = name;
+    }
+    return result;
+  }
+
+  /**
    * ```
    * gl.useProgram(program);
    * ```

--- a/src/core/renderers/webgl/WebGlCoreRenderOp.ts
+++ b/src/core/renderers/webgl/WebGlCoreRenderOp.ts
@@ -88,7 +88,7 @@ export class WebGlCoreRenderOp extends CoreRenderOp {
     shader.bindRenderOp(this, shaderProps);
 
     // TODO: Reduce calculations required
-    const quadIdx = (this.bufferIdx / 24) * 6 * 2;
+    const quadIdx = (this.bufferIdx / 32) * 6 * 2;
 
     // Clipping
     if (this.clippingRect.valid) {

--- a/src/core/renderers/webgl/WebGlCoreRenderer.ts
+++ b/src/core/renderers/webgl/WebGlCoreRenderer.ts
@@ -136,7 +136,7 @@ export class WebGlCoreRenderer extends CoreRenderer {
     this.defaultShader = this.defShaderCtrl.shader as WebGlCoreShader;
     const quadBuffer = glw.createBuffer();
     assertTruthy(quadBuffer);
-    const stride = 6 * Float32Array.BYTES_PER_ELEMENT;
+    const stride = 8 * Float32Array.BYTES_PER_ELEMENT;
     this.quadBufferCollection = new BufferCollection([
       {
         buffer: quadBuffer,
@@ -172,6 +172,14 @@ export class WebGlCoreRenderer extends CoreRenderer {
             normalized: false,
             stride,
             offset: 5 * Float32Array.BYTES_PER_ELEMENT,
+          },
+          a_nodeCoordinate: {
+            name: 'a_nodeCoordinate',
+            size: 2,
+            type: glw.FLOAT,
+            normalized: false,
+            stride,
+            offset: 6 * Float32Array.BYTES_PER_ELEMENT,
           },
         },
       },
@@ -355,6 +363,8 @@ export class WebGlCoreRenderer extends CoreRenderer {
       fQuadBuffer[bufferIdx++] = texCoordY1; // texCoordY
       uiQuadBuffer[bufferIdx++] = params.colorTl; // color
       fQuadBuffer[bufferIdx++] = textureIdx; // texIndex
+      fQuadBuffer[bufferIdx++] = 0;
+      fQuadBuffer[bufferIdx++] = 0;
 
       // Upper-Right
       fQuadBuffer[bufferIdx++] = params.renderCoords.x2;
@@ -363,6 +373,8 @@ export class WebGlCoreRenderer extends CoreRenderer {
       fQuadBuffer[bufferIdx++] = texCoordY1;
       uiQuadBuffer[bufferIdx++] = params.colorTr;
       fQuadBuffer[bufferIdx++] = textureIdx;
+      fQuadBuffer[bufferIdx++] = 1;
+      fQuadBuffer[bufferIdx++] = 0;
 
       // Lower-Left
       fQuadBuffer[bufferIdx++] = params.renderCoords.x4;
@@ -371,6 +383,8 @@ export class WebGlCoreRenderer extends CoreRenderer {
       fQuadBuffer[bufferIdx++] = texCoordY2;
       uiQuadBuffer[bufferIdx++] = params.colorBl;
       fQuadBuffer[bufferIdx++] = textureIdx;
+      fQuadBuffer[bufferIdx++] = 0;
+      fQuadBuffer[bufferIdx++] = 1;
 
       // Lower-Right
       fQuadBuffer[bufferIdx++] = params.renderCoords.x3;
@@ -379,6 +393,9 @@ export class WebGlCoreRenderer extends CoreRenderer {
       fQuadBuffer[bufferIdx++] = texCoordY2;
       uiQuadBuffer[bufferIdx++] = params.colorBr;
       fQuadBuffer[bufferIdx++] = textureIdx;
+
+      fQuadBuffer[bufferIdx++] = 1;
+      fQuadBuffer[bufferIdx++] = 1;
     } else if (params.tb !== 0 || params.tc !== 0) {
       // Upper-Left
       fQuadBuffer[bufferIdx++] = params.tx; // vertexX
@@ -387,6 +404,8 @@ export class WebGlCoreRenderer extends CoreRenderer {
       fQuadBuffer[bufferIdx++] = texCoordY1; // texCoordY
       uiQuadBuffer[bufferIdx++] = params.colorTl; // color
       fQuadBuffer[bufferIdx++] = textureIdx; // texIndex
+      fQuadBuffer[bufferIdx++] = 0;
+      fQuadBuffer[bufferIdx++] = 0;
 
       // Upper-Right
       fQuadBuffer[bufferIdx++] = params.tx + params.width * params.ta;
@@ -395,6 +414,8 @@ export class WebGlCoreRenderer extends CoreRenderer {
       fQuadBuffer[bufferIdx++] = texCoordY1;
       uiQuadBuffer[bufferIdx++] = params.colorTr;
       fQuadBuffer[bufferIdx++] = textureIdx;
+      fQuadBuffer[bufferIdx++] = 1;
+      fQuadBuffer[bufferIdx++] = 0;
 
       // Lower-Left
       fQuadBuffer[bufferIdx++] = params.tx + params.height * params.tb;
@@ -403,6 +424,8 @@ export class WebGlCoreRenderer extends CoreRenderer {
       fQuadBuffer[bufferIdx++] = texCoordY2;
       uiQuadBuffer[bufferIdx++] = params.colorBl;
       fQuadBuffer[bufferIdx++] = textureIdx;
+      fQuadBuffer[bufferIdx++] = 0;
+      fQuadBuffer[bufferIdx++] = 1;
 
       // Lower-Right
       fQuadBuffer[bufferIdx++] =
@@ -413,6 +436,8 @@ export class WebGlCoreRenderer extends CoreRenderer {
       fQuadBuffer[bufferIdx++] = texCoordY2;
       uiQuadBuffer[bufferIdx++] = params.colorBr;
       fQuadBuffer[bufferIdx++] = textureIdx;
+      fQuadBuffer[bufferIdx++] = 1;
+      fQuadBuffer[bufferIdx++] = 1;
     } else {
       // Calculate the right corner of the quad
       // multiplied by the scale
@@ -426,6 +451,8 @@ export class WebGlCoreRenderer extends CoreRenderer {
       fQuadBuffer[bufferIdx++] = texCoordY1; // texCoordY
       uiQuadBuffer[bufferIdx++] = params.colorTl; // color
       fQuadBuffer[bufferIdx++] = textureIdx; // texIndex
+      fQuadBuffer[bufferIdx++] = 0;
+      fQuadBuffer[bufferIdx++] = 0;
 
       // Upper-Right
       fQuadBuffer[bufferIdx++] = rightCornerX;
@@ -434,6 +461,8 @@ export class WebGlCoreRenderer extends CoreRenderer {
       fQuadBuffer[bufferIdx++] = texCoordY1;
       uiQuadBuffer[bufferIdx++] = params.colorTr;
       fQuadBuffer[bufferIdx++] = textureIdx;
+      fQuadBuffer[bufferIdx++] = 1;
+      fQuadBuffer[bufferIdx++] = 0;
 
       // Lower-Left
       fQuadBuffer[bufferIdx++] = params.tx;
@@ -442,6 +471,8 @@ export class WebGlCoreRenderer extends CoreRenderer {
       fQuadBuffer[bufferIdx++] = texCoordY2;
       uiQuadBuffer[bufferIdx++] = params.colorBl;
       fQuadBuffer[bufferIdx++] = textureIdx;
+      fQuadBuffer[bufferIdx++] = 0;
+      fQuadBuffer[bufferIdx++] = 1;
 
       // Lower-Right
       fQuadBuffer[bufferIdx++] = rightCornerX;
@@ -450,9 +481,10 @@ export class WebGlCoreRenderer extends CoreRenderer {
       fQuadBuffer[bufferIdx++] = texCoordY2;
       uiQuadBuffer[bufferIdx++] = params.colorBr;
       fQuadBuffer[bufferIdx++] = textureIdx;
+      fQuadBuffer[bufferIdx++] = 1;
+      fQuadBuffer[bufferIdx++] = 1;
     }
     // Update the length of the current render op
-    this.curRenderOp.length += WORDS_PER_QUAD;
     this.curRenderOp.numQuads++;
     this.curBufferIdx = bufferIdx;
   }
@@ -607,7 +639,7 @@ export class WebGlCoreRenderer extends CoreRenderer {
     this.quadBufferUsage = this.curBufferIdx * arr.BYTES_PER_ELEMENT;
 
     // Calculate the size of each quad in bytes (4 vertices per quad) times the size of each vertex in bytes
-    const QUAD_SIZE_IN_BYTES = 4 * (6 * arr.BYTES_PER_ELEMENT); // 6 attributes per vertex
+    const QUAD_SIZE_IN_BYTES = 4 * (8 * arr.BYTES_PER_ELEMENT); // 8 attributes per vertex
     this.numQuadsRendered = this.quadBufferUsage / QUAD_SIZE_IN_BYTES;
   }
 

--- a/src/core/renderers/webgl/internal/ShaderUtils.ts
+++ b/src/core/renderers/webgl/internal/ShaderUtils.ts
@@ -37,8 +37,6 @@ export interface UniformInfo {
 
 export interface ShaderOptions {
   renderer: WebGlCoreRenderer;
-  attributes: string[];
-  uniforms: UniformInfo[];
   shaderSources?: ShaderProgramSources;
   supportsIndexedTextures?: boolean;
   webgl1Extensions?: string[];

--- a/src/core/renderers/webgl/shaders/DefaultShader.ts
+++ b/src/core/renderers/webgl/shaders/DefaultShader.ts
@@ -26,12 +26,6 @@ export class DefaultShader extends WebGlCoreShader {
   constructor(renderer: WebGlCoreRenderer) {
     super({
       renderer,
-      attributes: ['a_position', 'a_textureCoordinate', 'a_color'],
-      uniforms: [
-        { name: 'u_resolution', uniform: 'uniform2fv' },
-        { name: 'u_pixelRatio', uniform: 'uniform1f' },
-        { name: 'u_texture', uniform: 'uniform2fv' },
-      ],
     });
   }
 
@@ -51,6 +45,7 @@ export class DefaultShader extends WebGlCoreShader {
 
       attribute vec2 a_position;
       attribute vec2 a_textureCoordinate;
+      attribute vec2 a_nodeCoordinate;
       attribute vec4 a_color;
 
       uniform vec2 u_resolution;
@@ -59,6 +54,7 @@ export class DefaultShader extends WebGlCoreShader {
 
       varying vec4 v_color;
       varying vec2 v_textureCoordinate;
+      varying vec2 v_nodeCoordinate;
 
       void main() {
         vec2 normalized = a_position * u_pixelRatio;
@@ -66,6 +62,7 @@ export class DefaultShader extends WebGlCoreShader {
 
         v_color = a_color;
         v_textureCoordinate = a_textureCoordinate;
+        v_nodeCoordinate = a_nodeCoordinate;
 
         gl_Position = vec4(normalized.x * screenSpace.x - 1.0, normalized.y * -abs(screenSpace.y) + 1.0, 0.0, 1.0);
         gl_Position.y = -sign(screenSpace.y) * gl_Position.y;

--- a/src/core/renderers/webgl/shaders/DefaultShaderBatched.ts
+++ b/src/core/renderers/webgl/shaders/DefaultShaderBatched.ts
@@ -29,17 +29,6 @@ export class DefaultShaderBatched extends WebGlCoreShader {
   constructor(renderer: WebGlCoreRenderer) {
     super({
       renderer,
-      attributes: [
-        'a_position',
-        'a_textureCoordinate',
-        'a_color',
-        'a_textureIndex',
-      ],
-      uniforms: [
-        { name: 'u_resolution', uniform: 'uniform2fv' },
-        { name: 'u_pixelRatio', uniform: 'uniform1f' },
-        { name: 'u_textures[0]', uniform: 'uniform1iv' },
-      ],
     });
   }
 

--- a/src/core/renderers/webgl/shaders/DynamicShader.ts
+++ b/src/core/renderers/webgl/shaders/DynamicShader.ts
@@ -118,15 +118,6 @@ export class DynamicShader extends WebGlCoreShader {
     const shader = DynamicShader.createShader(props, effectContructors);
     super({
       renderer,
-      attributes: ['a_position', 'a_textureCoordinate', 'a_color'],
-      uniforms: [
-        { name: 'u_resolution', uniform: 'uniform2fv' },
-        { name: 'u_pixelRatio', uniform: 'uniform1f' },
-        { name: 'u_texture', uniform: 'uniform2fv' },
-        { name: 'u_dimensions', uniform: 'uniform2fv' },
-        { name: 'u_alpha', uniform: 'uniform1f' },
-        ...shader.uniforms,
-      ],
       shaderSources: {
         vertex: shader.vertex,
         fragment: shader.fragment,
@@ -504,6 +495,7 @@ export class DynamicShader extends WebGlCoreShader {
     # endif
 
     attribute vec2 a_textureCoordinate;
+    attribute vec2 a_nodeCoordinate;
     attribute vec2 a_position;
     attribute vec4 a_color;
     attribute float a_textureIndex;
@@ -514,6 +506,7 @@ export class DynamicShader extends WebGlCoreShader {
     varying vec4 v_color;
     varying vec2 v_textureCoordinate;
     varying float v_textureIndex;
+    varying vec2 v_nodeCoordinate;
 
     void main(){
       vec2 normalized = a_position * u_pixelRatio / u_resolution;
@@ -524,6 +517,7 @@ export class DynamicShader extends WebGlCoreShader {
       v_color = a_color;
       v_textureCoordinate = a_textureCoordinate;
       v_textureIndex = a_textureIndex;
+      v_nodeCoordinate = a_nodeCoordinate;
 
       // flip y
       gl_Position = vec4(clip_space * vec2(1.0, -1.0), 0, 1);
@@ -555,13 +549,14 @@ export class DynamicShader extends WebGlCoreShader {
 
     varying vec4 v_color;
     varying vec2 v_textureCoordinate;
+    varying vec2 v_nodeCoordinate;
 
     ${methods}
 
     ${effectMethods}
 
     void main() {
-      vec2 p = v_textureCoordinate.xy * u_dimensions - u_dimensions * 0.5;
+      vec2 p = v_nodeCoordinate.xy * u_dimensions - u_dimensions * 0.5;
       vec2 d = abs(p) - (u_dimensions) * 0.5;
       float lng_DefaultMask = min(max(d.x, d.y), 0.0) + length(max(d, 0.0));
 

--- a/src/core/renderers/webgl/shaders/RoundedRectangle.ts
+++ b/src/core/renderers/webgl/shaders/RoundedRectangle.ts
@@ -45,14 +45,6 @@ export class RoundedRectangle extends WebGlCoreShader {
   constructor(renderer: WebGlCoreRenderer) {
     super({
       renderer,
-      attributes: ['a_position', 'a_textureCoordinate', 'a_color'],
-      uniforms: [
-        { name: 'u_resolution', uniform: 'uniform2fv' },
-        { name: 'u_pixelRatio', uniform: 'uniform1f' },
-        { name: 'u_texture', uniform: 'uniform2f' },
-        { name: 'u_dimensions', uniform: 'uniform2fv' },
-        { name: 'u_radius', uniform: 'uniform1f' },
-      ],
     });
   }
 
@@ -109,13 +101,14 @@ export class RoundedRectangle extends WebGlCoreShader {
       attribute vec2 a_textureCoordinate;
       attribute vec4 a_color;
       attribute float a_textureIndex;
-      attribute float a_depth;
+      attribute vec2 a_nodeCoordinate;
 
       uniform vec2 u_resolution;
       uniform float u_pixelRatio;
 
       varying vec4 v_color;
       varying vec2 v_textureCoordinate;
+      varying vec2 v_nodeCoordinate;
 
       void main() {
         vec2 normalized = a_position * u_pixelRatio / u_resolution;
@@ -125,6 +118,7 @@ export class RoundedRectangle extends WebGlCoreShader {
         // pass to fragment
         v_color = a_color;
         v_textureCoordinate = a_textureCoordinate;
+        v_nodeCoordinate = a_nodeCoordinate;
 
         // flip y
         gl_Position = vec4(clip_space * vec2(1.0, -1.0), 0, 1);
@@ -144,6 +138,7 @@ export class RoundedRectangle extends WebGlCoreShader {
 
       varying vec4 v_color;
       varying vec2 v_textureCoordinate;
+      varying vec2 v_nodeCoordinate;
 
       float boxDist(vec2 p, vec2 size, float radius){
         size -= vec2(radius);
@@ -159,7 +154,7 @@ export class RoundedRectangle extends WebGlCoreShader {
         vec4 color = texture2D(u_texture, v_textureCoordinate) * v_color;
         vec2 halfDimensions = u_dimensions * 0.5;
 
-        float d = boxDist(v_textureCoordinate.xy * u_dimensions - halfDimensions, halfDimensions + 0.5, u_radius);
+        float d = boxDist(v_nodeCoordinate.xy * u_dimensions - halfDimensions, halfDimensions + 0.5, u_radius);
         gl_FragColor = mix(vec4(0.0), color, fillMask(d));
       }
     `,

--- a/src/core/renderers/webgl/shaders/SdfShader.ts
+++ b/src/core/renderers/webgl/shaders/SdfShader.ts
@@ -64,18 +64,6 @@ export class SdfShader extends WebGlCoreShader {
   constructor(renderer: WebGlCoreRenderer) {
     super({
       renderer,
-      attributes: ['a_position', 'a_textureCoordinate'],
-      uniforms: [
-        { name: 'u_resolution', uniform: 'uniform2fv' },
-        { name: 'u_transform', uniform: 'uniformMatrix3fv' },
-        { name: 'u_scrollY', uniform: 'uniform1f' },
-        { name: 'u_pixelRatio', uniform: 'uniform1f' },
-        { name: 'u_texture', uniform: 'uniform2f' },
-        { name: 'u_color', uniform: 'uniform4fv' },
-        { name: 'u_size', uniform: 'uniform1f' },
-        { name: 'u_distanceRange', uniform: 'uniform1f' },
-        { name: 'u_debug', uniform: 'uniform1i' },
-      ],
     });
   }
 

--- a/src/core/renderers/webgl/shaders/effects/BorderBottomEffect.ts
+++ b/src/core/renderers/webgl/shaders/effects/BorderBottomEffect.ts
@@ -91,7 +91,7 @@ export class BorderBottomEffect extends ShaderEffect {
 
   static override onEffectMask = `
   vec2 pos = vec2(0.0, u_dimensions.y - width * 0.5);
-  float mask = $rectDist(v_textureCoordinate.xy * u_dimensions - pos, vec2(u_dimensions.x, width*0.5));
+  float mask = $rectDist(v_nodeCoordinate.xy * u_dimensions - pos, vec2(u_dimensions.x, width*0.5));
   return mix(shaderColor, maskColor, $fillMask(mask));
   `;
 

--- a/src/core/renderers/webgl/shaders/effects/BorderLeftEffect.ts
+++ b/src/core/renderers/webgl/shaders/effects/BorderLeftEffect.ts
@@ -91,7 +91,7 @@ export class BorderLeftEffect extends ShaderEffect {
 
   static override onEffectMask = `
   vec2 pos = vec2(width * 0.5, 0.0);
-  float mask = $rectDist(v_textureCoordinate.xy * u_dimensions - pos, vec2(width*0.5, u_dimensions.y));
+  float mask = $rectDist(v_nodeCoordinate.xy * u_dimensions - pos, vec2(width*0.5, u_dimensions.y));
   return mix(shaderColor, maskColor, $fillMask(mask));
   `;
 

--- a/src/core/renderers/webgl/shaders/effects/BorderRightEffect.ts
+++ b/src/core/renderers/webgl/shaders/effects/BorderRightEffect.ts
@@ -91,7 +91,7 @@ export class BorderRightEffect extends ShaderEffect {
 
   static override onEffectMask = `
   vec2 pos = vec2(u_dimensions.x - width * 0.5, 0.0);
-  float mask = $rectDist(v_textureCoordinate.xy * u_dimensions - pos, vec2(width*0.5, u_dimensions.y));
+  float mask = $rectDist(v_nodeCoordinate.xy * u_dimensions - pos, vec2(width*0.5, u_dimensions.y));
   return mix(shaderColor, maskColor, $fillMask(mask));
   `;
 

--- a/src/core/renderers/webgl/shaders/effects/BorderTopEffect.ts
+++ b/src/core/renderers/webgl/shaders/effects/BorderTopEffect.ts
@@ -91,7 +91,7 @@ export class BorderTopEffect extends ShaderEffect {
 
   static override onEffectMask = `
   vec2 pos = vec2(0.0, width * 0.5);
-  float mask = $rectDist(v_textureCoordinate.xy * u_dimensions - pos, vec2(u_dimensions.x, width*0.5));
+  float mask = $rectDist(v_nodeCoordinate.xy * u_dimensions - pos, vec2(u_dimensions.x, width*0.5));
   return mix(shaderColor, maskColor, $fillMask(mask));
   `;
 

--- a/src/core/renderers/webgl/shaders/effects/FadeOutEffect.ts
+++ b/src/core/renderers/webgl/shaders/effects/FadeOutEffect.ts
@@ -82,7 +82,7 @@ export class FadeOutEffect extends ShaderEffect {
   }
 
   static override onColorize = `
-  vec2 point = v_textureCoordinate.xy * u_dimensions.xy;
+  vec2 point = v_nodeCoordinate.xy * u_dimensions.xy;
   vec2 pos1;
   vec2 pos2;
   vec2 d;
@@ -99,16 +99,16 @@ export class FadeOutEffect extends ShaderEffect {
   }
 
   if(fade[1] > 0.0) {
-    pos1 = vec2(point.x - u_dimensions.x - fade[1], v_textureCoordinate.y);
-    pos2 = vec2(point.x - u_dimensions.x, v_textureCoordinate.y);
+    pos1 = vec2(point.x - u_dimensions.x - fade[1], v_nodeCoordinate.y);
+    pos2 = vec2(point.x - u_dimensions.x, v_nodeCoordinate.y);
     d = pos1 - pos2;
     c = dot(pos2, d) / dot(d, d);
     result = mix(vec4(0.0), result, smoothstep(0.0, 1.0, clamp(c, 0.0, 1.0)));
   }
 
   if(fade[2] > 0.0) {
-    pos1 = vec2(v_textureCoordinate.x, point.y - u_dimensions.y - fade[2]);
-    pos2 = vec2(v_textureCoordinate.x, point.y - u_dimensions.y);
+    pos1 = vec2(v_nodeCoordinate.x, point.y - u_dimensions.y - fade[2]);
+    pos2 = vec2(v_nodeCoordinate.x, point.y - u_dimensions.y);
     d = pos1 - pos2;
     c = dot(pos2, d) / dot(d, d);
     result = mix(vec4(0.0), result, smoothstep(0.0, 1.0, clamp(c, 0.0, 1.0)));

--- a/src/core/renderers/webgl/shaders/effects/HolePunchEffect.ts
+++ b/src/core/renderers/webgl/shaders/effects/HolePunchEffect.ts
@@ -142,7 +142,7 @@ export class HolePunchEffect extends ShaderEffect {
   static override onShaderMask = `
   vec2 halfDimensions = u_dimensions * 0.5;
   vec2 size = vec2(width, height) * 0.5;
-  vec2 basePos = v_textureCoordinate.xy * u_dimensions.xy - vec2(x, y);
+  vec2 basePos = v_nodeCoordinate.xy * u_dimensions.xy - vec2(x, y);
   vec2 pos = basePos - size;
   float r = radius[0] * step(pos.x, 0.5) * step(pos.y, 0.5);
   r = r + radius[1] * step(0.5, pos.x) * step(pos.y, 0.5);

--- a/src/core/renderers/webgl/shaders/effects/LinearGradientEffect.ts
+++ b/src/core/renderers/webgl/shaders/effects/LinearGradientEffect.ts
@@ -146,7 +146,7 @@ export class LinearGradientEffect extends ShaderEffect {
       vec2 f = $calcPoint(lineDist * 0.5, a);
       vec2 t = $calcPoint(lineDist * 0.5, a + PI);
       vec2 gradVec = t - f;
-      float dist = dot(v_textureCoordinate.xy * u_dimensions - f, gradVec) / dot(gradVec, gradVec);
+      float dist = dot(v_nodeCoordinate.xy * u_dimensions - f, gradVec) / dot(gradVec, gradVec);
 
       //return early if dist is lower or equal to first stop
       if(dist <= stops[0]) {

--- a/src/core/renderers/webgl/shaders/effects/RadialGradientEffect.ts
+++ b/src/core/renderers/webgl/shaders/effects/RadialGradientEffect.ts
@@ -162,7 +162,7 @@ export class RadialGradientEffect extends ShaderEffect {
   static override onColorize = (props: RadialGradientEffectProps) => {
     const colors = props.colors!.length || 1;
     return `
-      vec2 point = v_textureCoordinate.xy * u_dimensions;
+      vec2 point = v_nodeCoordinate.xy * u_dimensions;
       vec2 projection = vec2(pivot.x * u_dimensions.x, pivot.y * u_dimensions.y);
 
       float dist = length((point - projection) / vec2(width, height));

--- a/src/core/renderers/webgl/shaders/effects/RadialProgressEffect.ts
+++ b/src/core/renderers/webgl/shaders/effects/RadialProgressEffect.ts
@@ -162,7 +162,7 @@ export class RadialProgressEffect extends ShaderEffect {
 
     float endAngle = range * progress - 0.0005;
 
-    vec2 uv = v_textureCoordinate.xy * u_dimensions.xy - u_dimensions * 0.5;
+    vec2 uv = v_nodeCoordinate.xy * u_dimensions.xy - u_dimensions * 0.5;
 
     uv = $rotateUV(uv, -(offset));
     float linewidth = width * u_pixelRatio;

--- a/src/core/renderers/webgl/shaders/effects/RadiusEffect.ts
+++ b/src/core/renderers/webgl/shaders/effects/RadiusEffect.ts
@@ -97,11 +97,11 @@ export class RadiusEffect extends ShaderEffect {
 
   static override onShaderMask = `
   vec2 halfDimensions = u_dimensions * 0.5;
-  float r = radius[0] * step(v_textureCoordinate.x, 0.5) * step(v_textureCoordinate.y, 0.5);
-  r = r + radius[1] * step(0.5, v_textureCoordinate.x) * step(v_textureCoordinate.y, 0.5);
-  r = r + radius[2] * step(0.5, v_textureCoordinate.x) * step(0.5, v_textureCoordinate.y);
-  r = r + radius[3] * step(v_textureCoordinate.x, 0.5) * step(0.5, v_textureCoordinate.y);
-  return $boxDist(v_textureCoordinate.xy * u_dimensions - halfDimensions, halfDimensions, r);
+  float r = radius[0] * step(v_nodeCoordinate.x, 0.5) * step(v_nodeCoordinate.y, 0.5);
+  r = r + radius[1] * step(0.5, v_nodeCoordinate.x) * step(v_nodeCoordinate.y, 0.5);
+  r = r + radius[2] * step(0.5, v_nodeCoordinate.x) * step(0.5, v_nodeCoordinate.y);
+  r = r + radius[3] * step(v_nodeCoordinate.x, 0.5) * step(0.5, v_nodeCoordinate.y);
+  return $boxDist(v_nodeCoordinate.xy * u_dimensions - halfDimensions, halfDimensions, r);
   `;
 
   static override onEffectMask = `


### PR DESCRIPTION
We already use this same concept on v3. 

We need nodeCoordinates so can accurately calculated the edges of nodes, we are currently doing these with textureCoords, but in case of sprites or images with textureOptions texturecoords can be different from what the shader expects them to be.


resolves known issue(s):
#357 