### PR TITLE
fix(webgl): correctly handle premultiplied-alpha for ImageBitmap

### DIFF
--- a/src/core/platforms/web/WebPlatform.ts
+++ b/src/core/platforms/web/WebPlatform.ts
@@ -230,7 +230,11 @@ export class WebPlatform extends Platform {
         colorSpaceConversion: 'none',
         imageOrientation: 'none',
       });
-      return { data: bitmap, premultiplyAlpha: hasAlphaChannel };
+      return {
+        data: bitmap,
+        premultiplyAlpha: hasAlphaChannel,
+        premultiplied: true,
+      };
     }
 
     // default createImageBitmap without crop but with options
@@ -240,7 +244,11 @@ export class WebPlatform extends Platform {
       imageOrientation: 'none',
     });
 
-    return { data: bitmap, premultiplyAlpha: hasAlphaChannel };
+    return {
+      data: bitmap,
+      premultiplyAlpha: hasAlphaChannel,
+      premultiplied: true,
+    };
   }
 
   override async loadImage(

--- a/src/core/platforms/web/WebPlatformChrome50.ts
+++ b/src/core/platforms/web/WebPlatformChrome50.ts
@@ -58,6 +58,14 @@ export class WebPlatformChrome50 extends WebPlatform {
     // No options or cropping parameters supported
     const bitmap = await createImageBitmap(blob);
 
-    return { data: bitmap, premultiplyAlpha: hasAlphaChannel };
+    // The bitmap was created without a premultiplyAlpha option so the browser
+    // decides whether to premultiply. On older WPEWebKit the default is
+    // straight alpha, so we mark premultiplied: false here to signal
+    // that UNPACK_PREMULTIPLY_ALPHA_WEBGL should be set at upload time.
+    return {
+      data: bitmap,
+      premultiplyAlpha: hasAlphaChannel,
+      premultiplied: false,
+    };
   }
 }

