### PR TITLE
fix(shaders): remove branches in RadialGradient getGradientColor

### DIFF
--- a/src/core/shaders/webgl/RadialGradient.ts
+++ b/src/core/shaders/webgl/RadialGradient.ts
@@ -73,25 +73,12 @@ export const RadialGradient: WebGlShaderType<RadialGradientProps> = {
 
       vec4 getGradientColor(float dist) {
         dist = clamp(dist, 0.0, 1.0);
-
-        if(dist <= u_stops[0]) {
-          return u_colors[0];
-        }
-
-        if(dist >= u_stops[LAST_STOP]) {
-          return u_colors[LAST_STOP];
-        }
-
+        vec4 color = u_colors[0];
         for(int i = 0; i < LAST_STOP; i++) {
-          float left = u_stops[i];
-          float right = u_stops[i + 1];
-          if(dist >= left && dist <= right) {
-            float lDist = smoothstep(left, right, dist);
-            return mix(u_colors[i], u_colors[i + 1], lDist);
-          }
+          float t = smoothstep(u_stops[i], u_stops[i + 1], dist);
+          color = mix(color, mix(u_colors[i], u_colors[i + 1], t), step(u_stops[i], dist));
         }
-
-        return u_colors[LAST_STOP];
+        return color;
       }
 
       void main() {


### PR DESCRIPTION
## Problem

Same branching pattern as `LinearGradient`: two early-exit `if`s before the loop, an `if` + `return` inside the loop body. All three cause pipeline serialization on Mali 400's in-order scalar fragment pipeline.

(`RadialGradient` already had a final `return` so the GLSL ES 1.0 missing-return UB was not present here, unlike `LinearGradient`.)

## Fix

Replace with the same branchless accumulation loop, preserving `smoothstep` easing:

```glsl
vec4 getGradientColor(float dist) {
  dist = clamp(dist, 0.0, 1.0);
  vec4 color = u_colors[0];
  for(int i = 0; i < LAST_STOP; i++) {
    float t = smoothstep(u_stops[i], u_stops[i + 1], dist);
    color = mix(color, mix(u_colors[i], u_colors[i + 1], t), step(u_stops[i], dist));
  }
  return color;
}
```

Visual output is identical. No snapshot recapture required.