### PR TITLE
limit the test timeout to 10 min

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   run-all-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Prevents runs from going for 6 hours when VRT messes up. Runs are currently taking < 3min.