### PR TITLE
fix: correct canvas clipping rect handling in addQuad

### DIFF
--- a/src/core/renderers/canvas/CanvasRenderer.ts
+++ b/src/core/renderers/canvas/CanvasRenderer.ts
@@ -83,7 +83,19 @@ export class CanvasRenderer extends CoreRenderer {
     }
 
     const hasTransform = ta !== 1;
-    const hasClipping = clippingRect.w !== 0 && clippingRect.h !== 0;
+    const clippingValid = clippingRect.valid === true;
+
+    // If the clipping rect is valid but zero-area, the node is fully clipped — skip rendering
+    if (
+      clippingValid === true &&
+      clippingRect.w === 0 &&
+      clippingRect.h === 0
+    ) {
+      return;
+    }
+
+    const hasClipping =
+      clippingValid === true && clippingRect.w !== 0 && clippingRect.h !== 0;
     const shader = node.props.shader;
     const hasShader = shader !== null;
 


### PR DESCRIPTION
- Use clippingRect.valid to determine whether clipping should be applied instead of checking w/h alone which ignored the valid flag
- Early return when clipping rect is valid but zero-area, meaning the node is fully outside the clipping region and nothing should be drawn
- Previously a zero-area rect caused hasClipping=false, resulting in the node rendering with no clip constraint at all