### PR TITLE
fix(shaders): remove sampler array GLSL ES 1.0 undefined behavior in DefaultBatched

### DIFF
--- a/src/core/shaders/webgl/DefaultBatched.ts
+++ b/src/core/shaders/webgl/DefaultBatched.ts
@@ -92,8 +92,30 @@ export const DefaultBatched: WebGlShaderType = {
   fragment(renderer) {
     const textureUnits =
       renderer.system.parameters.MAX_VERTEX_TEXTURE_IMAGE_UNITS;
+
+    // Declare each sampler as an individual uniform.
+    // GLSL ES 1.0 does not permit indexing a sampler array with a non-constant
+    // expression — doing so is undefined behavior and silently breaks on Mali 400
+    // drivers. Individual uniforms indexed via a compile-time-unrolled if/else
+    // chain is the correct GLSL ES 1.0 pattern.
+    //
+    // NOTE: when the CPU-side multi-texture path is activated, bind each unit with:
+    //   gl.uniform1i(gl.getUniformLocation(program, `u_texture_${i}`), i)
+    // rather than the array form uniform1iv('u_textures[0]', [...]).
+    const samplerDeclarations = Array.from(Array(textureUnits).keys())
+      .map((i) => `uniform sampler2D u_texture_${i};`)
+      .join('\n      ');
+
+    const ifElseChain = Array.from(Array(textureUnits).keys())
+      .map(
+        (i) => `
+        ${i !== 0 ? 'else ' : ''}if (idx == ${i}) {
+          return texture2D(u_texture_${i}, uv);
+        }`,
+      )
+      .join('');
+
     return `
-    #define txUnits ${textureUnits}
       # ifdef GL_FRAGMENT_PRECISION_HIGH
       precision highp float;
       # else
@@ -101,28 +123,20 @@ export const DefaultBatched: WebGlShaderType = {
       # endif
 
       uniform vec2 u_resolution;
-      uniform sampler2D u_image;
-      uniform sampler2D u_textures[txUnits];
+      ${samplerDeclarations}
 
       varying vec4 v_color;
       varying vec2 v_textureCoords;
       varying float v_textureIndex;
 
-      vec4 sampleFromTexture(sampler2D textures[${textureUnits}], int idx, vec2 uv) {
-        ${Array.from(Array(textureUnits).keys())
-          .map(
-            (idx) => `
-          ${idx !== 0 ? 'else ' : ''}if (idx == ${idx}) {
-            return texture2D(textures[${idx}], uv);
-          }
-        `,
-          )
-          .join('')}
-        return texture2D(textures[0], uv);
+      vec4 sampleFromTexture(int idx, vec2 uv) {
+        ${ifElseChain}
+        // Safe fallback — idx should always match one of the above branches.
+        return vec4(0.0);
       }
 
       void main(){
-        gl_FragColor = vec4(v_color) * sampleFromTexture(u_textures, int(v_textureIndex), v_textureCoords);
+        gl_FragColor = vec4(v_color) * sampleFromTexture(int(v_textureIndex), v_textureCoords);
       }
     `;
   },


### PR DESCRIPTION
## Problem

`DefaultBatched` fragment shader declared a sampler array and indexed it with a non-constant expression:

```glsl
uniform sampler2D u_textures[N];

vec4 sampleFromTexture(sampler2D textures[N], int idx, vec2 uv) {
  if (idx == 0) { return texture2D(textures[0], uv); }
  // ...
  return texture2D(textures[0], uv);  // unsafe fallback
}

void main() {
  gl_FragColor = ... * sampleFromTexture(u_textures, int(v_textureIndex), ...);
}
```

Two GLSL ES 1.0 undefined behaviors:
1. **Sampler array indexed by a non-constant** (`int(v_textureIndex)` is a varying) — silently samples unit 0 on Mali 400 drivers for all indices.
2. **Sampler array passed as function parameter** — not permitted in GLSL ES 1.0.

Also removed: `uniform sampler2D u_image` which was declared but never used.

Note: the multi-texture CPU path (`bindTextures` override, `addTexture` cap) remains dormant — this PR only corrects the GLSL.

## Fix

Replace the array with individually named uniforms and remove the array parameter from `sampleFromTexture()`. The if/else chain references each named uniform directly — the correct GLSL ES 1.0 pattern:

```glsl
uniform sampler2D u_texture_0;
uniform sampler2D u_texture_1;
// ...

vec4 sampleFromTexture(int idx, vec2 uv) {
  if (idx == 0) { return texture2D(u_texture_0, uv); }
  else if (idx == 1) { return texture2D(u_texture_1, uv); }
  // ...
  return vec4(0.0);  // explicit safe fallback
}
```

CPU-side note added in comments: when the multi-texture path is activated, each unit must be bound with `uniform1i(location('u_texture_N'), N)` rather than `uniform1iv`.

## Visual impact

None — the multi-texture path is currently unreachable at runtime (`addTexture` is hard-capped at 1 texture per render op). No snapshot recapture required.