### PR TITLE
fix(shaders): remove branches and fix missing return in LinearGradient

### DIFF
--- a/src/core/shaders/webgl/LinearGradient.ts
+++ b/src/core/shaders/webgl/LinearGradient.ts
@@ -70,23 +70,12 @@ export const LinearGradient: WebGlShaderType<LinearGradientProps> = {
 
     vec4 getGradientColor(float dist) {
       dist = clamp(dist, 0.0, 1.0);
-
-      if(dist <= u_stops[0]) {
-        return u_colors[0];
-      }
-
-      if(dist >= u_stops[LAST_STOP]) {
-        return u_colors[LAST_STOP];
-      }
-
+      vec4 color = u_colors[0];
       for(int i = 0; i < LAST_STOP; i++) {
-        float left = u_stops[i];
-        float right = u_stops[i + 1];
-        if(dist >= left && dist <= right) {
-          float lDist = smoothstep(left, right, dist);
-          return mix(u_colors[i], u_colors[i + 1], lDist);
-        }
+        float t = smoothstep(u_stops[i], u_stops[i + 1], dist);
+        color = mix(color, mix(u_colors[i], u_colors[i + 1], t), step(u_stops[i], dist));
       }
+      return color;
     }
 
     void main() {


### PR DESCRIPTION
## Problem

Three issues in `getGradientColor()` on Mali 400 / GLSL ES 1.0:

1. **Two early-exit `if` branches** before the loop cause pipeline serialization on every fragment call.
2. **`if` + `return` inside the `for` loop body** forces per-iteration branch evaluation.
3. **No final `return` statement** — undefined behavior in GLSL ES 1.0 if no branch is taken (possible due to `mediump` rounding at stop boundaries on Mali 400).

## Fix

Replace with a branchless accumulation loop. `smoothstep` easing between stops is preserved so visual output is identical:

```glsl
vec4 getGradientColor(float dist) {
  dist = clamp(dist, 0.0, 1.0);
  vec4 color = u_colors[0];
  for(int i = 0; i < LAST_STOP; i++) {
    float t = smoothstep(u_stops[i], u_stops[i + 1], dist);
    color = mix(color, mix(u_colors[i], u_colors[i + 1], t), step(u_stops[i], dist));
  }
  return color;
}
```

- No branches — `step()` and `mix()` are pure ALU
- Single unconditional `return` — eliminates the GLSL ES 1.0 UB
- `smoothstep` easing preserved — no visual change, no snapshot recapture required