### PR TITLE
docs(agent): add Mali 400 / OpenGL ES 2.0 GPU target instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,6 +15,90 @@
 - **Early returns** - Most common paths first, error checks on top
 - **Arrow functions for utilities** - Use arrow functions for libraries/singletons/utilities
 
+## GPU Target: Mali 400 / OpenGL ES 2.0 Class Hardware
+
+This renderer targets **Mali 400-class GPUs** (and comparable OpenGL ES 2.0-class silicon such as Vivante GC400, PowerVR SGX). These are in-order, tile-based, scalar fragment pipelines with strict GLSL ES 1.0 constraints. Every shader decision must be evaluated against this baseline. Modern GPUs are a bonus, not the target.
+
+### WebGL / GLSL Hard Constraints
+
+- **WebGL 1.0 only** — no WebGL 2.0 APIs (`textureLod`, `textureOffset`, integer attributes, MRT, `gl.UNSIGNED_INT` indices, etc.)
+- **Fragment shader precision** — Mali 400 has no `highp` in fragment shaders. Always use the `#ifdef GL_FRAGMENT_PRECISION_HIGH` guard that is already the project standard. Never assume `highp` is available in a fragment shader.
+- **Index buffers** — always use `Uint16Array` / `gl.UNSIGNED_SHORT`. `gl.UNSIGNED_INT` requires `OES_element_index_uint` which is absent on Mali 400.
+- **Max 8 texture units** — keep sampler count at or below 8. Do not index sampler arrays with a non-constant (varying or computed) expression — this is undefined behavior in GLSL ES 1.0 and silently breaks on Mali 400 drivers.
+- **Max 8 vec4-equivalent varyings** — count varyings before adding new ones. Each `vec4` or `vec2 + vec2` pair counts as one unit toward the limit of 8. Exceeding this will silently drop varyings or fail to compile on constrained drivers.
+- **NPOT textures** — non-power-of-two textures must use `CLAMP_TO_EDGE` wrapping and must not use mipmaps.
+- **No derivative instructions** — `dFdx`, `dFdy`, and `fwidth` require `OES_standard_derivatives`. Check for the extension before use; do not use in core shaders.
+
+### Avoid Branching in GLSL Shaders (CRITICAL)
+
+Mali 400 has an in-order scalar fragment pipeline. Any `if`, `else`, or ternary `?:` in a fragment shader causes the pipeline to serialize both code paths for every fragment in the affected batch. This is not a style concern — it is a frame-time concern.
+
+**Rule: never use `if`, `else`, or `?:` in a fragment shader.** Use arithmetic equivalents instead.
+
+```glsl
+// ❌ AVOID: if/else branch in fragment shader
+if (v_texcoord.x < 0.0) {
+  gl_FragColor = solidColor;
+} else {
+  gl_FragColor = texture2D(u_texture, v_texcoord);
+}
+
+// ✅ DO: arithmetic mask — no branch, both paths are cheap
+float isSolid = step(0.0, -v_texcoord.x);   // 1.0 when x < 0, else 0.0
+gl_FragColor = mix(texture2D(u_texture, v_texcoord), solidColor, isSolid);
+```
+
+```glsl
+// ❌ AVOID: ternary in fragment shader (it is a branch in GLSL ES 1.0)
+r.xy = (p.x > 0.0) ? r.yz : r.xw;
+
+// ✅ DO: mix + step
+float s = step(0.0, p.x);
+r.xy = mix(r.xw, r.yz, s);
+```
+
+```glsl
+// ❌ AVOID: early return from fragment main() or fragment functions
+float getGradientColor(float dist) {
+  if (dist <= u_stops[0]) return u_colors[0];  // early exit — branch
+  for (int i = 0; i < LAST_STOP; i++) {
+    if (dist >= u_stops[i] && dist <= u_stops[i+1]) {
+      return mix(u_colors[i], u_colors[i+1], ...); // return inside loop — UB risk
+    }
+  }
+  // missing final return — undefined behavior in GLSL ES 1.0
+}
+
+// ✅ DO: branchless accumulation — single return, no conditionals
+vec4 getGradientColor(float dist) {
+  vec4 color = u_colors[0];
+  for (int i = 0; i < LAST_STOP; i++) {
+    float t = clamp((dist - u_stops[i]) / (u_stops[i+1] - u_stops[i]), 0.0, 1.0);
+    color = mix(color, mix(u_colors[i], u_colors[i+1], t), step(u_stops[i], dist));
+  }
+  return color;
+}
+```
+
+Additional rules:
+
+- **No `discard`** in fragment shaders — kills early-Z optimizations and stalls the tile pipeline. Use `mix()` with a zero-alpha result instead.
+- **No `for` loops with non-compile-time-constant bounds** in shaders — loop counts must be a literal or `#define` constant resolvable at compile time.
+- **No sampler array indexing by varying** — `texture2D(u_textures[int(v_index)], uv)` is undefined behavior in GLSL ES 1.0. Use a compile-time-unrolled `if/else` chain per texture unit, or restructure to avoid batched multi-texture lookups entirely.
+- **All non-void GLSL functions must have a `return` on every code path** — a function that can exit without returning is undefined behavior in GLSL ES 1.0 and will produce incorrect output on Mali 400.
+
+### CPU-side WebGL for Tile-Based Renderers
+
+Tile-based GPUs (Mali, PowerVR, Adreno low-end) pay a heavy cost for certain API patterns that are cheap on desktop GPUs:
+
+- **Minimize draw calls per frame** — each `drawElements` / `drawArrays` call triggers a tile flush. Batch geometry aggressively into as few calls as possible.
+- **Avoid FBO switches mid-frame** — binding a different framebuffer forces the GPU to resolve and reload tile memory. Batch all RTT operations together; do not interleave them with main framebuffer draws.
+- **No `gl.getError()` in hot paths** — this synchronizes the CPU and GPU pipelines. Use it only during development/debug builds.
+- **No `readPixels` in hot paths** — stalls the GPU pipeline completely while data is transferred to CPU memory.
+- **Request `antialias: false`** in WebGL context creation — MSAA is prohibitively expensive on tile-based hardware. Handle anti-aliasing in-shader with `smoothstep` SDF edges if needed.
+- **Only request `depth: true` / `stencil: true` if the feature actually requires it** — each enabled buffer consumes tile memory bandwidth on every flush.
+- **Prefer `preserveDrawingBuffer: false`** (the default) — `true` forces a framebuffer copy on every frame on most tile-based drivers.
+
 ## Performance Rules (CRITICAL)
 
 ### 1. Loop Performance
