### PR TITLE
update addQuad to take CoreNode instances

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -1800,47 +1800,31 @@ export class CoreNode extends EventEmitter {
         return;
     }
 
-    const p = this.props;
-    const t = this.globalTransform!;
-    const coords = this.renderCoords;
-    const texture = p.texture || this.stage.defaultTexture;
-    const textureCoords =
-      this.textureCoords || this.stage.renderer.defaultTextureCoords;
+    const texture = this.renderTexture;
 
     // There is a race condition where the texture can be null
     // with RTT nodes. Adding this defensively to avoid errors.
-    if (texture && texture.state !== 'loaded') {
+    // Also check if we have a valid texture or default texture to render
+    if (!texture || texture.state !== 'loaded') {
       return;
     }
 
-    renderer.addQuad({
-      width: p.w,
-      height: p.h,
-      colorTl: this.premultipliedColorTl,
-      colorTr: this.premultipliedColorTr,
-      colorBl: this.premultipliedColorBl,
-      colorBr: this.premultipliedColorBr,
-      texture,
-      textureOptions: p.textureOptions,
-      textureCoords: textureCoords,
-      shader: p.shader as CoreShaderNode<any>,
-      alpha: this.worldAlpha,
-      clippingRect: this.clippingRect,
-      tx: t.tx,
-      ty: t.ty,
-      ta: t.ta,
-      tb: t.tb,
-      tc: t.tc,
-      td: t.td,
-      renderCoords: coords,
-      rtt: p.rtt,
-      zIndex: this.calcZIndex,
-      parentHasRenderTexture: this.parentHasRenderTexture,
-      framebufferDimensions: this.parentHasRenderTexture
-        ? this.parentFramebufferDimensions
-        : null,
-      time: this.hasShaderTimeFn === true ? this.getTimerValue() : null,
-    });
+    renderer.addQuad(this);
+  }
+
+  get renderTexture(): Texture | null {
+    return this.props.texture || this.stage.defaultTexture;
+  }
+
+  get renderTextureCoords(): TextureCoords | undefined {
+    return this.textureCoords || this.stage.renderer.defaultTextureCoords;
+  }
+
+  get renderTime(): number | null {
+    if (this.hasShaderTimeFn === true) {
+      return this.getTimerValue();
+    }
+    return null;
   }
 
   getTimerValue(): number {

--- a/src/core/renderers/CoreRenderer.ts
+++ b/src/core/renderers/CoreRenderer.ts
@@ -84,7 +84,7 @@ export abstract class CoreRenderer {
 
   abstract reset(): void;
   abstract render(surface?: 'screen' | CoreContextTexture): void;
-  abstract addQuad(quad: QuadOptions): void;
+  abstract addQuad(node: CoreNode): void;
   abstract createCtxTexture(textureSource: Texture): CoreContextTexture;
   abstract createShaderProgram(
     shaderConfig: Readonly<CoreShaderType>,

--- a/src/core/renderers/webgl/WebGlShaderNode.ts
+++ b/src/core/renderers/webgl/WebGlShaderNode.ts
@@ -2,7 +2,6 @@ import type { CoreNode } from '../../CoreNode.js';
 import { getNormalizedRgbaComponents } from '../../lib/utils.js';
 import type { WebGlContextWrapper } from '../../lib/WebGlContextWrapper.js';
 import type { Stage } from '../../Stage.js';
-import type { QuadOptions } from '../CoreRenderer.js';
 import { CoreShaderNode, type CoreShaderType } from '../CoreShaderNode.js';
 import type {
   UniformCollection,
@@ -47,10 +46,7 @@ export type WebGlShaderType<T extends object = Record<string, unknown>> =
      * This function is used to check if the shader can be reused based on quad info
      * @param props
      */
-    canBatch?: (
-      incomingQuad: QuadOptions,
-      currentRenderOp: WebGlRenderOp,
-    ) => boolean;
+    canBatch?: (node: CoreNode, currentRenderOp: WebGlRenderOp) => boolean;
     /**
      * extensions required for specific shader?
      */


### PR DESCRIPTION
Phase one of garbage collection cleanup. addQuad took in a new object which was basically a copy of CoreNode. This creates a lot of objects that need to be cleaned up. Instead simply passing in CoreNode makes more sense. 

I'd like to continue cleanup of RenderOps and have CoreNode and SDF match interfaces. I think removing the RenderOp and simply having a draw() call on the CoreNode / SDF would be lot faster.