### PR TITLE
fix elapsed time not to be negative

### DIFF
--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -393,7 +393,7 @@ export class Stage {
     const newFrameTime = this.platform.getTimeStamp();
     this.lastFrameTime = this.currentFrameTime;
     this.currentFrameTime = newFrameTime;
-    this.elapsedTime = this.startTime - newFrameTime;
+    this.elapsedTime = newFrameTime - this.startTime;
     this.deltaTime = !this.lastFrameTime
       ? 100 / 6
       : newFrameTime - this.lastFrameTime;


### PR DESCRIPTION
This should be opposite - part of the new time for shaders and keeps the elapsed time a positive value.