@@ -347,6 +431,12 @@ Before submitting code, verify:
 - [ ] Unit tests added for new code
 - [ ] Visual regression tests added for rendering features
 - [ ] All tests passing (`pnpm test`)
+- [ ] No `if`, `else`, or `?:` in fragment shaders — use `step()`/`mix()`/`clamp()` arithmetic
+- [ ] All non-void GLSL functions have a `return` on every code path
+- [ ] No `discard` in fragment shaders
+- [ ] No sampler array indexed by a varying or non-constant expression
+- [ ] Varying count does not exceed 8 vec4-equivalents per shader
+- [ ] No `gl.getError()`, `readPixels`, or FBO switches in hot paths
 
 ## Common Patterns to Follow
 
@@ -371,6 +461,12 @@ When performing a code review on a pull request, enforce the following:
 - Use of `delete` operator — request setting to `null` or `undefined` instead
 - JSDoc comments added to TypeScript code — request conversion to TypeScript types
 - `try/catch` inside hot paths — request pre-condition guards instead
+- Any `if`, `else`, or ternary `?:` operator in a **fragment shader** — request replacement with `step()`/`mix()`/`clamp()` arithmetic equivalents
+- Any non-void GLSL function that can exit without a `return` statement — request a final unconditional `return` to eliminate undefined behavior
+- `discard` in a fragment shader — request replacement with a `mix()` to `vec4(0.0)` or alpha-zero result
+- A sampler array indexed by a varying or any non-compile-time-constant expression — request a compile-time-unrolled `if/else` chain or a shader restructure
+- Varying count exceeding 8 vec4-equivalents in a single shader program — request packing or removal of varyings
+- `gl.getError()`, `readPixels`, or framebuffer object switches inside a render or update loop
 
 ### Flag as missing test coverage
 


### PR DESCRIPTION
## Summary

Documents Mali 400-class GPU as the primary render target and adds
concrete GLSL / WebGL constraints to the Copilot agent instructions so
the agent (and human reviewers) do not introduce patterns that silently
break or regress on this hardware.

## Changes to `.github/copilot-instructions.md`

### New section: GPU Target: Mali 400 / OpenGL ES 2.0 Class Hardware

**WebGL / GLSL hard constraints**
- WebGL 1.0 only — no WebGL 2.0 APIs
- Fragment shader precision — `highp` is absent on Mali 400; always use the existing `#ifdef GL_FRAGMENT_PRECISION_HIGH` guard
- Index buffers must use `Uint16Array` / `gl.UNSIGNED_SHORT`
- Max 8 texture units; sampler arrays must not be indexed by a varying (GLSL ES 1.0 UB)
- Max 8 vec4-equivalent varyings per shader program
- NPOT textures require `CLAMP_TO_EDGE` and no mipmaps
- No `dFdx`/`dFdy`/`fwidth` without checking for `OES_standard_derivatives`

**Avoid branching in GLSL shaders (CRITICAL)**
- No `if`, `else`, or `?:` in fragment shaders — use `step()`/`mix()`/`clamp()` arithmetic equivalents
- No early `return` from fragment functions; all non-void functions must return on every code path
- No `discard` in fragment shaders
- No `for` loops with non-compile-time-constant bounds
- No sampler array indexing by a varying
- Three before/after GLSL code examples covering the most common violation patterns

**CPU-side WebGL for tile-based renderers**
- Minimize draw calls / FBO switches per frame
- No `gl.getError()` or `readPixels` in hot paths
- Request `antialias: false`; `depth`/`stencil` only when needed; `preserveDrawingBuffer: false`

### Code Review Checklist — 6 new items
GLSL and WebGL-specific checks mirroring the new rules above.

### Code Review Instructions — 6 new "Flag as required changes" entries
Gives the agent explicit guidance on what to flag when reviewing PRs that touch shader code.

## Motivation

An audit of the existing shaders found several patterns that are incorrect or expensive on Mali 400:
- Non-constant sampler array indexing in `DefaultBatched` (GLSL ES 1.0 UB)
- Missing final `return` in `LinearGradient`'s `getGradientColor` (GLSL ES 1.0 UB)
- Data-driven `if/else` branches in `SdfShader`, `LinearGradient`, `RadialGradient`
- Ternary branches in the `roundedBox` SDF helper used across 5 shaders
- Varying-driven `if/else` in `RoundedWithBorderAndShadow`
- Varying count exceeding 8 vec4-equivalents in `RoundedWithBorder`

Those shader fixes will come in a follow-up PR. This PR ensures the agent instructions prevent new instances of the same problems from being introduced.