### PR TITLE
Lint unused variables, params and imports

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,6 +30,7 @@ export default [
           argsIgnorePattern: '^_',
           caughtErrorsIgnorePattern: '^_',
           destructuredArrayIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
         },
       ],
       '@typescript-eslint/no-unsafe-argument': 'warn',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,14 @@ export default [
     },
     rules: {
       ...eslintPluginTs.configs.recommended.rules,
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+        },
+      ],
       '@typescript-eslint/no-unsafe-argument': 'warn',
       '@typescript-eslint/no-unsafe-assignment': 'warn',
       '@typescript-eslint/no-unsafe-return': 'warn',
@@ -32,9 +40,14 @@ export default [
       '@typescript-eslint/no-unsafe-member-access': 'warn',
       '@typescript-eslint/ban-ts-comment': 'warn',
       '@typescript-eslint/no-explicit-any': 'warn',
-      '@typescript-eslint/no-unused-vars': 'warn',
       '@typescript-eslint/no-empty-object-type': 'warn',
       '@typescript-eslint/no-unused-expressions': 'warn',
+    },
+  },
+  {
+    files: ['examples/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': 'off',
     },
   },
   {

--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -47,7 +47,6 @@ const devTarget = 'es2020';
 /**
  * Vite Config
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default defineConfig(({ command, mode, isSsrBuild }) => {
   return {
     base: './',

--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -461,7 +461,6 @@ export class Stage {
    */
   drawFrame() {
     const { renderer, renderRequested, root } = this;
-    const txMemManager = this.txMemManager;
 
     // Update tree if needed
     if (root.updateType !== 0) {

--- a/src/core/animations/CoreAnimationController.ts
+++ b/src/core/animations/CoreAnimationController.ts
@@ -24,7 +24,6 @@ import type {
 import type { AnimationManager } from './AnimationManager.js';
 import type { CoreAnimation } from './CoreAnimation.js';
 import { EventEmitter } from '../../common/EventEmitter.js';
-import type { AnimationTickPayload } from '../../common/CommonTypes.js';
 
 export class CoreAnimationController
   extends EventEmitter

--- a/src/core/platforms/Platform.ts
+++ b/src/core/platforms/Platform.ts
@@ -18,7 +18,6 @@
  */
 
 import { type Stage } from '../Stage.js';
-import type { WebGlContextWrapper } from './web/WebGlContextWrapper.js';
 import type { ImageResponse } from '../textures/ImageTexture.js';
 import type { GlContextWrapper } from './GlContextWrapper.js';
 

--- a/src/core/platforms/web/lib/ImageWorkerNoOptions.ts
+++ b/src/core/platforms/web/lib/ImageWorkerNoOptions.ts
@@ -32,10 +32,6 @@ export function createImageWorkerNoOptions() {
   function getImage(
     src: string,
     premultiplyAlpha: boolean | null,
-    x: number | null,
-    y: number | null,
-    width: number | null,
-    height: number | null,
   ): Promise<{
     data: ImageBitmap;
     premultiplyAlpha: boolean | null;
@@ -93,12 +89,8 @@ export function createImageWorkerNoOptions() {
     var src = event.data.src;
     var id = event.data.id;
     var premultiplyAlpha = event.data.premultiplyAlpha;
-    var x = event.data.sx;
-    var y = event.data.sy;
-    var width = event.data.sw;
-    var height = event.data.sh;
 
-    getImage(src, premultiplyAlpha, x, y, width, height)
+    getImage(src, premultiplyAlpha)
       .then(function (data) {
         // @ts-expect-error ts has wrong postMessage signature
         self.postMessage({ id: id, src: src, data: data }, [data.data]);

--- a/src/core/renderers/CoreRenderer.ts
+++ b/src/core/renderers/CoreRenderer.ts
@@ -73,7 +73,6 @@ export abstract class CoreRenderer {
    * Delete a GPU buffer previously allocated by this renderer.
    * No-op for renderers that do not use WebGL buffers (e.g. Canvas).
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   deleteBuffer(_buffer: WebGLBuffer): void {
     // no-op default — overridden by WebGlRenderer
   }

--- a/src/core/renderers/CoreRenderer.ts
+++ b/src/core/renderers/CoreRenderer.ts
@@ -19,7 +19,6 @@
 
 import type { CoreNode } from '../CoreNode.js';
 import type { Stage } from '../Stage.js';
-import type { ContextSpy } from '../lib/ContextSpy.js';
 import type { CoreShaderProgram } from './CoreShaderProgram.js';
 import type { Texture, TextureCoords } from '../textures/Texture.js';
 import { CoreContextTexture } from './CoreContextTexture.js';

--- a/src/core/renderers/canvas/CanvasRenderer.ts
+++ b/src/core/renderers/canvas/CanvasRenderer.ts
@@ -226,7 +226,7 @@ export class CanvasRenderer extends CoreRenderer {
     return new CanvasShaderNode(shaderKey, shaderType, this.stage, props);
   }
 
-  createShaderProgram(shaderConfig) {
+  createShaderProgram(_shaderConfig) {
     return null;
   }
 
@@ -242,11 +242,11 @@ export class CanvasRenderer extends CoreRenderer {
     // noop
   }
 
-  removeRTTNode(node: CoreNode): void {
+  removeRTTNode(_node: CoreNode): void {
     // noop
   }
 
-  renderToTexture(node: CoreNode): void {
+  renderToTexture(_node: CoreNode): void {
     // noop
   }
   getBufferInfo(): null {

--- a/src/core/renderers/webgl/WebGlRenderer.ts
+++ b/src/core/renderers/webgl/WebGlRenderer.ts
@@ -416,7 +416,7 @@ export class WebGlRenderer extends CoreRenderer {
    *
    * @param surface
    */
-  render(surface: 'screen' | CoreContextTexture = 'screen'): void {
+  render(_surface: 'screen' | CoreContextTexture = 'screen'): void {
     const { glw, quadBuffer } = this;
 
     const arr = new Float32Array(quadBuffer, 0, this.curBufferIdx);

--- a/src/core/renderers/webgl/WebGlShaderNode.ts
+++ b/src/core/renderers/webgl/WebGlShaderNode.ts
@@ -125,6 +125,7 @@ export class WebGlShaderNode<
   }
 
   updateUniformUsage(): void {
+    /* eslint-disable @typescript-eslint/no-unused-vars */
     for (const _ in this.uniforms.single) {
       this.uniforms.hasStoredUniforms = true;
       return;
@@ -141,6 +142,7 @@ export class WebGlShaderNode<
       this.uniforms.hasStoredUniforms = true;
       return;
     }
+    /* eslint-enable @typescript-eslint/no-unused-vars */
     this.uniforms.hasStoredUniforms = false;
   }
 

--- a/src/core/renderers/webgl/WebGlShaderNode.ts
+++ b/src/core/renderers/webgl/WebGlShaderNode.ts
@@ -125,7 +125,6 @@ export class WebGlShaderNode<
   }
 
   updateUniformUsage(): void {
-    /* eslint-disable @typescript-eslint/no-unused-vars */
     for (const _ in this.uniforms.single) {
       this.uniforms.hasStoredUniforms = true;
       return;
@@ -142,7 +141,6 @@ export class WebGlShaderNode<
       this.uniforms.hasStoredUniforms = true;
       return;
     }
-    /* eslint-enable @typescript-eslint/no-unused-vars */
     this.uniforms.hasStoredUniforms = false;
   }
 

--- a/src/core/renderers/webgl/internal/ShaderUtils.ts
+++ b/src/core/renderers/webgl/internal/ShaderUtils.ts
@@ -79,6 +79,7 @@ export interface SupportedSetUniforms {
     | 'uniform4i';
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 type SupportSetUniforms =
   | 'uniform2fv'
   | 'uniform2iv'

--- a/src/core/renderers/webgl/internal/ShaderUtils.ts
+++ b/src/core/renderers/webgl/internal/ShaderUtils.ts
@@ -79,29 +79,6 @@ export interface SupportedSetUniforms {
     | 'uniform4i';
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type SupportSetUniforms =
-  | 'uniform2fv'
-  | 'uniform2iv'
-  | 'uniform3fv'
-  | 'uniform3iv'
-  | 'uniform4fv'
-  | 'uniform4iv'
-  | 'uniformMatrix2fv'
-  | 'uniformMatrix3fv'
-  | 'uniformMatrix4fv'
-  | 'uniform1f'
-  | 'uniform1fv'
-  | 'uniform1i'
-  | 'uniform1iv'
-  | 'uniform3fv'
-  | 'uniform2f'
-  | 'uniform2i'
-  | 'uniform3f'
-  | 'uniform3i'
-  | 'uniform4f'
-  | 'uniform4i';
-
 export interface ShaderOptions {
   shaderSources?: ShaderProgramSources;
   supportsIndexedTextures?: boolean;

--- a/src/core/shaders/webgl/Border.ts
+++ b/src/core/shaders/webgl/Border.ts
@@ -23,7 +23,7 @@ import type { WebGlShaderType } from '../../renderers/webgl/WebGlShaderNode.js';
 
 export const Border: WebGlShaderType<BorderProps> = {
   props: BorderTemplate.props,
-  update(node) {
+  update(_node) {
     this.uniform4fa('u_borderWidth', this.props!.w as Vec4);
     this.uniformRGBA('u_borderColor', this.props!.color);
     this.uniform1f('u_borderGap', this.props!.gap as number);

--- a/src/core/shaders/webgl/LinearGradient.ts
+++ b/src/core/shaders/webgl/LinearGradient.ts
@@ -20,7 +20,6 @@ import {
   LinearGradientTemplate,
   type LinearGradientProps,
 } from '../templates/LinearGradientTemplate.js';
-import { genGradientColors } from '../../renderers/webgl/internal/ShaderUtils.js';
 import type { WebGlRenderer } from '../../renderers/webgl/WebGlRenderer.js';
 import type { WebGlShaderType } from '../../renderers/webgl/WebGlShaderNode.js';
 

--- a/src/core/text-rendering/CanvasFontHandler.ts
+++ b/src/core/text-rendering/CanvasFontHandler.ts
@@ -258,9 +258,7 @@ export const measureText = (
  * @param fontSize
  * @returns
  */
-export function calculateFontMetrics(
-  fontFamily: string,
-): FontMetrics {
+export function calculateFontMetrics(fontFamily: string): FontMetrics {
   // If the font face doesn't have metrics defined, we fallback to using the
   // browser's measureText method to calculate take a best guess at the font
   // actual font's metrics.

--- a/src/core/text-rendering/CanvasFontHandler.ts
+++ b/src/core/text-rendering/CanvasFontHandler.ts
@@ -55,7 +55,6 @@ const nodesWaitingForFont: Record<string, CoreTextNode[]> = Object.create(
 const fontCache = new Map<string, CanvasFont>();
 
 let initialized = false;
-let context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
 let measureContext:
   | CanvasRenderingContext2D
   | OffscreenCanvasRenderingContext2D;
@@ -147,7 +146,6 @@ export const init = (
     );
   }
 
-  context = c;
   measureContext = mc || c;
 
   // Register the default 'sans-serif' font face

--- a/src/core/text-rendering/CanvasFontHandler.ts
+++ b/src/core/text-rendering/CanvasFontHandler.ts
@@ -207,7 +207,7 @@ export const getFontMetrics = (
   }
   let metrics = fontCache.get(fontFamily)!.metrics;
   if (metrics === undefined) {
-    metrics = calculateFontMetrics(fontFamily, fontSize);
+    metrics = calculateFontMetrics(fontFamily);
   }
   return processFontMetrics(fontFamily, fontSize, metrics);
 };
@@ -260,7 +260,6 @@ export const measureText = (
  */
 export function calculateFontMetrics(
   fontFamily: string,
-  fontSize: number,
 ): FontMetrics {
   // If the font face doesn't have metrics defined, we fallback to using the
   // browser's measureText method to calculate take a best guess at the font

--- a/src/core/text-rendering/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/CanvasTextRenderer.ts
@@ -143,8 +143,8 @@ const renderText = (props: CoreTextNodeProps): TextRenderInfo => {
     lines,
     remainingLines,
     hasRemainingText,
-    bareLineHeight,
-    lineHeightPx,
+    _bareLineHeight,
+    _lineHeightPx,
     effectiveWidth,
     effectiveHeight,
   ] = mapTextLayout(

--- a/src/core/text-rendering/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/CanvasTextRenderer.ts
@@ -32,8 +32,6 @@ import { mapTextLayout } from './TextLayoutEngine.js';
 import { parseRichText, ParseResult } from './RichTextParser.js';
 import { normalizeCanvasColor } from '../lib/colorCache.js';
 
-const MAX_TEXTURE_DIMENSION = 4096;
-
 const type = 'canvas' as const;
 const font: FontHandler = CanvasFontHandler;
 
@@ -114,7 +112,6 @@ const renderText = (props: CoreTextNodeProps): TextRenderInfo => {
     textAlign,
     maxLines,
     lineHeight,
-    verticalAlign,
     overflowSuffix,
     maxWidth,
     maxHeight,

--- a/src/core/text-rendering/SdfFontHandler.ts
+++ b/src/core/text-rendering/SdfFontHandler.ts
@@ -412,7 +412,7 @@ export const getFontFamilies = (): FontFamilyMap => {
  * Initialize the SDF font handler
  */
 export const init = (
-  c?: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  _c?: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
 ): void => {
   if (initialized === true) {
     return;

--- a/src/core/textures/SubTexture.ts
+++ b/src/core/textures/SubTexture.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import type { Dimensions } from '../../common/CommonTypes.js';
 import { assertTruthy } from '../../utils.js';
 import type { CoreTextureManager } from '../CoreTextureManager.js';
 import { ImageTexture } from './ImageTexture.js';
@@ -27,7 +26,6 @@ import {
   type TextureData,
   type TextureFailedEventHandler,
   type TextureLoadedEventHandler,
-  type TextureState,
 } from './Texture.js';
 
 let subTextureId = 0;

--- a/src/core/textures/SubTexture.ts
+++ b/src/core/textures/SubTexture.ts
@@ -154,7 +154,7 @@ export class SubTexture extends Texture {
 
   override async getTextureSource(): Promise<TextureData> {
     // Check if parent texture is loaded
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _reject) => {
       resolve({
         data: this.props,
       });

--- a/src/main-api/Inspector.ts
+++ b/src/main-api/Inspector.ts
@@ -796,9 +796,6 @@ export class Inspector {
   }
 
   createTextNode(node: CoreTextNode): CoreTextNode {
-    // eslint-disable-next-line
-    // @ts-ignore - textProps is a private property and keeping it that way
-    // but we need it from the inspector to set the initial properties on the div element
     const div = this.createDiv(node, node.textProps);
     (div as HTMLElement & { node: CoreNode }).node = node;
     (node as CoreTextNode & { div: HTMLElement }).div = div;

--- a/src/main-api/Inspector.ts
+++ b/src/main-api/Inspector.ts
@@ -195,6 +195,7 @@ const domPropertyMap: { [key: string]: string } = {
   id: 'test-id',
 };
 
+/**
 const gradientColorPropertyMap = [
   'colorTop',
   'colorBottom',
@@ -205,6 +206,7 @@ const gradientColorPropertyMap = [
   'colorBl',
   'colorBr',
 ];
+*/
 
 const textureTypeNames: Record<number, string> = {
   [TextureType.generic]: 'generic',


### PR DESCRIPTION
Noticed some unused vars, started removing them, then decided to enable the available linting rule to prevent this.