### PR TITLE
fix(platform): add loadFontFace to platform abstraction

### DIFF
--- a/src/core/platforms/Platform.ts
+++ b/src/core/platforms/Platform.ts
@@ -178,4 +178,24 @@ export abstract class Platform {
    * @param font - The FontFace to add
    */
   abstract addFont(font: FontFace): void;
+
+  /**
+   * Loads a font by URL and registers it for use with canvas rendering.
+   *
+   * @remarks
+   * Platform implementations may override this to use a browser-compatible
+   * font loading strategy. The default implementation (in {@link WebPlatform})
+   * uses the `FontFace` JavaScript API. Legacy platforms should override this
+   * to use CSS `@font-face` injection, which is supported by all browsers.
+   *
+   * @param fontFamily - The CSS font-family name to register the font under
+   * @param fontUrl - The URL of the font file (e.g. `.ttf`, `.woff`, `.woff2`)
+   * @returns A promise that resolves with the loaded `FontFace` object, or
+   * `null` if the platform used an alternative loading strategy (e.g. CSS
+   * injection) that does not produce a `FontFace` instance.
+   */
+  abstract loadFontFace(
+    fontFamily: string,
+    fontUrl: string,
+  ): Promise<FontFace | null>;
 }

--- a/src/core/platforms/web/WebPlatform.ts
+++ b/src/core/platforms/web/WebPlatform.ts
@@ -316,4 +316,13 @@ export class WebPlatform extends Platform {
   override addFont(font: FontFace): void {
     (document.fonts as FontFaceSetWithAdd).add(font);
   }
+
+  override async loadFontFace(
+    fontFamily: string,
+    fontUrl: string,
+  ): Promise<FontFace | null> {
+    const font = await new FontFace(fontFamily, `url(${fontUrl})`).load();
+    this.addFont(font);
+    return font;
+  }
 }

--- a/src/core/platforms/web/WebPlatformLegacy.ts
+++ b/src/core/platforms/web/WebPlatformLegacy.ts
@@ -147,4 +147,55 @@ export class WebPlatformLegacy extends WebPlatform {
       `Compressed textures are not supported in legacy mode. Attempted to load: ${src}`,
     );
   }
+
+  /**
+   * Load a font using CSS `@font-face` injection.
+   *
+   * @remarks
+   * The `FontFace` JavaScript constructor used by {@link WebPlatform} relies on
+   * the CSS Font Loading API. While the API is nominally present on Chrome 35+,
+   * embedded/legacy browsers (QtWebKit, older WPEWebKit builds, some set-top-box
+   * browsers) either lack the API entirely or silently drop fonts loaded this way
+   * before they reach the canvas 2D rasteriser.
+   *
+   * Injecting a `<style>` block with an `@font-face` rule is the universally
+   * supported alternative: every browser that renders text supports it.  When
+   * `document.fonts.load()` is available we also trigger an eager load so that
+   * the font is available immediately rather than on first paint.
+   */
+  override async loadFontFace(
+    fontFamily: string,
+    fontUrl: string,
+  ): Promise<FontFace | null> {
+    // Determine the format hint so old browsers know how to decode the file.
+    const lower = fontUrl.toLowerCase();
+    const formatHint = lower.endsWith('.ttf')
+      ? " format('truetype')"
+      : lower.endsWith('.woff2')
+      ? " format('woff2')"
+      : lower.endsWith('.woff')
+      ? " format('woff')"
+      : lower.endsWith('.otf')
+      ? " format('opentype')"
+      : '';
+
+    const style = document.createElement('style');
+    style.textContent = `@font-face { font-family: '${fontFamily}'; src: url('${fontUrl}')${formatHint}; }`;
+    document.head.appendChild(style);
+
+    // Eagerly trigger font loading when the CSS Font Loading API is available
+    // so callers can await full availability.  On browsers that lack the API
+    // the font will be loaded lazily by the layout engine on first use.
+    if (
+      typeof document.fonts !== 'undefined' &&
+      typeof document.fonts.load === 'function'
+    ) {
+      await document.fonts.load(`16px '${fontFamily}'`).catch(() => {
+        // Swallow load errors – the @font-face rule is already injected and
+        // the browser will retry when the font is actually needed.
+      });
+    }
+
+    return null;
+  }
 }

--- a/src/core/text-rendering/CanvasFontHandler.ts
+++ b/src/core/text-rendering/CanvasFontHandler.ts
@@ -103,11 +103,10 @@ export const loadFont = async (
 
   const nwff: CoreTextNode[] = (nodesWaitingForFont[fontFamily] = []);
   // Create and store the loading promise
-  const loadPromise = new FontFace(fontFamily, `url(${fontUrl})`)
-    .load()
+  const loadPromise = stage.platform
+    .loadFontFace(fontFamily, fontUrl!)
     .then((loadedFont) => {
-      stage.platform.addFont(loadedFont);
-      processFontData(fontFamily, loadedFont, metrics);
+      processFontData(fontFamily, loadedFont ?? undefined, metrics);
       fontLoadPromises.delete(fontFamily);
       for (let key in nwff) {
         nwff[key]!.setUpdateType(UpdateType.Local);


### PR DESCRIPTION
WebPlatformLegacy did not override font loading, so it inherited the FontFace JS constructor path from WebPlatform. On embedded/legacy browsers (QtWebKit, older WPEWebKit, some STB browsers) the FontFace API is absent or silently drops loaded fonts before they reach the canvas 2D rasteriser.

Introduce Platform.loadFontFace(family, url) as the single extension point for canvas font loading:

- WebPlatform: uses new FontFace().load() + document.fonts.add() (existing modern-browser behaviour, unchanged)
- WebPlatformLegacy: injects a <style> @font-face rule with format hints (.ttf/.woff2/.woff/.otf) and eagerly triggers loading via document.fonts.load() where available; resolves immediately on browsers that lack the CSS Font Loading API so the browser can load the font lazily on first paint.

CanvasFontHandler.loadFont() now delegates to
stage.platform.loadFontFace() instead of constructing FontFace directly, keeping all browser-specific font loading logic inside the platform layer.

Fixes font loading regression introduced in PR #746.