--- a/src/core/platforms/web/lib/ImageWorkerDefault.ts
+++ b/src/core/platforms/web/lib/ImageWorkerDefault.ts
@@ -65,7 +65,11 @@ export function createImageWorker() {
             imageOrientation: 'none',
           })
             .then(function (data) {
-              resolve({ data, premultiplyAlpha: premultiplyAlpha });
+              resolve({
+                data,
+                premultiplyAlpha: withAlphaChannel,
+                premultiplied: true,
+              });
             })
             .catch(function (error) {
               reject(error);
@@ -79,7 +83,11 @@ export function createImageWorker() {
           imageOrientation: 'none',
         })
           .then(function (data) {
-            resolve({ data, premultiplyAlpha: premultiplyAlpha });
+            resolve({
+              data,
+              premultiplyAlpha: withAlphaChannel,
+              premultiplied: true,
+            });
           })
           .catch(function (error) {
             reject(error);

--- a/src/core/platforms/web/lib/ImageWorkerNoOptions.ts
+++ b/src/core/platforms/web/lib/ImageWorkerNoOptions.ts
@@ -36,7 +36,11 @@ export function createImageWorkerNoOptions() {
     y: number | null,
     width: number | null,
     height: number | null,
-  ): Promise<{ data: ImageBitmap; premultiplyAlpha: boolean | null }> {
+  ): Promise<{
+    data: ImageBitmap;
+    premultiplyAlpha: boolean | null;
+    premultiplied: boolean;
+  }> {
     return new Promise(function (resolve, reject) {
       var xhr = new XMLHttpRequest();
       xhr.open('GET', src, true);
@@ -61,7 +65,14 @@ export function createImageWorkerNoOptions() {
 
         createImageBitmap(blob)
           .then(function (data) {
-            resolve({ data, premultiplyAlpha: withAlphaChannel });
+            // No premultiplyAlpha option was passed so the browser decides.
+            // Mark premultiplied: false so the upload path sets
+            // UNPACK_PREMULTIPLY_ALPHA_WEBGL = true for PNG images.
+            resolve({
+              data,
+              premultiplyAlpha: withAlphaChannel,
+              premultiplied: false,
+            });
           })
           .catch(function (error) {
             reject(error);

--- a/src/core/renderers/webgl/WebGlCtxTexture.test.ts
+++ b/src/core/renderers/webgl/WebGlCtxTexture.test.ts
@@ -31,10 +31,305 @@
  * All tests here are RED before the fix and GREEN after.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { WebGlShaderProgram } from './WebGlShaderProgram.js';
 import { CoreNode } from '../../CoreNode.js';
-import type { WebGlCtxTexture } from './WebGlCtxTexture.js';
+import { WebGlCtxTexture } from './WebGlCtxTexture.js';
+import type { TextureData } from '../../textures/Texture.js';
+
+// ---------------------------------------------------------------------------
+// Test 1 — bindTextures crashes when textures[0] is undefined
+//
+// Directly mirrors the crash from the production stack trace:
+//   fb.bindTextures → textures[0]!.ctxTexture
+//   → TypeError: Cannot read property 'ctxTexture' of undefined
+// ---------------------------------------------------------------------------
+describe('WebGlShaderProgram.bindTextures', () => {
+  it('does not throw when textures[0] is undefined', () => {
+    // Create a minimal instance that bypasses the GL-context-requiring constructor
+    const instance = Object.create(
+      WebGlShaderProgram.prototype,
+    ) as WebGlShaderProgram;
+    (instance as any).glw = { activeTexture: vi.fn(), bindTexture: vi.fn() };
+
+    // After Fix B: bindTextures returns early instead of crashing
+    expect(() =>
+      instance.bindTextures([undefined as unknown as WebGlCtxTexture]),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2 — addTexture silently accepts undefined and stores it
+//
+// The crash is silent at this layer: passing an undefined ctxTexture to
+// CoreNode.addTexture does NOT throw — it quietly pushes undefined into
+// renderOpTextures, poisoning the array for bindTextures later.
+// ---------------------------------------------------------------------------
+describe('CoreNode.addTexture with undefined ctxTexture', () => {
+  it('accepts undefined without throwing and stores it in renderOpTextures', () => {
+    // Call via prototype to avoid the complex CoreNode constructor
+    const fakeCtx = { renderOpTextures: [] as WebGlCtxTexture[] };
+    const idx = CoreNode.prototype.addTexture.call(
+      fakeCtx,
+      undefined as unknown as WebGlCtxTexture,
+    );
+
+    // No error raised here — that is the problem
+    expect(idx).toBe(0);
+    // undefined is now stored; any subsequent bindTextures call will crash
+    expect(fakeCtx.renderOpTextures[0]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 3 — full crash chain: undefined ctxTexture → addTexture → bindTextures
+//
+// End-to-end proof that the chain fails before any fix is applied.
+// ---------------------------------------------------------------------------
+describe('full OOM crash chain: undefined ctxTexture → bindTextures crash', () => {
+  it('does not crash when undefined ctxTexture propagates to bindTextures', () => {
+    // Simulate: GPU OOM causes Texture.release() → ctxTexture = undefined
+    const undefinedCtxTexture = undefined as unknown as WebGlCtxTexture;
+
+    // Simulate: WebGlRenderer.addQuad reads tx.ctxTexture (undefined) and
+    // passes it to curRenderOp.addTexture — no error thrown here
+    const fakeRenderOp = { renderOpTextures: [] as WebGlCtxTexture[] };
+    CoreNode.prototype.addTexture.call(fakeRenderOp, undefinedCtxTexture);
+
+    // Confirm undefined is still sitting in renderOpTextures (addTexture is unchanged)
+    expect(fakeRenderOp.renderOpTextures[0]).toBeUndefined();
+
+    // Simulate: bindRenderOp calls bindTextures with the poisoned array
+    const program = Object.create(
+      WebGlShaderProgram.prototype,
+    ) as WebGlShaderProgram;
+    (program as any).glw = { activeTexture: vi.fn(), bindTexture: vi.fn() };
+
+    // After Fix B: bindTextures returns early — the draw loop is protected
+    expect(() =>
+      program.bindTextures(fakeRenderOp.renderOpTextures),
+    ).not.toThrow();
+  });
+});
+
+// =============================================================================
+// Tests for UNPACK_PREMULTIPLY_ALPHA_WEBGL selection in onLoadRequest
+//
+// The renderer uses blendFunc(ONE, ONE_MINUS_SRC_ALPHA) which requires
+// premultiplied-alpha textures on the GPU. UNPACK_PREMULTIPLY_ALPHA_WEBGL
+// controls whether the WebGL driver premultiplies during the CPU→GPU copy:
+//
+//   UNPACK = false → data is already premultiplied (skip driver step)
+//   UNPACK = true  → data is straight alpha (driver premultiplies on upload)
+//
+// For ImageBitmap sources the WebGL spec permits drivers to ignore UNPACK, so
+// premultiplication MUST happen inside createImageBitmap itself.
+// TextureData.premultiplied records whether the platform did this:
+//
+//   true  → WebPlatform: explicit premultiplyAlpha:'premultiply' option
+//   false → WebPlatformChrome50 / older WPEWebKit: no option → straight alpha
+//   undef → legacy path, backwards-compatible (treated as true)
+//
+// For HTMLImageElement sources UNPACK is always honoured by spec; the old
+// premultiplyAlpha flag governs that path unchanged.
+// =============================================================================
+
+// The real WebGL constant for UNPACK_PREMULTIPLY_ALPHA_WEBGL.
+const UNPACK_PA = 0x9241;
+
+/**
+ * A stand-in for HTMLImageElement that satisfies isHTMLImageElement().
+ * The function checks obj.constructor.name === 'HTMLImageElement', so
+ * we rename the class using defineProperty.
+ */
+class FakeHTMLImageElement {
+  constructor(public width = 10, public height = 10) {}
+}
+Object.defineProperty(FakeHTMLImageElement, 'name', {
+  value: 'HTMLImageElement',
+});
+
+/**
+ * Build a minimal WebGlCtxTexture instance that bypasses the real constructor
+ * and has every GL method mocked. Returns the instance and a spy on pixelStorei
+ * so tests can assert exactly which UNPACK value was passed.
+ */
+function makeCtxTextureForUnpackTest(textureData: TextureData) {
+  const pixelStoreiSpy = vi.fn();
+
+  const glw = {
+    RGBA: 0x1908,
+    UNSIGNED_BYTE: 0x1401,
+    UNPACK_PREMULTIPLY_ALPHA_WEBGL: UNPACK_PA,
+    activeTexture: vi.fn(),
+    bindTexture: vi.fn(),
+    texImage2D: vi.fn(),
+    pixelStorei: pixelStoreiSpy,
+    getError: vi.fn(() => 0),
+  };
+
+  const instance = Object.create(WebGlCtxTexture.prototype) as WebGlCtxTexture;
+  (instance as any).glw = glw;
+  // Provide a non-null native texture handle so onLoadRequest doesn't bail out.
+  (instance as any)._nativeCtxTexture = {};
+  (instance as any).state = 'loading';
+  (instance as any).textureSource = { textureData };
+  (instance as any).setTextureMemUse = vi.fn();
+
+  return { instance, pixelStoreiSpy };
+}
+
+// ---------------------------------------------------------------------------
+// ImageBitmap — UNPACK selection driven by premultiplied flag
+// ---------------------------------------------------------------------------
+describe('WebGlCtxTexture.onLoadRequest — UNPACK for ImageBitmap (premultiplied flag)', () => {
+  // Stub a fake ImageBitmap class so that `tdata instanceof ImageBitmap`
+  // evaluates to true inside onLoadRequest even in a Node.js test context.
+  let OriginalImageBitmap: unknown;
+
+  beforeEach(() => {
+    OriginalImageBitmap = (globalThis as any).ImageBitmap;
+    (globalThis as any).ImageBitmap = class FakeImageBitmap {
+      width = 10;
+      height = 10;
+    };
+  });
+
+  afterEach(() => {
+    (globalThis as any).ImageBitmap = OriginalImageBitmap;
+  });
+
+  it(
+    'UNPACK = false when premultiplied is true ' +
+      '(WebPlatform: createImageBitmap with premultiplyAlpha option)',
+    async () => {
+      // Represents the WebPlatform / ImageWorkerDefault path where
+      // createImageBitmap was called with { premultiplyAlpha: 'premultiply' }.
+      const bitmap = new (globalThis as any).ImageBitmap();
+      const { instance, pixelStoreiSpy } = makeCtxTextureForUnpackTest({
+        data: bitmap,
+        premultiplyAlpha: true,
+        premultiplied: true,
+      });
+
+      await instance.onLoadRequest();
+
+      expect(pixelStoreiSpy).toHaveBeenCalledWith(UNPACK_PA, false);
+    },
+  );
+
+  it(
+    'UNPACK = true when premultiplied is false and premultiplyAlpha is true ' +
+      '(WebPlatformChrome50 / older WPEWebKit: no-option createImageBitmap, PNG)',
+    async () => {
+      // Represents WebPlatformChrome50 loading a PNG. createImageBitmap(blob)
+      // was called WITHOUT premultiplyAlpha option, so the browser may return
+      // straight-alpha data. We need the driver to premultiply on upload.
+      const bitmap = new (globalThis as any).ImageBitmap();
+      const { instance, pixelStoreiSpy } = makeCtxTextureForUnpackTest({
+        data: bitmap,
+        premultiplyAlpha: true,
+        premultiplied: false,
+      });
+
+      await instance.onLoadRequest();
+
+      // KEY ASSERTION: this was incorrectly `false` before the fix, producing
+      // straight-alpha pixels composited against ONE, ONE_MINUS_SRC_ALPHA.
+      expect(pixelStoreiSpy).toHaveBeenCalledWith(UNPACK_PA, true);
+    },
+  );
+
+  it(
+    'UNPACK = false when premultiplied is false and premultiplyAlpha is false ' +
+      '(Chrome50 non-alpha image: no premultiplication needed)',
+    async () => {
+      // JPEG / non-alpha image loaded via Chrome50. Neither the bitmap nor the
+      // driver should premultiply anything.
+      const bitmap = new (globalThis as any).ImageBitmap();
+      const { instance, pixelStoreiSpy } = makeCtxTextureForUnpackTest({
+        data: bitmap,
+        premultiplyAlpha: false,
+        premultiplied: false,
+      });
+
+      await instance.onLoadRequest();
+
+      expect(pixelStoreiSpy).toHaveBeenCalledWith(UNPACK_PA, false);
+    },
+  );
+
+  it(
+    'UNPACK = false when premultiplied is undefined ' +
+      '(legacy / missing flag: backwards-compatible default)',
+    async () => {
+      // An ImageBitmap response that predates the premultiplied flag.
+      // Should behave as before (assume bitmap is already premultiplied).
+      const bitmap = new (globalThis as any).ImageBitmap();
+      const { instance, pixelStoreiSpy } = makeCtxTextureForUnpackTest({
+        data: bitmap,
+        premultiplyAlpha: true,
+        // premultiplied intentionally absent
+      });
+
+      await instance.onLoadRequest();
+
+      expect(pixelStoreiSpy).toHaveBeenCalledWith(UNPACK_PA, false);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// HTMLImageElement — UNPACK governed by premultiplyAlpha flag (unchanged path)
+// ---------------------------------------------------------------------------
+describe('WebGlCtxTexture.onLoadRequest — UNPACK for HTMLImageElement (premultiplyAlpha flag)', () => {
+  // ImageData is a browser API not present in Node. The condition in
+  // onLoadRequest evaluates `tdata instanceof ImageData` before reaching the
+  // isHTMLImageElement check, so we need a stub to prevent a ReferenceError.
+  let OriginalImageData: unknown;
+
+  beforeEach(() => {
+    OriginalImageData = (globalThis as any).ImageData;
+    (globalThis as any).ImageData = class FakeImageData {};
+  });
+
+  afterEach(() => {
+    (globalThis as any).ImageData = OriginalImageData;
+  });
+
+  it(
+    'UNPACK = true when premultiplyAlpha is true ' +
+      '(WebPlatformLegacy PNG: driver premultiplies on upload)',
+    async () => {
+      const img = new FakeHTMLImageElement();
+      const { instance, pixelStoreiSpy } = makeCtxTextureForUnpackTest({
+        data: img as unknown as HTMLImageElement,
+        premultiplyAlpha: true,
+      });
+
+      await instance.onLoadRequest();
+
+      expect(pixelStoreiSpy).toHaveBeenCalledWith(UNPACK_PA, true);
+    },
+  );
+
+  it(
+    'UNPACK = false when premultiplyAlpha is false ' +
+      '(non-alpha image or SDF font atlas)',
+    async () => {
+      const img = new FakeHTMLImageElement();
+      const { instance, pixelStoreiSpy } = makeCtxTextureForUnpackTest({
+        data: img as unknown as HTMLImageElement,
+        premultiplyAlpha: false,
+      });
+
+      await instance.onLoadRequest();
+
+      expect(pixelStoreiSpy).toHaveBeenCalledWith(UNPACK_PA, false);
+    },
+  );
+});
 
 // ---------------------------------------------------------------------------
 // Test 1 — bindTextures crashes when textures[0] is undefined

--- a/src/core/renderers/webgl/WebGlCtxTexture.ts
+++ b/src/core/renderers/webgl/WebGlCtxTexture.ts
@@ -206,10 +206,34 @@ export class WebGlCtxTexture extends CoreContextTexture {
       w = tdata.width;
       h = tdata.height;
       glw.bindTexture(this._nativeCtxTexture);
-      glw.pixelStorei(
-        glw.UNPACK_PREMULTIPLY_ALPHA_WEBGL,
-        isImageBitmap ? false : !!textureData.premultiplyAlpha,
-      );
+
+      // Determine whether the WebGL driver should premultiply alpha at upload
+      // time (UNPACK_PREMULTIPLY_ALPHA_WEBGL).
+      //
+      // • ImageBitmap — the spec allows implementations to ignore UNPACK for
+      //   ImageBitmap sources, so premultiplication must happen inside
+      //   createImageBitmap itself.  We use textureData.premultiplied
+      //   to know whether the platform did that:
+      //     - true  → bitmap is already premultiplied → UNPACK = false (no-op)
+      //     - false → bitmap has straight alpha (e.g. WebPlatformChrome50 on
+      //               older WPEWebKit) → UNPACK = !!premultiplyAlpha so the
+      //               driver premultiplies during the CPU→GPU copy
+      //     - undefined → legacy path, assume premultiplied (UNPACK = false)
+      //
+      // • HTMLImageElement / ImageData — the spec guarantees that
+      //   UNPACK_PREMULTIPLY_ALPHA_WEBGL is honoured for these types, so we
+      //   delegate to the premultiplyAlpha flag as before.
+      let unpackPremultiply: boolean;
+      if (isImageBitmap) {
+        const premultiplied = textureData.premultiplied ?? true;
+        unpackPremultiply = premultiplied
+          ? false
+          : !!textureData.premultiplyAlpha;
+      } else {
+        unpackPremultiply = !!textureData.premultiplyAlpha;
+      }
+
+      glw.pixelStorei(glw.UNPACK_PREMULTIPLY_ALPHA_WEBGL, unpackPremultiply);
 
       glw.texImage2D(0, format, format, glw.UNSIGNED_BYTE, tdata);
 

--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -109,6 +109,22 @@ export interface ImageTextureProps {
 export interface ImageResponse {
   data: ImageBitmap | ImageData | CompressedImageData | HTMLImageElement | null;
   premultiplyAlpha: boolean | null;
+  /**
+   * Whether the pixel data is already premultiplied.
+   *
+   * @remarks
+   * Only meaningful for `ImageBitmap` responses. Platforms that invoke
+   * `createImageBitmap` with an explicit `premultiplyAlpha: 'premultiply'`
+   * option set this to `true`. Platforms that call `createImageBitmap`
+   * without options (e.g. `WebPlatformChrome50`) set this to `false` because
+   * the browser's default alpha handling is implementation-defined and may
+   * return straight-alpha data on older WPEWebKit.
+   *
+   * `HTMLImageElement`-based platforms (e.g. `WebPlatformLegacy`) leave this
+   * `undefined`; it is irrelevant for them because straight-alpha is handled
+   * via `UNPACK_PREMULTIPLY_ALPHA_WEBGL = true` at upload time.
+   */
+  premultiplied?: boolean;
 }
 
 /**
@@ -182,6 +198,7 @@ export class ImageTexture extends Texture {
     return {
       data: resp.data,
       premultiplyAlpha: this.props.premultiplyAlpha ?? true,
+      premultiplied: resp.premultiplied,
     };
   }
 

--- a/src/core/textures/Texture.ts
+++ b/src/core/textures/Texture.ts
@@ -113,6 +113,27 @@ export interface TextureData {
    * @defaultValue `false`
    */
   premultiplyAlpha?: boolean | null;
+  /**
+   * Whether the pixel data is already premultiplied (e.g. produced by
+   * `createImageBitmap` with `premultiplyAlpha: 'premultiply'`).
+   *
+   * @remarks
+   * This flag is only meaningful for `ImageBitmap` data sources. When `true`,
+   * `UNPACK_PREMULTIPLY_ALPHA_WEBGL` is set to `false` at upload time to
+   * prevent double-premultiplication. When `false`, the flag is set to `true`
+   * so the WebGL driver premultiplies during the CPU→GPU copy (same path as
+   * `HTMLImageElement`). When `undefined`, behaviour falls back to the legacy
+   * assumption that all `ImageBitmap` sources are already premultiplied.
+   *
+   * Platforms that call `createImageBitmap` **without** the
+   * `premultiplyAlpha: 'premultiply'` option (e.g. `WebPlatformChrome50`)
+   * must set this to `false`, otherwise the renderer composites straight-alpha
+   * pixels against a `blendFunc(ONE, ONE_MINUS_SRC_ALPHA)` equation and
+   * produces incorrect results on older WPEWebKit.
+   *
+   * @defaultValue `undefined` (treated as `true` for `ImageBitmap` sources)
+   */
+  premultiplied?: boolean;
 }
 /**
  * TextureCoords generally numbers between 0 - 1


### PR DESCRIPTION
The WebGL spec permits implementations to ignore UNPACK_PREMULTIPLY_ALPHA_WEBGL for ImageBitmap sources — premultiplication must occur inside createImageBitmap(). Older WPEWebKit (Xi6 / Chrome 50 era) does not honour the 'premultiplyAlpha' option on createImageBitmap, delivering straight-alpha pixels.  Uploading those with UNPACK_PREMULTIPLY_ALPHA_WEBGL=false into a pipeline that uses blendFunc(ONE, ONE_MINUS_SRC_ALPHA) produces washed-out compositing artefacts.

Changes:
- TextureData / ImageResponse: add optional alreadyPremultiplied flag that platforms set to indicate whether the bitmap pixels are already premultiplied
- WebPlatform: sets alreadyPremultiplied: true (both crop and no-crop paths)
- WebPlatformChrome50: sets alreadyPremultiplied: false (WPEWebKit straight-alpha)
- ImageWorkerDefault: alreadyPremultiplied: true; also fix secondary bug where premultiplyAlpha resolved the raw input param instead of the computed withAlphaChannel value
- ImageWorkerNoOptions: alreadyPremultiplied: false + updated return type
- WebGlCtxTexture: replace hard-coded isImageBitmap ? false : ... with explicit branch using alreadyPremultiplied ?? true (undefined preserves old behaviour)