### PR TITLE
feat: added premultiplyAlpha parameter to uniformRGBA

### DIFF
--- a/src/core/renderers/webgl/WebGlShaderNode.ts
+++ b/src/core/renderers/webgl/WebGlShaderNode.ts
@@ -161,7 +161,10 @@ export class WebGlShaderNode<
     }
 
     const a = rgba[3];
-    this.uniform4fa(location, [rgba[0] * a, rgba[1] * a, rgba[2] * a, a]);
+    rgba[0] *= a;
+    rgba[1] *= a;
+    rgba[2] *= a;
+    this.uniform4fa(location, rgba);
   }
 
   /**

--- a/src/core/renderers/webgl/WebGlShaderNode.ts
+++ b/src/core/renderers/webgl/WebGlShaderNode.ts
@@ -148,6 +148,7 @@ export class WebGlShaderNode<
    * Sets the value of a RGBA variable
    * @param location
    * @param value
+   * @param premultiplyAlpha
    */
   uniformRGBA(
     location: string,

--- a/src/core/renderers/webgl/WebGlShaderNode.ts
+++ b/src/core/renderers/webgl/WebGlShaderNode.ts
@@ -149,11 +149,19 @@ export class WebGlShaderNode<
    * @param location
    * @param value
    */
-  uniformRGBA(location: string, value: number) {
-    this.uniform4fv(
-      location,
-      new Float32Array(getNormalizedRgbaComponents(value)),
-    );
+  uniformRGBA(
+    location: string,
+    value: number,
+    premultiplyAlpha: boolean = false,
+  ) {
+    const rgba = getNormalizedRgbaComponents(value);
+    if (premultiplyAlpha === false || rgba[3] === 1) {
+      this.uniform4fa(location, rgba);
+      return;
+    }
+
+    const a = rgba[3];
+    this.uniform4fa(location, [rgba[0] * a, rgba[1] * a, rgba[2] * a, a]);
   }
 
   /**


### PR DESCRIPTION
Added alpha premultiplication parameter to uniformRGBA in the WebGlShaderNode / WebGlShaderType.


This parameter is a boolean and the default is false.