### PR TITLE
perf(sdf): use 4-float plain vertex format for non-richText nodes

### DIFF
--- a/src/core/CoreTextNode.ts
+++ b/src/core/CoreTextNode.ts
@@ -387,43 +387,65 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
         glw.STATIC_DRAW,
       );
 
+      // Select vertex format based on whether richText was used for this layout.
+      // Plain (richText=false): 4 floats/vertex — x, y, u, v.
+      // Rich  (richText=true):  6 floats/vertex — x, y, u, v, packed_color, style.
+      const isRich = this._renderInfo.layout.richText === true;
+      const floatsPerVertex = isRich ? 6 : 4;
+      const stride = floatsPerVertex * Float32Array.BYTES_PER_ELEMENT;
+
+      const attributes: Record<
+        string,
+        {
+          name: string;
+          size: number;
+          type: number;
+          normalized: boolean;
+          stride: number;
+          offset: number;
+        }
+      > = {
+        a_position: {
+          name: 'a_position',
+          size: 2,
+          type: glw.FLOAT as number,
+          normalized: false,
+          stride,
+          offset: 0,
+        },
+        a_textureCoords: {
+          name: 'a_textureCoords',
+          size: 2,
+          type: glw.FLOAT as number,
+          normalized: false,
+          stride,
+          offset: 2 * Float32Array.BYTES_PER_ELEMENT,
+        },
+      };
+
+      if (isRich) {
+        attributes['a_color'] = {
+          name: 'a_color',
+          size: 4,
+          type: glw.UNSIGNED_BYTE as number,
+          normalized: true,
+          stride,
+          offset: 4 * Float32Array.BYTES_PER_ELEMENT,
+        };
+        attributes['a_style'] = {
+          name: 'a_style',
+          size: 1,
+          type: glw.FLOAT as number,
+          normalized: false,
+          stride,
+          offset: 5 * Float32Array.BYTES_PER_ELEMENT,
+        };
+      }
+
       this._sdfQuadCollection = new BufferCollection([
         {
           buffer: this._sdfBuffer,
-          attributes: {
-            a_position: {
-              name: 'a_position',
-              size: 2,
-              type: glw.FLOAT as number,
-              normalized: false,
-              stride: 6 * Float32Array.BYTES_PER_ELEMENT,
-              offset: 0,
-            },
-            a_textureCoords: {
-              name: 'a_textureCoords',
-              size: 2,
-              type: glw.FLOAT as number,
-              normalized: false,
-              stride: 6 * Float32Array.BYTES_PER_ELEMENT,
-              offset: 2 * Float32Array.BYTES_PER_ELEMENT,
-            },
-            a_color: {
-              name: 'a_color',
-              size: 4,
-              type: glw.UNSIGNED_BYTE as number,
-              normalized: true,
-              stride: 6 * Float32Array.BYTES_PER_ELEMENT,
-              offset: 4 * Float32Array.BYTES_PER_ELEMENT,
-            },
-            a_style: {
-              name: 'a_style',
-              size: 1,
-              type: glw.FLOAT as number,
-              normalized: false,
-              stride: 6 * Float32Array.BYTES_PER_ELEMENT,
-              offset: 5 * Float32Array.BYTES_PER_ELEMENT,
-            },
-          },
+          attributes,
         },
       ]);
     }

