### PR TITLE
perf: inline AnimationSettings into CoreAnimation fields

### DIFF
--- a/src/core/animations/CoreAnimation.ts
+++ b/src/core/animations/CoreAnimation.ts
@@ -47,7 +47,11 @@ let animationIdCounter = 0;
 
 export class CoreAnimation extends EventEmitter {
   public id: number = 0;
-  public settings!: AnimationSettings;
+  public duration!: number;
+  public easing!: string | TimingFunction;
+  public loop!: boolean;
+  public repeat!: number;
+  public stopMethod!: 'reverse' | 'reset' | false;
   private progress = 0;
   private delayFor = 0;
   private delay = 0;
@@ -120,23 +124,20 @@ export class CoreAnimation extends EventEmitter {
 
     const easing = settings.easing || 'linear';
     const delay = settings.delay ?? 0;
-    this.settings = {
-      duration: settings.duration ?? 0,
-      delay,
-      easing,
-      loop: settings.loop ?? false,
-      repeat: settings.repeat ?? 0,
-      stopMethod: settings.stopMethod ?? false,
-    };
+    this.duration = settings.duration ?? 0;
+    this.delay = delay;
+    this.easing = easing;
+    this.loop = settings.loop ?? false;
+    this.repeat = settings.repeat ?? 0;
+    this.stopMethod = settings.stopMethod ?? false;
     this.timingFunction =
       typeof easing === 'string' ? getTimingFunction(easing) : easing;
     this.delayFor = delay;
-    this.delay = delay;
   }
 
   reset() {
     this.progress = 0;
-    this.delayFor = this.settings.delay || 0;
+    this.delayFor = this.delay || 0;
     this.update(0);
   }
 
@@ -187,8 +188,8 @@ export class CoreAnimation extends EventEmitter {
     }
 
     // restore stop method if we are not looping
-    if (!this.settings.loop) {
-      this.settings.stopMethod = false;
+    if (!this.loop) {
+      this.stopMethod = false;
     }
   }
 
@@ -250,7 +251,7 @@ export class CoreAnimation extends EventEmitter {
   }
 
   update(dt: number) {
-    const { duration, loop, easing, stopMethod } = this.settings;
+    const { duration, loop, easing, stopMethod } = this;
     const { delayFor } = this;
 
     if (this.node.destroyed) {

--- a/src/core/animations/CoreAnimationController.test.ts
+++ b/src/core/animations/CoreAnimationController.test.ts
@@ -34,14 +34,12 @@ function createMockAnimation(
   const emitter = new EventEmitter();
   const animation = Object.assign(emitter, {
     id: 1,
-    settings: {
-      duration: 1000,
-      delay: 0,
-      easing: 'linear',
-      loop: false,
-      repeat: 0,
-      stopMethod: false as const,
-    },
+    duration: 1000,
+    delay: 0,
+    easing: 'linear',
+    loop: false,
+    repeat: 0,
+    stopMethod: false as const,
     progress: 0,
     propValuesMap: { props: null, shaderProps: null },
     reset: vi.fn(),
@@ -275,14 +273,7 @@ describe('CoreAnimationController', () => {
 
     it('should handle stopMethod reverse by re-registering finished listener', () => {
       const animationWithReverse = createMockAnimation({
-        settings: {
-          duration: 1000,
-          delay: 0,
-          easing: 'linear',
-          loop: false,
-          repeat: 0,
-          stopMethod: 'reverse',
-        },
+        stopMethod: 'reverse' as const,
       });
 
       const controller = createController(manager, animationWithReverse);
@@ -296,14 +287,7 @@ describe('CoreAnimationController', () => {
 
     it('should not resolve promise when looping', () => {
       const loopingAnimation = createMockAnimation({
-        settings: {
-          duration: 1000,
-          delay: 0,
-          easing: 'linear',
-          loop: true,
-          repeat: 0,
-          stopMethod: false,
-        },
+        loop: true,
       });
 
       const controller = createController(manager, loopingAnimation);

--- a/src/core/animations/CoreAnimationController.ts
+++ b/src/core/animations/CoreAnimationController.ts
@@ -148,7 +148,7 @@ export class CoreAnimationController
 
   private onFinished = (): void => {
     // If the animation is looping, then we need to restart it.
-    const { loop, stopMethod } = this.animation.settings;
+    const { loop, stopMethod } = this.animation;
 
     if (stopMethod === 'reverse') {
       this.animation.reverse();


### PR DESCRIPTION
## Summary

Replace the `settings` object literal allocation in `CoreAnimation` with direct class fields (`duration`, `easing`, `loop`, `repeat`, `stopMethod`).

## Changes

- `CoreAnimation`: replaced `public settings: AnimationSettings` with individual public fields
- Constructor now assigns `this.duration`, `this.easing`, etc. directly instead of allocating `this.settings = { ... }`
- All internal references updated from `this.settings.X` to `this.X`
- `CoreAnimationController`: updated `onFinished()` to read `this.animation.loop` / `this.animation.stopMethod` directly instead of `this.animation.settings.loop`

## Motivation

Every `CoreAnimation` constructor previously allocated a new `AnimationSettings` object literal with 6 properties. By storing these as direct fields on the instance, we eliminate 1 object allocation per animation spawn. In animation-heavy scenarios this reduces GC pressure.

## Backward Compatibility

- The public `AnimationSettings` interface/type is preserved unchanged -- it continues to be exported and used as the input parameter type for `node.animate()`
- `CoreAnimation` is not part of the public API (only `AnimationSettings` type is exported from `exports/index.ts`)
- The `IAnimationController` interface is unchanged

## Testing

- All 378 existing tests pass
- Build passes, no lint errors