### PR TITLE
feat: add enableClear flag to disable glw.clear

### DIFF
--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -69,6 +69,7 @@ export type StageOptions = Omit<
   platform: Platform | WebPlatform;
   inspector: boolean;
   maxRetryCount: number;
+  enableClear: boolean;
 };
 
 export type StageFpsUpdateHandler = (

--- a/src/core/renderers/webgl/WebGlRenderer.ts
+++ b/src/core/renderers/webgl/WebGlRenderer.ts
@@ -190,7 +190,9 @@ export class WebGlRenderer extends CoreRenderer {
     this.curRenderOp = null;
     this.renderOps.length = 0;
     glw.setScissorTest(false);
-    glw.clear();
+    if (this.stage.options.enableClear !== false) {
+      glw.clear();
+    }
   }
 
   createShaderProgram(

--- a/src/main-api/Renderer.ts
+++ b/src/main-api/Renderer.ts
@@ -239,6 +239,17 @@ export interface RendererRuntimeSettings {
   fpsUpdateInterval: number;
 
   /**
+   * Clears the render buffer on reset
+   *
+   * @remarks
+   * If false, the renderer will not clear the buffer before rendering a new frame.
+   * This is useful if you want to preserve the previous frame.
+   *
+   * @defaultValue `true`
+   */
+  enableClear: boolean;
+
+  /**
    * DOM Inspector
    *
    * @remarks
@@ -525,6 +536,7 @@ export class RendererMain extends EventEmitter {
         settings.devicePhysicalPixelRatio || window.devicePixelRatio || 1,
       clearColor: settings.clearColor ?? 0x00000000,
       fpsUpdateInterval: settings.fpsUpdateInterval || 0,
+      enableClear: settings.enableClear ?? true,
       targetFPS: settings.targetFPS || 0,
       numImageWorkers:
         settings.numImageWorkers !== undefined ? settings.numImageWorkers : 2,
@@ -586,6 +598,7 @@ export class RendererMain extends EventEmitter {
       enableContextSpy: settings.enableContextSpy!,
       forceWebGL2: settings.forceWebGL2!,
       fpsUpdateInterval: settings.fpsUpdateInterval!,
+      enableClear: settings.enableClear!,
       numImageWorkers: settings.numImageWorkers!,
       renderEngine: settings.renderEngine!,
       textureMemory: resolvedTxSettings,


### PR DESCRIPTION
99% of the time we have a background image or node that covers everything removing the need to clear. Making this optional will save additional overhead on frames.