### PR TITLE
fix: prevent initial text position jump

### DIFF
--- a/src/core/Autosizer.ts
+++ b/src/core/Autosizer.ts
@@ -44,8 +44,10 @@ const getFilteredChildren = (
   const filtered: CoreNode[] = [];
   while (children.length > 0) {
     const id = children.pop()!;
-    const child = childMap.get(id)!;
-    filtered.push(child);
+    const child = childMap.get(id);
+    if (child !== undefined) {
+      filtered.push(child);
+    }
   }
   return filtered;
 };

--- a/src/core/CoreTextNode.ts
+++ b/src/core/CoreTextNode.ts
@@ -78,38 +78,25 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
   private _type: 'sdf' | 'canvas' = 'sdf'; // Default to SDF renderer
 
   /**
-   * Only texts whose transform depends on measured dimensions need eager layout
-   * to avoid an initial position jump.
+   * Only texts whose parent transform/layout depends on measured dimensions
+   * need eager layout to avoid an initial position jump.
    */
   private requiresLayoutForInitialTransform(props: CoreTextNodeProps): boolean {
+    const parent = props.parent;
+    if (parent === null) {
+      return false;
+    }
+
     if (
-      props.mountX !== 0 ||
-      props.mountY !== 0 ||
-      props.pivotX !== 0 ||
-      props.pivotY !== 0
+      parent.mountX !== 0 ||
+      parent.mountY !== 0 ||
+      parent.pivotX !== 0.5 ||
+      parent.pivotY !== 0.5
     ) {
       return true;
     }
 
-    const containType = TextConstraint[props.contain];
-
-    if (
-      (containType & TextConstraint.width) !== 0 &&
-      props.maxWidth > 0 &&
-      props.textAlign !== 'left'
-    ) {
-      return true;
-    }
-
-    if (
-      (containType & TextConstraint.height) !== 0 &&
-      props.maxHeight > 0 &&
-      props.verticalAlign !== 'top'
-    ) {
-      return true;
-    }
-
-    return false;
+    return parent.autosizer !== null || parent.parentAutosizer !== null;
   }
 
   constructor(
@@ -128,8 +115,8 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
     this._containType = TextConstraint[props.contain];
 
     if (
-      this.requiresLayoutForInitialTransform(props) === true &&
       (props.forceLoad === true || props.parent !== null) &&
+      this.requiresLayoutForInitialTransform(props) === true &&
       this.fontHandler.isFontLoaded(this.textProps.fontFamily) === true
     ) {
       const resp = this.textRenderer.renderText(this.textProps);

--- a/src/core/CoreTextNode.ts
+++ b/src/core/CoreTextNode.ts
@@ -92,6 +92,15 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
     this.textProps = props;
     this._containType = TextConstraint[props.contain];
 
+    if (
+      (props.forceLoad === true || props.parent !== null) &&
+      this.fontHandler.isFontLoaded(this.textProps.fontFamily) === true
+    ) {
+      const resp = this.textRenderer.renderText(this.textProps);
+      this.handleRenderResult(resp);
+      this._layoutGenerated = true;
+    }
+
     this.setUpdateType(UpdateType.All);
   }
 

--- a/src/core/CoreTextNode.ts
+++ b/src/core/CoreTextNode.ts
@@ -77,6 +77,41 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
 
   private _type: 'sdf' | 'canvas' = 'sdf'; // Default to SDF renderer
 
+  /**
+   * Only texts whose transform depends on measured dimensions need eager layout
+   * to avoid an initial position jump.
+   */
+  private requiresLayoutForInitialTransform(props: CoreTextNodeProps): boolean {
+    if (
+      props.mountX !== 0 ||
+      props.mountY !== 0 ||
+      props.pivotX !== 0 ||
+      props.pivotY !== 0
+    ) {
+      return true;
+    }
+
+    const containType = TextConstraint[props.contain];
+
+    if (
+      (containType & TextConstraint.width) !== 0 &&
+      props.maxWidth > 0 &&
+      props.textAlign !== 'left'
+    ) {
+      return true;
+    }
+
+    if (
+      (containType & TextConstraint.height) !== 0 &&
+      props.maxHeight > 0 &&
+      props.verticalAlign !== 'top'
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
   constructor(
     stage: Stage,
     props: CoreTextNodeProps,
@@ -93,6 +128,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
     this._containType = TextConstraint[props.contain];
 
     if (
+      this.requiresLayoutForInitialTransform(props) === true &&
       (props.forceLoad === true || props.parent !== null) &&
       this.fontHandler.isFontLoaded(this.textProps.fontFamily) === true
     ) {


### PR DESCRIPTION
When a Text node is inside an autosized parent with mount enabled, the text appears in the wrong position for 1 frame and then snaps into place.

This is an intentional tradeoff in favor of first-frame visual stability: it shifts some work earlier during node creation to avoid visible repositioning.