### PR TITLE
CanvasTextRenderer to use settings dpr

### DIFF
--- a/src/core/text-rendering/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/CanvasTextRenderer.ts
@@ -56,7 +56,7 @@ const layoutCache = new Map<
 
 // Initialize the Text Renderer
 const init = (stage: Stage): void => {
-  const dpr = stage.options.devicePhysicalPixelRatio || 1;
+  const dpr = stage.options.devicePhysicalPixelRatio;
 
   // Drawing canvas and context
   canvas = stage.platform.createCanvas() as HTMLCanvasElement | OffscreenCanvas;

--- a/src/main-api/Renderer.ts
+++ b/src/main-api/Renderer.ts
@@ -508,7 +508,7 @@ export class RendererMain extends EventEmitter {
       boundsMargin: settings.boundsMargin || 0,
       deviceLogicalPixelRatio: settings.deviceLogicalPixelRatio || 1,
       devicePhysicalPixelRatio:
-        settings.devicePhysicalPixelRatio || window.devicePixelRatio,
+        settings.devicePhysicalPixelRatio || (window.devicePixelRatio || 1),
       clearColor: settings.clearColor ?? 0x00000000,
       fpsUpdateInterval: settings.fpsUpdateInterval || 0,
       targetFPS: settings.targetFPS || 0,


### PR DESCRIPTION
The actual dpr is established higher up in the renderer, resolving the incoming settings & fallback to window.

should the `|| 1` still happen here? or should that also resolve earlier in the render creation?