### PR TITLE
fix loaded events not being fired when a parent node has rtt

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -2339,7 +2339,7 @@ export class CoreNode extends EventEmitter {
       this.texture = null;
       return;
     }
-    console.log('change source', imageUrl);
+
     this.texture = this.stage.txManager.createTexture('ImageTexture', {
       src: imageUrl,
       width: this.props.width,


### PR DESCRIPTION
Fixed an issue where the events are not properly emitted when a parent has rtt enabled.