### PR TITLE
Add `handleLoopError`, an escape hatch for `requestAnimationFrame` crashes

### DIFF
--- a/src/core/platforms/Platform.ts
+++ b/src/core/platforms/Platform.ts
@@ -42,6 +42,16 @@ export interface PlatformSettings {
    * Optional provided canvas element to use for rendering. If not provided, the platform will create its own canvas element.
    */
   canvas?: HTMLCanvasElement | null;
+
+  /**
+   * Request Animation Frame Error Callback
+   *
+   * @remarks
+   * If the render loop throws an error, this callback will be called.
+   *
+   * @param error The error that was thrown
+   */
+  handleLoopError?: (error: unknown) => void;
 }
 
 export abstract class Platform {

--- a/src/core/platforms/web/WebPlatform.ts
+++ b/src/core/platforms/web/WebPlatform.ts
@@ -120,45 +120,56 @@ export class WebPlatform extends Platform {
         return;
       }
 
-      stage.updateFrameTime();
-      stage.updateAnimations();
+      try {
+        stage.updateFrameTime();
+        stage.updateAnimations();
 
-      if (!stage.hasSceneUpdates()) {
-        // We still need to calculate the fps else it looks like the app is frozen
-        stage.calculateFps();
+        if (!stage.hasSceneUpdates()) {
+          // We still need to calculate the fps else it looks like the app is frozen
+          stage.calculateFps();
 
-        if (targetFrameTime > 0) {
-          // Use setTimeout for throttled idle frames
-          setTimeout(
-            () => requestAnimationFrame(runLoop),
-            Math.max(targetFrameTime, 16.666666666666668),
-          );
-        } else {
-          // Use standard idle timeout when not throttling
-          setTimeout(() => requestAnimationFrame(runLoop), 16.666666666666668);
+          if (targetFrameTime > 0) {
+            // Use setTimeout for throttled idle frames
+            setTimeout(
+              () => requestAnimationFrame(runLoop),
+              Math.max(targetFrameTime, 16.666666666666668),
+            );
+          } else {
+            // Use standard idle timeout when not throttling
+            setTimeout(
+              () => requestAnimationFrame(runLoop),
+              16.666666666666668,
+            );
+          }
+
+          if (isIdle === false) {
+            stage.shManager.cleanup();
+            stage.eventBus.emit('idle');
+            isIdle = true;
+          }
+
+          if (stage.txMemManager.checkCleanup() === true) {
+            stage.txMemManager.cleanup();
+          }
+
+          stage.flushFrameEvents();
+          return;
         }
 
-        if (isIdle === false) {
-          stage.shManager.cleanup();
-          stage.eventBus.emit('idle');
-          isIdle = true;
+        if (isIdle === true) {
+          stage.eventBus.emit('active');
+          isIdle = false;
         }
 
-        if (stage.txMemManager.checkCleanup() === true) {
-          stage.txMemManager.cleanup();
-        }
-
+        stage.drawFrame();
         stage.flushFrameEvents();
-        return;
+      } catch (error: unknown) {
+        if (this.settings.handleLoopError) {
+          this.settings.handleLoopError(error);
+        } else {
+          throw error;
+        }
       }
-
-      if (isIdle === true) {
-        stage.eventBus.emit('active');
-        isIdle = false;
-      }
-
-      stage.drawFrame();
-      stage.flushFrameEvents();
 
       // Schedule next frame
       if (targetFrameTime > 0) {

--- a/src/main-api/Renderer.ts
+++ b/src/main-api/Renderer.ts
@@ -552,6 +552,7 @@ export class RendererMain extends EventEmitter {
       createImageBitmapSupport: settings.createImageBitmapSupport || 'full',
       platform: settings.platform || WebPlatform,
       maxRetryCount: settings.maxRetryCount ?? 5,
+      handleLoopError: settings.handleLoopError,
     };
 
     const {


### PR DESCRIPTION
It's easier to review this PR with whitespace turned off: https://github.com/lightning-js/renderer/pull/819/changes?w=1

Long story short: client code is buggy and can crash Lightning's render loop. When that happens, the raf stops running and effectively the client app is frozen.

Some crashes we've had on Peacock are along the lines of:

```ts
animation.on('finish', () => {
  this.foo.x();
    // ^ oops, `foo` does not exist at this point, TypeError: Cannot read property 'x' of undefined
});
```

This crashes the raf since this code runs synchronously.
In L2, the stack trace is: raf → stage.updateFrame() → emit('frameStart') → AnimationManager.progress() → client code
In L3, the stack trace is: raf → stage.updateAnimations() → AnimationManager.update() → client code