--- a/src/core/shaders/webgl/SdfShader.ts
+++ b/src/core/shaders/webgl/SdfShader.ts
@@ -48,6 +48,84 @@ export interface SdfShaderProps {
  * ends up being a performance bottleneck we can always look at ways to
  * remove it.
  */
+/**
+ * Plain SDF shader — no per-vertex color or style attributes.
+ *
+ * Used when richText=false (the default). Matches the v3.0.6 vertex format
+ * (4 floats/vertex: x, y, u, v) and the original simple fragment path with
+ * no solid-fill branch. This keeps the VBO 33% smaller and the fragment
+ * shader minimal for all ordinary text nodes.
+ */
+export const SdfPlain: WebGlShaderType<SdfShaderProps> = {
+  props: {
+    transform: IDENTITY_MATRIX_3x3,
+    color: 0xffffffff,
+    size: 16,
+    distanceRange: 1.0,
+  },
+  onSdfBind(props) {
+    this.uniformMatrix3fv('u_transform', props.transform);
+    this.uniform4fa('u_color', getNormalizedRgbaComponents(props.color));
+    this.uniform1f('u_size', props.size);
+    this.uniform1f('u_distanceRange', props.distanceRange);
+  },
+  vertex: `
+    # ifdef GL_FRAGMENT_PRECISION_HIGH
+    precision highp float;
+    # else
+    precision mediump float;
+    # endif
+    attribute vec2 a_position;
+    attribute vec2 a_textureCoords;
+
+    uniform vec2 u_resolution;
+    uniform mat3 u_transform;
+    uniform float u_pixelRatio;
+    uniform float u_size;
+    uniform float u_distanceRange;
+
+    varying vec2 v_texcoord;
+    varying float v_scaledDistRange;
+
+    void main() {
+      vec2 scrolledPosition = a_position * u_size;
+      vec2 transformedPosition = (u_transform * vec3(scrolledPosition, 1)).xy;
+
+      // Calculate screen space with pixel ratio
+      vec2 screenSpace = (transformedPosition * u_pixelRatio / u_resolution * 2.0 - 1.0) * vec2(1, -1);
+
+      gl_Position = vec4(screenSpace, 0.0, 1.0);
+      v_texcoord = a_textureCoords;
+      v_scaledDistRange = u_distanceRange * u_pixelRatio;
+    }
+  `,
+  fragment: `
+    # ifdef GL_FRAGMENT_PRECISION_HIGH
+    precision highp float;
+    # else
+    precision mediump float;
+    # endif
+    uniform vec4 u_color;
+    uniform sampler2D u_texture;
+
+    varying vec2 v_texcoord;
+    varying float v_scaledDistRange;
+
+    float median(float r, float g, float b) {
+        return clamp(b, min(r, g), max(r, g));
+    }
+
+    void main() {
+        vec3 sample = texture2D(u_texture, v_texcoord).rgb;
+        float sigDist = v_scaledDistRange * (median(sample.r, sample.g, sample.b) - 0.5);
+        float opacity = clamp(sigDist + 0.5, 0.0, 1.0) * u_color.a;
+
+        // IMPORTANT: We must premultiply the color by the alpha value before returning it.
+        gl_FragColor = vec4(u_color.r * opacity, u_color.g * opacity, u_color.b * opacity, opacity);
+    }
+  `,
+};
+
 export const Sdf: WebGlShaderType<SdfShaderProps> = {
   props: {
     transform: IDENTITY_MATRIX_3x3,

--- a/src/core/text-rendering/SdfTextRenderer.ts
+++ b/src/core/text-rendering/SdfTextRenderer.ts
@@ -28,18 +28,20 @@ import type { CoreTextNode, CoreTextNodeProps } from '../CoreTextNode.js';
 import { getLayoutCacheKey, hasZeroWidthSpace } from './Utils.js';
 import * as SdfFontHandler from './SdfFontHandler.js';
 import { WebGlRenderer } from '../renderers/webgl/WebGlRenderer.js';
-import { Sdf } from '../shaders/webgl/SdfShader.js';
+import { Sdf, SdfPlain } from '../shaders/webgl/SdfShader.js';
 import type { WebGlShaderNode } from '../renderers/webgl/WebGlShaderNode.js';
 import type { TextLayout } from './TextRenderer.js';
 import { mapTextLayout } from './TextLayoutEngine.js';
 import type { WebGlCtxTexture } from '../renderers/webgl/WebGlCtxTexture.js';
 import { parseRichText, ParseResult } from './RichTextParser.js';
 
-// Each glyph/deco quad requires 6 vertices with 6 floats each
-// (x, y, u, v, packed_color, style)
-const FLOATS_PER_VERTEX = 6;
+// Plain (non-richText) layout: x, y, u, v — matches v3.0.6 format
+const FLOATS_PER_VERTEX_PLAIN = 4;
+// Rich-text layout: x, y, u, v, packed_color, style
+const FLOATS_PER_VERTEX_RICH = 6;
 const VERTICES_PER_GLYPH = 6;
-const FLOATS_PER_QUAD = VERTICES_PER_GLYPH * FLOATS_PER_VERTEX; // 36
+const FLOATS_PER_QUAD_PLAIN = VERTICES_PER_GLYPH * FLOATS_PER_VERTEX_PLAIN; // 24
+const FLOATS_PER_QUAD_RICH = VERTICES_PER_GLYPH * FLOATS_PER_VERTEX_RICH; // 36
 
 // Horizontal shear factor for fake italic: tan(14°).
 // Applied to glyph and decoration vertices in design-unit space.
@@ -56,15 +58,18 @@ const _richTextResult = new ParseResult();
 const type = 'sdf' as const;
 
 let sdfShader: WebGlShaderNode | null = null;
+let sdfPlainShader: WebGlShaderNode | null = null;
 let renderer: WebGlRenderer | null = null;
 
 // Initialize the SDF text renderer
 const init = (stage: Stage): void => {
   SdfFontHandler.init();
 
-  // Register SDF shader with the shader manager
+  // Register both SDF shader variants with the shader manager
   stage.shManager.registerShaderType('Sdf', Sdf);
+  stage.shManager.registerShaderType('SdfPlain', SdfPlain);
   sdfShader = stage.shManager.createShader('Sdf') as WebGlShaderNode;
+  sdfPlainShader = stage.shManager.createShader('SdfPlain') as WebGlShaderNode;
   renderer = stage.renderer as WebGlRenderer;
 };
 
@@ -126,7 +131,11 @@ const renderText = (props: CoreTextNodeProps): TextRenderInfo => {
  * Called from CoreTextNode during rendering.
  */
 const renderQuads = (textNode: CoreTextNode): void => {
-  textNode.props.shader = sdfShader;
+  // Select the correct shader variant based on richText mode.
+  // sdfPlainShader uses a 4-float-per-vertex VBO (no a_color / a_style attributes).
+  // sdfShader uses a 6-float-per-vertex VBO with per-span color and style.
+  textNode.props.shader =
+    textNode.textProps.richText === true ? sdfShader : sdfPlainShader;
   renderer!.addRenderOp(textNode);
 };
 
@@ -280,9 +289,107 @@ const generateTextLayout = (
 
   const lineAmount = lines.length;
 
-  // --- PASS 1: count exact glyphs and decoration quads ---
-  // getGlyph is called here (not just in pass 2) so the buffer is sized exactly,
-  // preventing degenerate zero-position triangles at the tail.
+  if (richText === false) {
+    // --- PLAIN PATH (richText=false): 4 floats/vertex, single counting pass ---
+    // Pass 1: count glyphs (calling getGlyph to skip null entries, matching rich pass 1 behaviour)
+    let glyphCount = 0;
+    for (let i = 0; i < lineAmount; i++) {
+      const textLine = (lines[i] as TextLineStruct)[0];
+      for (const char of textLine) {
+        if (hasZeroWidthSpace(char) === true) continue;
+        const codepoint = char.codePointAt(0);
+        if (codepoint === undefined) continue;
+        if (SdfFontHandler.getGlyph(fontFamily, codepoint) === null) continue;
+        glyphCount++;
+      }
+    }
+
+    const vertexBuffer = new Float32Array(glyphCount * FLOATS_PER_QUAD_PLAIN);
+    let bi = 0;
+    let currentX = 0;
+    let currentY = 0;
+
+    for (let i = 0; i < lineAmount; i++) {
+      const line = lines[i] as TextLineStruct;
+      const textLine = line[0];
+      let prevGlyphId = 0;
+      currentX = line[3];
+      currentY = line[4] / fontScale;
+
+      for (const char of textLine) {
+        if (hasZeroWidthSpace(char) === true) continue;
+        const codepoint = char.codePointAt(0);
+        if (codepoint === undefined) continue;
+        const glyph = SdfFontHandler.getGlyph(fontFamily, codepoint);
+        if (glyph === null) continue;
+
+        if (prevGlyphId !== 0) {
+          currentX += SdfFontHandler.getKerning(
+            fontFamily,
+            prevGlyphId,
+            glyph.id,
+          );
+        }
+
+        const x1 = currentX + glyph.xoffset;
+        const y1 = currentY + glyph.yoffset;
+        const x2 = x1 + glyph.width;
+        const y2 = y1 + glyph.height;
+
+        const u1 = glyph.x / atlasWidth;
+        const v1 = glyph.y / atlasHeight;
+        const u2 = u1 + glyph.width / atlasWidth;
+        const v2 = v1 + glyph.height / atlasHeight;
+
+        // Triangle 1: TL, TR, BL
+        vertexBuffer[bi++] = x1;
+        vertexBuffer[bi++] = y1;
+        vertexBuffer[bi++] = u1;
+        vertexBuffer[bi++] = v1;
+        vertexBuffer[bi++] = x2;
+        vertexBuffer[bi++] = y1;
+        vertexBuffer[bi++] = u2;
+        vertexBuffer[bi++] = v1;
+        vertexBuffer[bi++] = x1;
+        vertexBuffer[bi++] = y2;
+        vertexBuffer[bi++] = u1;
+        vertexBuffer[bi++] = v2;
+        // Triangle 2: TR, BR, BL
+        vertexBuffer[bi++] = x2;
+        vertexBuffer[bi++] = y1;
+        vertexBuffer[bi++] = u2;
+        vertexBuffer[bi++] = v1;
+        vertexBuffer[bi++] = x2;
+        vertexBuffer[bi++] = y2;
+        vertexBuffer[bi++] = u2;
+        vertexBuffer[bi++] = v2;
+        vertexBuffer[bi++] = x1;
+        vertexBuffer[bi++] = y2;
+        vertexBuffer[bi++] = u1;
+        vertexBuffer[bi++] = v2;
+
+        currentX += glyph.xadvance + letterSpacing;
+        prevGlyphId = glyph.id;
+      }
+    }
+
+    return {
+      vertexBuffer,
+      glyphCount,
+      totalQuadCount: glyphCount,
+      richText: false,
+      distanceRange: fontScale * fontData.distanceField.distanceRange,
+      width: effectiveWidth * fontScale,
+      height: effectiveHeight,
+      fontScale: fontScale,
+      lineHeight: lineHeightPx,
+      fontFamily,
+      remainingLines,
+      hasRemainingText,
+    };
+  }
+
+  // --- RICH PATH (richText=true): 6 floats/vertex, two-pass ---
   let glyphCount = 0;
   let decoQuadCount = 0;
   let strippedPos = 0;
@@ -292,48 +399,46 @@ const generateTextLayout = (
     const textLine = (lines[i] as TextLineStruct)[0];
     for (const char of textLine) {
       if (hasZeroWidthSpace(char) === true) {
-        if (richText === true) strippedPos++;
+        strippedPos++;
         continue;
       }
       const codepoint = char.codePointAt(0);
       if (codepoint === undefined) {
-        if (richText === true) strippedPos++;
+        strippedPos++;
         continue;
       }
       const glyph = SdfFontHandler.getGlyph(fontFamily, codepoint);
       if (glyph === null) {
-        if (richText === true) strippedPos++;
+        strippedPos++;
         continue;
       }
       glyphCount++;
-      if (richText === true) {
-        // Advance span cursor past any spans that ended before this position.
-        // curSpanIdx is always < spanCount after the loop; non-null assertions are safe.
-        while (
-          curSpanIdx < _richTextResult.spanCount - 1 &&
-          strippedPos >= _richTextResult.spans[curSpanIdx]!.end
-        ) {
-          curSpanIdx++;
-        }
-        const span = _richTextResult.spans[curSpanIdx]!;
-        if (span.underline === true) decoQuadCount++;
-        if (span.strikethrough === true) decoQuadCount++;
-        strippedPos++;
+      // Advance span cursor past any spans that ended before this position.
+      // curSpanIdx is always < spanCount after the loop; non-null assertions are safe.
+      while (
+        curSpanIdx < _richTextResult.spanCount - 1 &&
+        strippedPos >= _richTextResult.spans[curSpanIdx]!.end
+      ) {
+        curSpanIdx++;
       }
+      const span = _richTextResult.spans[curSpanIdx]!;
+      if (span.underline === true) decoQuadCount++;
+      if (span.strikethrough === true) decoQuadCount++;
+      strippedPos++;
     }
   }
 
   const totalQuadCount = glyphCount + decoQuadCount;
 
   // --- Single allocation for the entire vertex payload ---
-  // Layout: [glyph quads (glyphCount × 6 × 5)] [deco quads (decoQuadCount × 6 × 5)]
-  const vertexBuffer = new Float32Array(totalQuadCount * FLOATS_PER_QUAD);
+  // Layout: [glyph quads (glyphCount × 36)] [deco quads (decoQuadCount × 36)]
+  const vertexBuffer = new Float32Array(totalQuadCount * FLOATS_PER_QUAD_RICH);
   // Uint32Array view of the same ArrayBuffer for packed-color writes at slot 4 of each vertex.
   const u32Buffer = new Uint32Array(vertexBuffer.buffer);
 
   // Write cursors (float indices into vertexBuffer / u32Buffer).
   let gi = 0; // glyph region: 0 … glyphCount*36-1
-  let di = glyphCount * FLOATS_PER_QUAD; // deco region: starts after all glyph quads
+  let di = glyphCount * FLOATS_PER_QUAD_RICH; // deco region: starts after all glyph quads
 
   // Reset rich-text tracking for pass 2.
   strippedPos = 0;
@@ -355,17 +460,17 @@ const generateTextLayout = (
 
     for (const char of textLine) {
       if (hasZeroWidthSpace(char) === true) {
-        if (richText === true) strippedPos++;
+        strippedPos++;
         continue;
       }
       const codepoint = char.codePointAt(0);
       if (codepoint === undefined) {
-        if (richText === true) strippedPos++;
+        strippedPos++;
         continue;
       }
       const glyph = SdfFontHandler.getGlyph(fontFamily, codepoint);
       if (glyph === null) {
-        if (richText === true) strippedPos++;
+        strippedPos++;
         continue;
       }
 
@@ -376,20 +481,18 @@ const generateTextLayout = (
       let spanBold = false;
       let spanItalic = false;
 
-      if (richText === true) {
-        while (
-          curSpanIdx < _richTextResult.spanCount - 1 &&
-          strippedPos >= _richTextResult.spans[curSpanIdx]!.end
-        ) {
-          curSpanIdx++;
-        }
-        const span = _richTextResult.spans[curSpanIdx]!;
-        packedColor = span.color !== 0 ? _packColor(span.color) : _PACKED_WHITE;
-        spanUnderline = span.underline;
-        spanStrikethrough = span.strikethrough;
-        spanBold = span.bold;
-        spanItalic = span.italic;
+      while (
+        curSpanIdx < _richTextResult.spanCount - 1 &&
+        strippedPos >= _richTextResult.spans[curSpanIdx]!.end
+      ) {
+        curSpanIdx++;
       }
+      const span = _richTextResult.spans[curSpanIdx]!;
+      packedColor = span.color !== 0 ? _packColor(span.color) : _PACKED_WHITE;
+      spanUnderline = span.underline;
+      spanStrikethrough = span.strikethrough;
+      spanBold = span.bold;
+      spanItalic = span.italic;
 
       // --- Kerning ---
       if (prevGlyphId !== 0) {
@@ -523,6 +626,7 @@ const generateTextLayout = (
     vertexBuffer,
     glyphCount,
     totalQuadCount,
+    richText: true,
     distanceRange: fontScale * fontData.distanceField.distanceRange,
     width: effectiveWidth * fontScale,
     height: effectiveHeight,

--- a/src/core/text-rendering/TextRenderer.ts
+++ b/src/core/text-rendering/TextRenderer.ts
@@ -334,6 +334,11 @@ export interface TextLayout {
    */
   totalQuadCount: number;
   /**
+   * Whether this layout was generated for richText mode.
+   * Determines the vertex format: false = 4 floats/vertex (plain), true = 6 floats/vertex (rich).
+   */
+  richText: boolean;
+  /**
    * Total text width
    */
   width: number;


### PR DESCRIPTION
## Problem

The `richText` feature (#809–#814) bumped `FLOATS_PER_VERTEX` from 4 to 6 for **all** SDF text nodes to support per-span color (`a_color`) and bold/italic (`a_style`) attributes. This caused a universal performance regression even for nodes that never use `richText`:

- **VBO size +50%**: every glyph's vertex buffer grew from 96 → 144 bytes, increasing `glBufferData` upload size on every text layout
- **Fragment shader bloat**: added `step`/`mix`/2×`vec4`-multiply per fragment *every frame* even when `v_color = vec4(1,1,1,1)` and `v_style = 0.0` (identity values for plain text)

Measured regressions (3.0.6 → 3.1.0) on the [lightning-js/benchmark](https://github.com/lightning-js/benchmark):

| test | 3.0.6 | 3.1.0 |
|---|---|---|
| creation | 37 ms | 63 ms |
| replace | 29 ms | 46 ms |
| update | 23 ms | 41 ms |
| select | 28 ms | 38 ms |
| create many | 118 ms | 136 ms |
| append | 129 ms | 148 ms |
| clear | 18 ms | 37 ms |

## Fix

Split into two shader variants and two vertex formats, selected at layout time based on `props.richText`:

### `SdfPlain` (new — default when `richText=false`)
- **4 floats/vertex**: `x, y, u, v` — identical to the v3.0.6 format
- Original minimal fragment shader: no `isSolid` sentinel, no `v_color`/`v_style` varyings, no `mix()`
- VBO is 33% smaller per glyph; fragment GPU work reverts to the 3.0.x baseline

### `Sdf` (unchanged — used only when `richText=true`)
- **6 floats/vertex**: `x, y, u, v, packed_color, style`
- Full rich fragment shader with solid-fill sentinel, per-span color multiply, bold SDF threshold shift

### Changes

- **`SdfShader.ts`**: adds `SdfPlain` export — the original v3.0.6 vertex+fragment shader
- **`SdfTextRenderer.ts`**:
  - `FLOATS_PER_VERTEX_PLAIN = 4` / `FLOATS_PER_VERTEX_RICH = 6`
  - Registers both shader types in `init()`
  - `renderQuads()` picks `sdfPlainShader` or `sdfShader` based on `textNode.textProps.richText`
  - `generateTextLayout()` branches at the top: plain path writes a clean 4-float-per-vertex loop; rich path is the existing two-pass 6-float loop. Both stamp `richText: boolean` on the returned `TextLayout`
- **`TextRenderer.ts`**: adds `richText: boolean` to `TextLayout` interface
- **`CoreTextNode.ts`**: `renderQuads()` reads `layout.richText` to set VBO stride and conditionally register `a_color`/`a_style` attributes in `BufferCollection`

No behaviour change for `richText=true` nodes.