### PR TITLE
Inspector text visible issue

### DIFF
--- a/src/main-api/Inspector.ts
+++ b/src/main-api/Inspector.ts
@@ -578,8 +578,9 @@ export class Inspector {
     if (property === 'text') {
       div.innerHTML = String(value);
 
-      // Keep DOM text invisible without breaking visibility checks by using color:transparent instead of opacity:0
-      div.style.color = 'transparent';
+      // Keep DOM text invisible without breaking visibility checks
+      // Use very low opacity (0.001) instead of 0 so Playwright still detects it
+      div.style.opacity = '0.001';
       div.style.pointerEvents = 'none';
       div.style.userSelect = 'none';
       return;


### PR DESCRIPTION
So we have this issue where if the inspector is on, and a TextNode is updated / visibilty changes (or parent visibility/renderable), the dom element turns visible. This fix should work the #678 issue but the dom node should still be detectable as visible for playwright