### PR TITLE
actually fix the update loop not going idle

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -1072,7 +1072,7 @@ export class CoreNode extends EventEmitter {
     const parentHasRenderTexture = this.parentHasRenderTexture;
     const hasParent = props.parent !== null;
 
-    let renderState: CoreNodeRenderState | null = null;
+    let newRenderState: CoreNodeRenderState | null = null;
 
     let updateType = this.updateType;
     let childUpdateType = this.childUpdateType;
@@ -1154,7 +1154,7 @@ export class CoreNode extends EventEmitter {
     }
 
     if (updateType & UpdateType.RenderState) {
-      renderState = this.checkRenderBounds();
+      newRenderState = this.checkRenderBounds();
 
       updateType |= UpdateType.IsRenderable;
       updateParent = hasParent;
@@ -1162,8 +1162,8 @@ export class CoreNode extends EventEmitter {
       // if we're not going out of bounds, update the render state
       // this is done so the update loop can finish before we mark a node
       // as out of bounds
-      if (renderState !== CoreNodeRenderState.OutOfBounds) {
-        this.updateRenderState(renderState);
+      if (newRenderState !== CoreNodeRenderState.OutOfBounds) {
+        this.updateRenderState(newRenderState);
       }
     }
 
@@ -1228,12 +1228,15 @@ export class CoreNode extends EventEmitter {
       }
     }
 
-    if (updateParent === true) {
-      parent!.setUpdateType(UpdateType.Children);
+    if (this.renderState === CoreNodeRenderState.OutOfBounds) {
+      // Delay updating children until the node is in bounds
+      this.updateType = updateType;
+      this.childUpdateType = childUpdateType;
+      return;
     }
 
-    if (this.renderState === CoreNodeRenderState.OutOfBounds) {
-      return;
+    if (updateParent === true) {
+      parent!.setUpdateType(UpdateType.Children);
     }
 
     if (
@@ -1287,17 +1290,17 @@ export class CoreNode extends EventEmitter {
     // If we're out of bounds, apply the render state now
     // this is done so nodes can finish their entire update loop before
     // being marked as out of bounds
-    if (renderState === CoreNodeRenderState.OutOfBounds) {
-      this.updateRenderState(renderState);
+    if (newRenderState === CoreNodeRenderState.OutOfBounds) {
+      this.updateRenderState(newRenderState);
       this.updateIsRenderable();
 
       if (
         this.rtt === true &&
-        renderState === CoreNodeRenderState.OutOfBounds
+        newRenderState === CoreNodeRenderState.OutOfBounds
       ) {
         // notify children that we are going out of bounds
         // we have to do this now before we stop processing the render tree
-        this.notifyChildrenRTTOfUpdate(renderState);
+        this.notifyChildrenRTTOfUpdate(newRenderState);
       }
     }
   }


### PR DESCRIPTION
Renamed renderState -> newRenderState to avoid confusion with this.renderState

1) When the node is out of bounds, we need to keep the updates for the next loop when its back in bounds.

2) The loop was caused by the updateParent being true which the out of bounds causes. Moving that after the return statements prevents parent from being updated which caused the loop.


Note - that updateParent had no effect in the previous loop as updateType was reset at the end of the loop. So should that be in there at all?