### PR TITLE
fix: throw an error for unexpected texture data

### DIFF
--- a/src/core/renderers/webgl/WebGlCtxTexture.ts
+++ b/src/core/renderers/webgl/WebGlCtxTexture.ts
@@ -265,9 +265,8 @@ export class WebGlCtxTexture extends CoreContextTexture {
 
       this.setTextureMemUse(w * h * formatBytes);
     } else {
-      console.error(
+      throw new Error(
         `WebGlCoreCtxTexture.onLoadRequest: Unexpected textureData returned`,
-        textureData,
       );
     }
 


### PR DESCRIPTION
This should fix for the compressed Texture that have an invalid texture data, by throwing an error the Texture will go to failed and an error should be propagated up.