### PR TITLE
fix: disable texture memory threshold blocking for canvas renderer

### DIFF
--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -224,6 +224,17 @@ export class Stage {
 
     const renderMode = this.renderer.mode || 'webgl';
 
+    // Canvas2D textures are plain JS heap objects managed by the browser GC.
+    // Threshold-based upload blocking makes no sense for JS heap — disable it
+    // by setting criticalThreshold to 0 while keeping the eviction machinery.
+    if (renderMode === 'canvas') {
+      this.txMemManager.updateSettings({
+        ...textureMemory,
+        criticalThreshold: 0,
+        doNotExceedCriticalThreshold: false,
+      });
+    }
+
     this.createDefaultTexture();
     setPremultiplyMode(renderMode);
 

--- a/src/core/TextureMemoryManager.ts
+++ b/src/core/TextureMemoryManager.ts
@@ -177,7 +177,7 @@ export class TextureMemoryManager {
       }
     }
 
-    if (this.memUsed > this.criticalThreshold) {
+    if (this.criticalThreshold > 0 && this.memUsed > this.criticalThreshold) {
       this.criticalCleanupRequested = true;
     }
   }
@@ -185,13 +185,14 @@ export class TextureMemoryManager {
   checkCleanup() {
     return (
       this.criticalCleanupRequested ||
-      (this.memUsed > this.targetThreshold &&
+      (this.criticalThreshold > 0 &&
+        this.memUsed > this.targetThreshold &&
         this.frameTime - this.lastCleanupTime >= this.cleanupInterval)
     );
   }
 
   checkCriticalCleanup() {
-    return this.memUsed > this.criticalThreshold;
+    return this.criticalThreshold > 0 && this.memUsed > this.criticalThreshold;
   }
 
   /**


### PR DESCRIPTION
Canvas2D textures are plain JS heap objects (ImageBitmap, HTMLCanvasElement, HTMLImageElement) managed by the browser GC. The threshold-based upload blocking designed for WebGL VRAM management does not apply to JS heap and causes textures to stop uploading incorrectly.

- TextureMemoryManager: honour criticalThreshold=0 as documented to disable threshold checks in setTextureMemUse, checkCleanup and checkCriticalCleanup — eviction/cleanup machinery remains intact
- Stage: automatically set criticalThreshold=0 and disable doNotExceedCriticalThreshold when canvas renderer is active, keeping a single control point with no split flows elsewhere