### PR TITLE
Fix `Stage` receiving settings intended for `Platform`

### DIFF
--- a/src/core/CoreTextureManager.ts
+++ b/src/core/CoreTextureManager.ts
@@ -58,7 +58,6 @@ export interface TextureManagerDebugInfo {
 }
 
 export interface TextureManagerSettings {
-  numImageWorkers: number;
   createImageBitmapSupport: 'auto' | 'basic' | 'options' | 'full';
   maxRetryCount: number;
 }

--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -54,16 +54,15 @@ import type { CoreShaderNode } from './renderers/CoreShaderNode.js';
 import { createBound, createPreloadBounds, type Bound } from './lib/utils.js';
 import type { Texture } from './textures/Texture.js';
 import { ColorTexture } from './textures/ColorTexture.js';
-import type { Platform } from './platforms/Platform.js';
+import type { Platform, PlatformSettings } from './platforms/Platform.js';
 import type { WebPlatform } from './platforms/web/WebPlatform.js';
 import type { RendererMainSettings } from '../main-api/Renderer.js';
 
 export type StageOptions = Omit<
   RendererMainSettings,
-  'inspector' | 'platform' | 'maxRetryCount'
+  'inspector' | 'platform' | 'maxRetryCount' | keyof PlatformSettings
 > & {
   textureMemory: TextureMemoryManagerSettings;
-  canvas: HTMLCanvasElement | OffscreenCanvas;
   fpsUpdateInterval: number;
   eventBus: EventEmitter;
   platform: Platform | WebPlatform;
@@ -164,7 +163,6 @@ export class Stage {
       appHeight,
       boundsMargin,
       enableContextSpy,
-      numImageWorkers,
       textureMemory,
       renderEngine,
       fontEngines,
@@ -188,7 +186,6 @@ export class Stage {
     this.targetFrameTime = options.targetFPS > 0 ? 1000 / options.targetFPS : 0;
 
     this.txManager = new CoreTextureManager(this, {
-      numImageWorkers,
       createImageBitmapSupport,
       maxRetryCount,
     });

--- a/src/core/platforms/Platform.ts
+++ b/src/core/platforms/Platform.ts
@@ -45,7 +45,8 @@ export interface PlatformSettings {
 }
 
 export abstract class Platform {
-  public readonly settings: Required<PlatformSettings>;
+  public readonly settings: PlatformSettings &
+    Required<Pick<PlatformSettings, 'numImageWorkers' | 'forceWebGL2'>>;
 
   public glw: GlContextWrapper | null = null;
   public canvas: HTMLCanvasElement | null = null;
@@ -55,15 +56,10 @@ export abstract class Platform {
     this.settings = {
       numImageWorkers: settings.numImageWorkers ?? 2,
       forceWebGL2: settings.forceWebGL2 ?? false,
-      canvas: settings.canvas ?? null,
     };
 
     // If a canvas was provided in the settings, use it. Otherwise, create a new one.
-    if (this.settings.canvas !== null) {
-      this.canvas = this.settings.canvas;
-    } else {
-      this.canvas = this.createCanvas();
-    }
+    this.canvas = settings.canvas || this.createCanvas();
   }
 
   /**

--- a/src/main-api/Renderer.ts
+++ b/src/main-api/Renderer.ts
@@ -536,18 +536,13 @@ export class RendererMain extends EventEmitter {
       'A platform implementation must be provided in settings.platform',
     );
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-    const platform = new (settings.platform as any)({
-      numImageWorkers: settings.numImageWorkers,
-      forceWebGL2: settings.forceWebGL2,
-      canvas: settings.canvas,
-    });
+    const platform = new (settings.platform as typeof WebPlatform)(settings);
 
     const deviceLogicalWidth = appWidth * deviceLogicalPixelRatio;
     const deviceLogicalHeight = appHeight * deviceLogicalPixelRatio;
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unsafe-member-access
-    this.canvas = platform.canvas! as HTMLCanvasElement;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    this.canvas = platform.canvas!;
     this.canvas.width = deviceLogicalWidth * devicePhysicalPixelRatio;
     this.canvas.height = deviceLogicalHeight * devicePhysicalPixelRatio;
 

--- a/src/main-api/Renderer.ts
+++ b/src/main-api/Renderer.ts
@@ -36,7 +36,7 @@ import type {
   ShaderMap,
 } from '../core/CoreShaderManager.js';
 import { WebPlatform } from '../core/platforms/web/WebPlatform.js';
-import { Platform } from '../core/platforms/Platform.js';
+import { Platform, type PlatformSettings } from '../core/platforms/Platform.js';
 
 /**
  * FPS Update Event Data
@@ -300,157 +300,126 @@ export interface RendererRuntimeSettings {
 /**
  * Configuration settings for {@link RendererMain}
  */
-export type RendererMainSettings = RendererRuntimeSettings & {
-  /**
-   * Include context call (i.e. WebGL) information in FPS updates
-   *
-   * @remarks
-   * When enabled the number of calls to each context method over the
-   * `fpsUpdateInterval` will be included in the FPS update payload's
-   * `contextSpyData` property.
-   *
-   * Enabling the context spy has a serious impact on performance so only use it
-   * when you need to extract context call information.
-   *
-   * @defaultValue `false` (disabled)
-   */
-  enableContextSpy: boolean;
+export type RendererMainSettings = RendererRuntimeSettings &
+  Required<PlatformSettings> & {
+    /**
+     * Include context call (i.e. WebGL) information in FPS updates
+     *
+     * @remarks
+     * When enabled the number of calls to each context method over the
+     * `fpsUpdateInterval` will be included in the FPS update payload's
+     * `contextSpyData` property.
+     *
+     * Enabling the context spy has a serious impact on performance so only use it
+     * when you need to extract context call information.
+     *
+     * @defaultValue `false` (disabled)
+     */
+    enableContextSpy: boolean;
 
-  /**
-   * Number or Image Workers to use
-   *
-   * @remarks
-   * On devices with multiple cores, this can be used to improve image loading
-   * as well as reduce the impact of image loading on the main thread.
-   * Set to 0 to disable image workers.
-   *
-   * @defaultValue `2`
-   */
-  numImageWorkers: number;
+    /**
+     * Renderer Engine
+     *
+     * @remarks
+     * The renderer engine to use. Spawns a WebGL or Canvas renderer.
+     * WebGL is more performant and supports more features. Canvas is
+     * supported on most platforms.
+     *
+     * Note: When using CanvasCoreRenderer you can only use
+     * CanvasTextRenderer. The WebGLCoreRenderer supports
+     * both CanvasTextRenderer and SdfTextRenderer for Text Rendering.
+     *
+     */
+    renderEngine: typeof CanvasRenderer | typeof WebGlRenderer;
 
-  /**
-   * Renderer Engine
-   *
-   * @remarks
-   * The renderer engine to use. Spawns a WebGL or Canvas renderer.
-   * WebGL is more performant and supports more features. Canvas is
-   * supported on most platforms.
-   *
-   * Note: When using CanvasCoreRenderer you can only use
-   * CanvasTextRenderer. The WebGLCoreRenderer supports
-   * both CanvasTextRenderer and SdfTextRenderer for Text Rendering.
-   *
-   */
-  renderEngine: typeof CanvasRenderer | typeof WebGlRenderer;
+    /**
+     * Quad buffer size in bytes
+     *
+     * @defaultValue 4 * 1024 * 1024
+     */
+    quadBufferSize: number;
 
-  /**
-   * Quad buffer size in bytes
-   *
-   * @defaultValue 4 * 1024 * 1024
-   */
-  quadBufferSize: number;
+    /**
+     * Font Engines
+     *
+     * @remarks
+     * The font engines to use for text rendering. CanvasTextRenderer is supported
+     * on all platforms. SdfTextRenderer is a more performant renderer.
+     * When using `renderEngine=CanvasCoreRenderer` you can only use `CanvasTextRenderer`.
+     * The `renderEngine=WebGLCoreRenderer` supports both `CanvasTextRenderer` and `SdfTextRenderer`.
+     *
+     * This setting is used to enable tree shaking of unused font engines. Please
+     * import your font engine(s) as follows:
+     * ```
+     * import { CanvasTextRenderer } from '@lightning/renderer/canvas';
+     * import { SdfTextRenderer } from '@lightning/renderer/webgl';
+     * ```
+     *
+     * If both CanvasTextRenderer and SdfTextRenderer are provided, the first renderer
+     * provided will be asked first if it can render the font. If it cannot render the
+     * font, the next renderer will be asked. If no renderer can render the font, the
+     * text will not be rendered.
+     *
+     * **Note** that if you have fonts available in both engines the second font engine
+     * will not be used. This is because the first font engine will always be asked first.
+     *
+     * @defaultValue '[]'
+     *
+     *
+     */
+    fontEngines: TextRenderer[];
 
-  /**
-   * Font Engines
-   *
-   * @remarks
-   * The font engines to use for text rendering. CanvasTextRenderer is supported
-   * on all platforms. SdfTextRenderer is a more performant renderer.
-   * When using `renderEngine=CanvasCoreRenderer` you can only use `CanvasTextRenderer`.
-   * The `renderEngine=WebGLCoreRenderer` supports both `CanvasTextRenderer` and `SdfTextRenderer`.
-   *
-   * This setting is used to enable tree shaking of unused font engines. Please
-   * import your font engine(s) as follows:
-   * ```
-   * import { CanvasTextRenderer } from '@lightning/renderer/canvas';
-   * import { SdfTextRenderer } from '@lightning/renderer/webgl';
-   * ```
-   *
-   * If both CanvasTextRenderer and SdfTextRenderer are provided, the first renderer
-   * provided will be asked first if it can render the font. If it cannot render the
-   * font, the next renderer will be asked. If no renderer can render the font, the
-   * text will not be rendered.
-   *
-   * **Note** that if you have fonts available in both engines the second font engine
-   * will not be used. This is because the first font engine will always be asked first.
-   *
-   * @defaultValue '[]'
-   *
-   *
-   */
-  fontEngines: TextRenderer[];
+    /**
+     * createImageBitmap support for the runtime
+     *
+     * @remarks
+     * This is used to determine if and which version of the createImageBitmap API
+     * is supported by the runtime. This is used to determine if the renderer can
+     * use createImageBitmap to load images.
+     *
+     * Options supported
+     * - Auto - Automatically determine the supported version
+     * - Basic - Supports createImageBitmap(image)
+     * - Options - Supports createImageBitmap(image, options)
+     * - Full - Supports createImageBitmap(image, sx, sy, sw, sh, options)
+     *
+     * Note with auto detection, the renderer will attempt to use the most advanced
+     * version of the API available. If the API is not available, the renderer will
+     * fall back to the next available version.
+     *
+     * This will affect startup performance as the renderer will need to determine
+     * the supported version of the API.
+     *
+     * @defaultValue `full`
+     */
+    createImageBitmapSupport: 'auto' | 'basic' | 'options' | 'full';
 
-  /**
-   * Force WebGL2
-   *
-   * @remarks
-   * Force the renderer to use WebGL2. This can be used to force the renderer to
-   * use WebGL2 even if the browser supports WebGL1.
-   *
-   * @defaultValue `false`
-   */
-  forceWebGL2: boolean;
+    /**
+     * Provide an alternative platform abstraction layer
+     *
+     * @remarks
+     * By default the Lightning 3 renderer will load a webplatform, assuming it runs
+     * inside a web browsr. However for special cases there might be a need to provide
+     * an abstracted platform layer to run on non-web or non-standard JS engines
+     *
+     * @defaultValue `null`
+     */
+    platform: typeof Platform | null;
 
-  /**
-   * Canvas object to use for rendering
-   *
-   * @remarks
-   * This is used to render the scene graph. If not provided, a new canvas
-   * element will be created and appended to the target element.
-   */
-  canvas: HTMLCanvasElement;
-
-  /**
-   * createImageBitmap support for the runtime
-   *
-   * @remarks
-   * This is used to determine if and which version of the createImageBitmap API
-   * is supported by the runtime. This is used to determine if the renderer can
-   * use createImageBitmap to load images.
-   *
-   * Options supported
-   * - Auto - Automatically determine the supported version
-   * - Basic - Supports createImageBitmap(image)
-   * - Options - Supports createImageBitmap(image, options)
-   * - Full - Supports createImageBitmap(image, sx, sy, sw, sh, options)
-   *
-   * Note with auto detection, the renderer will attempt to use the most advanced
-   * version of the API available. If the API is not available, the renderer will
-   * fall back to the next available version.
-   *
-   * This will affect startup performance as the renderer will need to determine
-   * the supported version of the API.
-   *
-   * @defaultValue `full`
-   */
-  createImageBitmapSupport: 'auto' | 'basic' | 'options' | 'full';
-
-  /**
-   * Provide an alternative platform abstraction layer
-   *
-   * @remarks
-   * By default the Lightning 3 renderer will load a webplatform, assuming it runs
-   * inside a web browsr. However for special cases there might be a need to provide
-   * an abstracted platform layer to run on non-web or non-standard JS engines
-   *
-   * @defaultValue `null`
-   */
-  platform: typeof Platform | null;
-
-  /**
-   * Number of times to retry loading a failed texture
-   *
-   * @remarks
-   * When a texture fails to load, Lightning will retry up to this many times
-   * before permanently giving up. Each retry will clear the texture ownership
-   * and then re-establish it to trigger a new load attempt.
-   *
-   * Set to null to disable retries. Set to 0 to always try once and never retry.
-   * This is typically only used on ImageTexture instances.
-   *
-   */
-  maxRetryCount?: number;
-};
+    /**
+     * Number of times to retry loading a failed texture
+     *
+     * @remarks
+     * When a texture fails to load, Lightning will retry up to this many times
+     * before permanently giving up. Each retry will clear the texture ownership
+     * and then re-establish it to trigger a new load attempt.
+     *
+     * Set to null to disable retries. Set to 0 to always try once and never retry.
+     * This is typically only used on ImageTexture instances.
+     *
+     */
+    maxRetryCount?: number;
+  };
 
 /**
  * The Renderer Main API
@@ -593,14 +562,11 @@ export class RendererMain extends EventEmitter {
       appHeight,
       boundsMargin: settings.boundsMargin!,
       clearColor: settings.clearColor!,
-      canvas: this.canvas,
       deviceLogicalPixelRatio,
       devicePhysicalPixelRatio,
       enableContextSpy: settings.enableContextSpy!,
-      forceWebGL2: settings.forceWebGL2!,
       fpsUpdateInterval: settings.fpsUpdateInterval!,
       enableClear: settings.enableClear!,
-      numImageWorkers: settings.numImageWorkers!,
       renderEngine: settings.renderEngine!,
       textureMemory: resolvedTxSettings,
       eventBus: this,


### PR DESCRIPTION
Also, instead of duplicating the type definitions between `RendererMainSettings` and `PlatformSettings`, make `RendererMainSettings` "extend" `PlatformSettings` instead.

It's easier to review this PR with whitespace turned off: https://github.com/lightning-js/renderer/pull/829/changes?w=1