### PR TITLE
feat(rich-text): add richText boolean prop to TrProps and CoreTextNode

### DIFF
--- a/src/core/CoreTextNode.test.ts
+++ b/src/core/CoreTextNode.test.ts
@@ -85,6 +85,7 @@ describe('CoreTextNode', () => {
     // CoreTextNodeProps specific
     textRendererOverride: null,
     forceLoad: false,
+    richText: false,
   };
 
   const clippingRect = {
@@ -656,6 +657,66 @@ describe('CoreTextNode', () => {
       expect(setScissorTest).toHaveBeenCalledWith(true);
       expect(scissor).toHaveBeenCalledWith(10, 155, 30, 40);
       expect(drawArrays).toHaveBeenCalledWith(4, 0, 12);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // richText property
+  // -------------------------------------------------------------------------
+
+  describe('richText property', () => {
+    let node: CoreTextNode;
+
+    beforeEach(() => {
+      node = new CoreTextNode(stage, { ...defaultTextProps }, mockTextRenderer);
+      // Start each test with a clean update state
+      node.update(0, stage as any);
+    });
+
+    it('defaults to false', () => {
+      const fresh = new CoreTextNode(
+        stage,
+        { ...defaultTextProps },
+        mockTextRenderer,
+      );
+      expect(fresh.richText).toBe(false);
+    });
+
+    it('getter returns the stored value after being set to true', () => {
+      node.richText = true;
+      expect(node.richText).toBe(true);
+    });
+
+    it('getter returns false after being set back to false', () => {
+      node.richText = true;
+      node.richText = false;
+      expect(node.richText).toBe(false);
+    });
+
+    it('setter marks layout as stale when value changes to true', () => {
+      node['_layoutGenerated'] = true;
+      node.richText = true;
+      expect(node['_layoutGenerated']).toBe(false);
+    });
+
+    it('setter marks layout as stale when value changes back to false', () => {
+      node.richText = true;
+      node['_layoutGenerated'] = true;
+      node.richText = false;
+      expect(node['_layoutGenerated']).toBe(false);
+    });
+
+    it('setter does not mark layout as stale when value is unchanged (false → false)', () => {
+      node['_layoutGenerated'] = true;
+      node.richText = false;
+      expect(node['_layoutGenerated']).toBe(true);
+    });
+
+    it('setter does not mark layout as stale when value is unchanged (true → true)', () => {
+      node.richText = true;
+      node['_layoutGenerated'] = true;
+      node.richText = true;
+      expect(node['_layoutGenerated']).toBe(true);
     });
   });
 });

--- a/src/core/CoreTextNode.ts
+++ b/src/core/CoreTextNode.ts
@@ -728,6 +728,18 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
     }
   }
 
+  get richText(): boolean {
+    return this.textProps.richText;
+  }
+
+  set richText(value: boolean) {
+    if (this.textProps.richText !== value) {
+      this.textProps.richText = value;
+      this._layoutGenerated = false;
+      this.setUpdateType(UpdateType.Local);
+    }
+  }
+
   get renderInfo(): TextRenderInfo | null {
     return this._renderInfo;
   }

--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -699,6 +699,7 @@ export class Stage {
       maxWidth: props.maxWidth || 0,
       maxHeight: props.maxHeight || 0,
       forceLoad: props.forceLoad || false,
+      richText: props.richText ?? false,
     });
 
     const resolvedTextRenderer = this.resolveTextRenderer(

--- a/src/core/renderers/webgl/WebGlShaderProgram.test.ts
+++ b/src/core/renderers/webgl/WebGlShaderProgram.test.ts
@@ -90,6 +90,7 @@ const makeTextProps = (): CoreTextNodeProps => ({
   wordBreak: 'break-word',
   textRendererOverride: null,
   forceLoad: false,
+  richText: false,
 });
 
 const makeSdfTextRenderer = (): TextRenderer =>

--- a/src/core/text-rendering/TextRenderer.ts
+++ b/src/core/text-rendering/TextRenderer.ts
@@ -248,6 +248,31 @@ export interface TrProps extends TrFontProps {
    * @default 'none'
    */
   contain: 'width' | 'height' | 'both' | 'none';
+
+  /**
+   * Enable BB-code rich text parsing for this text node.
+   *
+   * @remarks
+   *
+   * When `true`, the {@link text} string is parsed for BB-code tags before
+   * layout and rendering. Supported tags:
+   *
+   * - `[b]…[/b]` — bold
+   * - `[i]…[/i]` — italic
+   * - `[u]…[/u]` — underline
+   * - `[s]…[/s]` — strikethrough
+   * - `[color=0xRRGGBBAA]…[/color]` — inline color (must use the renderer's
+   *   internal `0xRRGGBBAA` hex format, e.g. `[color=0xff0000ff]`)
+   *
+   * Unrecognised or malformed tags are emitted as literal text. Mis-nested
+   * closing tags implicitly close any intervening open tags.
+   *
+   * When `false` (the default), the `text` string is rendered as-is with no
+   * tag parsing.
+   *
+   * @default false
+   */
+  richText: boolean;
 }
 
 /**

--- a/src/core/text-rendering/Utils.ts
+++ b/src/core/text-rendering/Utils.ts
@@ -99,5 +99,5 @@ export function tokenizeString(tokenRegex: RegExp, text: string): string[] {
 }
 
 export function getLayoutCacheKey(props: CoreTextNodeProps): string {
-  return `${props.text}-${props.fontFamily}-${props.fontSize}-${props.letterSpacing}-${props.lineHeight}-${props.maxHeight}-${props.maxWidth}-${props.textAlign}-${props.wordBreak}-${props.maxLines}-${props.overflowSuffix}`;
+  return `${props.text}-${props.fontFamily}-${props.fontSize}-${props.letterSpacing}-${props.lineHeight}-${props.maxHeight}-${props.maxWidth}-${props.textAlign}-${props.wordBreak}-${props.maxLines}-${props.overflowSuffix}-${props.richText}`;
 }


### PR DESCRIPTION
Wires the richText: boolean flag into the full prop surface. Renderers
will use it to gate BB-code parsing in subsequent PRs. This PR is purely plumbing — no rendering behaviour changes.

Depends on https://github.com/lightning-js/renderer/pull/809

Changes:
- TrProps: add richText: boolean with JSDoc listing all supported tags
- getLayoutCacheKey: append richText to the cache key so that the same text string cached under richText=false is never returned for richText=true once the renderers start stripping tags
- Stage.createTextNode: default richText to false via ?? operator
- CoreTextNode: getter + setter for richText; setter invalidates layout (_layoutGenerated=false) and schedules UpdateType.Local on change
- CoreTextNode.test.ts: add richText to defaultTextProps fixture; add 7 tests covering default value, getter, setter state transitions, and idempotent no-op behaviour

ITextNodeProps inherits richText automatically through the existing Omit<CoreTextNodeProps, 'parent'> chain — no INode.ts change needed.