### PR TITLE
Fix shader setter not updating `hasShaderUpdater` and `hasShaderTimeFn`

### DIFF
--- a/src/core/CoreNode.test.ts
+++ b/src/core/CoreNode.test.ts
@@ -26,7 +26,7 @@ import { type TextureOptions } from './CoreTextureManager.js';
 import { createBound } from './lib/utils.js';
 import { ImageTexture } from './textures/ImageTexture.js';
 
-describe('set color()', () => {
+describe('CoreNode', () => {
   const defaultProps: CoreNodeProps = {
     alpha: 0,
     autosize: false,

--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -2550,14 +2550,14 @@ export class CoreNode extends EventEmitter {
       return;
     }
     if (shader === null) {
-      this.hasShaderUpdater = false;
+      this.hasShaderUpdater = this.hasShaderTimeFn = false;
       this.props.shader = this.stage.defShaderNode;
       this.setUpdateType(UpdateType.IsRenderable);
       return;
     }
+    this.hasShaderUpdater = shader.update !== undefined;
+    this.hasShaderTimeFn = shader.time !== undefined;
     if (shader.shaderKey !== 'default') {
-      this.hasShaderUpdater = shader.update !== undefined;
-      this.hasShaderTimeFn = shader.time !== undefined;
       shader.attachNode(this);
     }
 


### PR DESCRIPTION
Fix crash:

> TypeError: this.shader.update is not a function

 caused by doing:

```ts
this.bar = renderer.createNode({
    w: BAR_WIDTH,
    h: BAR_HEIGHT,
    color: 0x00000000,
    shader: renderer.createShader('border', { w: 4, color: 0x000000cc }),
});

setTimeout(() => {
  this.bar.shader = renderer.createShader('default');
}, 5000);
```

Now, the properties `hasShaderUpdater` and `hasShaderTimeFn` are always updated when the shader is set to `null` or to the `default` shader.
