### PR TITLE
fix: add safety against no ctxTexture

### DIFF
--- a/src/core/renderers/webgl/WebGlCoreRenderer.ts
+++ b/src/core/renderers/webgl/WebGlCoreRenderer.ts
@@ -294,6 +294,12 @@ export class WebGlCoreRenderer extends CoreRenderer {
       ctxTexture = texture.ctxTexture as WebGlCoreCtxTexture;
     } else {
       ctxTexture = texture.ctxTexture as WebGlCoreCtxTexture;
+      if (ctxTexture === undefined) {
+        ctxTexture = this.stage.defaultTexture?.ctxTexture as WebGlCoreCtxTexture;
+        console.warn(
+          'WebGL Renderer: Texture does not have a ctxTexture, using default texture instead',
+        );
+      }
       texCoordX1 = ctxTexture.txCoordX1;
       texCoordY1 = ctxTexture.txCoordY1;
       texCoordX2 = ctxTexture.txCoordX2;


### PR DESCRIPTION
This change fixes an issue seen on specific devices since V2.20.0.

Im not sure if this is the best approach but hopefully this PR starts the conversation