### PR TITLE
fix(canvas): fail fast for compressed textures in Canvas2D mode

### DIFF
--- a/src/core/renderers/canvas/CanvasTexture.ts
+++ b/src/core/renderers/canvas/CanvasTexture.ts
@@ -137,6 +137,15 @@ export class CanvasTexture extends CoreContextTexture {
     assertTruthy(this.textureSource?.textureData?.data, 'Texture data is null');
     const { data } = this.textureSource.textureData;
 
+    // CompressedData objects (KTX, PVR, ASTC) carry GPU-format mipmap buffers
+    // that cannot be decoded by Canvas2D. Reject explicitly rather than falling
+    // through silently and leaving this.image unassigned.
+    if (typeof data === 'object' && 'mipmaps' in data) {
+      throw new Error(
+        'CanvasTexture: Compressed texture data is not supported in Canvas2D render mode',
+      );
+    }
+
     // TODO: canvas from text renderer should be able to provide the canvas directly
     // instead of having to re-draw it into a new canvas...
     if (data instanceof ImageData) {

--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -143,6 +143,24 @@ export class ImageTexture extends Texture {
   }
 
   override async getTextureSource(): Promise<TextureData> {
+    // Compressed textures are not supported by the Canvas2D renderer.
+    // Fail fast here before incurring a network fetch or binary decode.
+    if (this.txManager.renderer?.mode === 'canvas') {
+      const { src, type } = this.props;
+      if (
+        type === 'compressed' ||
+        (typeof src === 'string' && isCompressedTextureContainer(src) === true)
+      ) {
+        const err = new Error(
+          `ImageTexture: Compressed textures are not supported in Canvas2D render mode (src: ${String(
+            src,
+          )})`,
+        );
+        this.setState('failed', err);
+        return { data: null };
+      }
+    }
+
     let resp: TextureData;
     try {
       resp = await this.determineImageTypeAndLoadImage();


### PR DESCRIPTION
Canvas2D cannot render compressed GPU formats (KTX, PVR, ASTC). Previously these would silently incur a full network fetch and binary decode, then fail with a cryptic assertTruthy error when getImage() found this.image unassigned.

Two-layer fix:
- ImageTexture.getTextureSource: detects canvas mode via txManager.renderer.mode and rejects before any fetch is started, setting texture state to 'failed' with a descriptive error.
- CanvasTexture.onLoadRequest: checks for the 'mipmaps' property that identifies CompressedData and throws explicitly, acting as an inner safety net if data arrives through an unexpected path.