### PR TITLE
isHTMLImageElement to use instanceof Image

### DIFF
--- a/src/core/renderers/webgl/internal/RendererUtils.ts
+++ b/src/core/renderers/webgl/internal/RendererUtils.ts
@@ -140,8 +140,7 @@ export function isHTMLImageElement(obj: unknown): obj is HTMLImageElement {
     ((typeof obj === 'object' &&
       obj.constructor &&
       obj.constructor.name === 'HTMLImageElement') ||
-      (typeof HTMLImageElement !== 'undefined' &&
-        obj instanceof HTMLImageElement))
+      (typeof Image !== 'undefined' && obj instanceof Image))
   );
 }
 


### PR DESCRIPTION
The condition of HTMLImageElement is duplicate of the constructor compare. But instanceof Image may compare to subclasses of a different prototype chain.