### PR TITLE
fix(inspector): Playwright visibility fixes and reactive property updates

### DIFF
--- a/src/core/CoreTextNode.ts
+++ b/src/core/CoreTextNode.ts
@@ -191,6 +191,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
 
   set text(value: string) {
     this.textRenderer.set.text(this.trState, value);
+    (this.props as CoreTextNodeProps).text = value;
   }
 
   get textRendererOverride(): CoreTextNodeProps['textRendererOverride'] {


### PR DESCRIPTION
- Fix Playwright toBeVisible() failures: set 0x0 dimensions to 1px and use opacity: 0 for text elements
- Improve reactive updates: Proxy intercepts CoreTextNodeProps and keeps props.text in sync