### PR TITLE
Fixes Canvas Render

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -764,6 +764,9 @@ export class CoreNode extends EventEmitter {
   constructor(readonly stage: Stage, props: CoreNodeProps) {
     super();
     const p = (this.props = {} as CoreNodeProps);
+    //inital update type
+    let initialUpdateType =
+      UpdateType.Local | UpdateType.RenderBounds | UpdateType.RenderState;
 
     // Fast-path assign only known keys
     p.x = props.x;
@@ -773,8 +776,8 @@ export class CoreNode extends EventEmitter {
     p.alpha = props.alpha;
     p.autosize = props.autosize;
     p.clipping = props.clipping;
-    p.color = props.color;
 
+    p.color = props.color;
     p.colorTop = props.colorTop;
     p.colorBottom = props.colorBottom;
     p.colorLeft = props.colorLeft;
@@ -783,6 +786,22 @@ export class CoreNode extends EventEmitter {
     p.colorTr = props.colorTr;
     p.colorBl = props.colorBl;
     p.colorBr = props.colorBr;
+
+    //check if any color props are set for premultiplied color updates
+    if (
+      props.color > 0 ||
+      props.colorTop > 0 ||
+      props.colorBottom > 0 ||
+      props.colorLeft > 0 ||
+      props.colorRight > 0 ||
+      props.colorTl > 0 ||
+      props.colorTr > 0 ||
+      props.colorBl > 0 ||
+      props.colorBr > 0
+    ) {
+      this.hasColorProps = true;
+      initialUpdateType |= UpdateType.PremultipliedColors;
+    }
 
     p.scaleX = props.scaleX;
     p.scaleY = props.scaleY;
@@ -828,9 +847,7 @@ export class CoreNode extends EventEmitter {
     this.boundsMargin = props.boundsMargin;
     this.interactive = props.interactive;
 
-    this.setUpdateType(
-      UpdateType.Local | UpdateType.RenderBounds | UpdateType.RenderState,
-    );
+    this.setUpdateType(initialUpdateType);
 
     // if the default texture isn't loaded yet, wait for it to load
     // this only happens when the node is created before the stage is ready
@@ -1860,6 +1877,7 @@ export class CoreNode extends EventEmitter {
       this.zIndexSortList.push(node);
       this.setUpdateType(UpdateType.SortZIndexChildren);
     }
+    this.setUpdateType(UpdateType.Children);
   }
 
   //#region Properties


### PR DESCRIPTION
- Fixed an issue where normal nodes without specific textures or shaders were not being drawn. Found out a problem with hasColorProps not being set on create, this is needed for the renderable check.
- Refactored some code in CanvasRenderer where checks are not needed (or simply are done again, after they've been done earlier in the render pipeline).