### PR TITLE
fix: width 0 or height 0 after text gen

### DIFF
--- a/src/core/CoreTextNode.ts
+++ b/src/core/CoreTextNode.ts
@@ -268,6 +268,15 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
       }
     }
 
+    // Handle zero-dimension case (can happen with certain text inputs or font issues)
+    if (width === 0 || height === 0) {
+      this.emit('failed', {
+        type: 'text',
+        error: new Error('Text rendering failed, width or height zero'),
+      } satisfies NodeTextFailedPayload);
+      return;
+    }
+
     this._cachedLayout = result.layout || null;
     this.props.w = width;
     this.props.h = height;


### PR DESCRIPTION
Previously when trying to load generated text with width 0 or height 0 warnings or on some cases error popped up. This fix sets the textnode as unrenderable and wont try to draw / load buffers if it cant render.