### PR TITLE
fix: resolve canvas texture race conditions

### DIFF
--- a/src/core/renderers/canvas/CanvasRenderer.ts
+++ b/src/core/renderers/canvas/CanvasRenderer.ts
@@ -146,6 +146,9 @@ export class CanvasRenderer extends CoreRenderer {
       const tintColor = parseColor(color);
       if (textureType !== TextureType.subTexture) {
         const image = (texture.ctxTexture as CanvasTexture).getImage(tintColor);
+        if (image === null) {
+          return;
+        }
         this.context.globalAlpha = tintColor.a ?? node.worldAlpha;
         this.context.drawImage(image, tx, ty, width, height);
         this.context.globalAlpha = 1;
@@ -154,6 +157,9 @@ export class CanvasRenderer extends CoreRenderer {
       const image = (
         (texture as SubTexture).parentTexture.ctxTexture as CanvasTexture
       ).getImage(tintColor);
+      if (image === null) {
+        return;
+      }
       const props = (texture as SubTexture).props;
 
       this.context.globalAlpha = tintColor.a ?? node.worldAlpha;

--- a/src/core/renderers/canvas/CanvasTexture.ts
+++ b/src/core/renderers/canvas/CanvasTexture.ts
@@ -36,10 +36,23 @@ export class CanvasTexture extends CoreContextTexture {
     | undefined;
 
   async load(): Promise<void> {
+    // Capture textureData synchronously before any await - a pending
+    // freeTextureDataTask microtask could null textureSource.textureData
+    // during the first async suspension, causing onLoadRequest to fail.
+    const textureData = this.textureSource.textureData;
+    assertTruthy(textureData?.data, 'Texture data is null before load');
+
     this.textureSource.setState('loading');
 
     try {
-      const size = await this.onLoadRequest();
+      const size = await this.onLoadRequest(textureData.data);
+
+      // Guard against the texture being freed while the load was in flight
+      if (this.textureSource.state === 'freed') {
+        this.image = undefined;
+        return;
+      }
+
       this.textureSource.setState('loaded', size);
       this.textureSource.freeTextureData();
       this.updateMemSize();
@@ -82,9 +95,11 @@ export class CanvasTexture extends CoreContextTexture {
 
   getImage(
     color: IParsedColor,
-  ): ImageBitmap | HTMLCanvasElement | HTMLImageElement {
+  ): ImageBitmap | HTMLCanvasElement | HTMLImageElement | null {
     const image = this.image;
-    assertTruthy(image, 'Attempt to get unloaded image texture');
+    if (image === undefined) {
+      return null;
+    }
 
     if (color.isWhite) {
       if (this.tintCache) {
@@ -133,10 +148,9 @@ export class CanvasTexture extends CoreContextTexture {
     return canvas;
   }
 
-  private async onLoadRequest(): Promise<Dimensions> {
-    assertTruthy(this.textureSource?.textureData?.data, 'Texture data is null');
-    const { data } = this.textureSource.textureData;
-
+  private async onLoadRequest(
+    data: NonNullable<NonNullable<Texture['textureData']>['data']>,
+  ): Promise<Dimensions> {
     // TODO: canvas from text renderer should be able to provide the canvas directly
     // instead of having to re-draw it into a new canvas...
     if (data instanceof ImageData) {
@@ -144,7 +158,7 @@ export class CanvasTexture extends CoreContextTexture {
       canvas.width = data.width;
       canvas.height = data.height;
       const ctx = canvas.getContext('2d');
-      if (ctx) ctx.putImageData(data, 0, 0);
+      if (ctx !== null) ctx.putImageData(data, 0, 0);
       this.image = canvas;
       return { w: data.width, h: data.height };
     } else if (

--- a/src/core/renderers/canvas/CanvasTexture.ts
+++ b/src/core/renderers/canvas/CanvasTexture.ts
@@ -21,6 +21,7 @@ import type { Dimensions } from '../../../common/CommonTypes.js';
 import { assertTruthy } from '../../../utils.js';
 import { formatRgba, type IParsedColor } from '../../lib/colorParser.js';
 import { CoreContextTexture } from '../CoreContextTexture.js';
+import type { Texture } from '../../textures/Texture.js';
 
 export class CanvasTexture extends CoreContextTexture {
   protected image:

--- a/src/core/textures/Texture.ts
+++ b/src/core/textures/Texture.ts
@@ -252,6 +252,11 @@ export abstract class Texture extends EventEmitter {
       return false;
     }
 
+    // Don't cleanup a texture that is in the process of loading
+    if (this.state === 'loading') {
+      return false;
+    }
+
     // Don't cleanup if not renderable
     if (this.renderable === true) {
       return false;
@@ -353,6 +358,7 @@ export abstract class Texture extends EventEmitter {
    */
   free(): void {
     this.ctxTexture?.free();
+    this.ctxTexture = undefined;
   }
 
   /**


### PR DESCRIPTION
- CanvasTexture.load(): capture textureData ref before first await to prevent freeTextureDataTask microtask from nulling it mid-flight
- CanvasTexture.load(): abort if texture is freed while load is in-flight to prevent state/image desync (state=loaded but image=undefined)
- CanvasTexture.getImage(): return null instead of asserting on missing image, allowing callers to skip gracefully
- CanvasRenderer.renderContext(): guard against null return from getImage()
- Texture.free(): null out ctxTexture after freeing to prevent stale reference reuse on reload
- Texture.canBeCleanedUp(): exclude textures in 'loading' state from eviction to prevent cleanup racing an in-flight load