### PR TITLE
added reset parameter to stop function Animation controller

### DIFF
--- a/src/core/animations/CoreAnimationController.ts
+++ b/src/core/animations/CoreAnimationController.ts
@@ -63,14 +63,16 @@ export class CoreAnimationController
     return this;
   }
 
-  stop(): IAnimationController {
+  stop(reset = true): IAnimationController {
     this.unregisterAnimation();
     if (this.stoppedResolve !== null) {
       this.stoppedResolve();
       this.stoppedResolve = null;
       this.emit('stopped', this);
     }
-    this.animation.reset();
+    if (reset === true) {
+      this.animation.reset();
+    }
     this.state = 'stopped';
     return this;
   }


### PR DESCRIPTION

Added a reset parameter to the CoreAnimationController stop function, by default it's true so there are no regressions. 

The reason for this change is that currently if you use the stop function the values will reset to their start values which is not handy if you want to chain the same value to a different animation.