### PR TITLE
perf: replace once() with on() for finished event, fix destroy event name

### DIFF
--- a/src/core/animations/CoreAnimationController.ts
+++ b/src/core/animations/CoreAnimationController.ts
@@ -94,7 +94,10 @@ export class CoreAnimationController
 
   private registerAnimation(): void {
     // Hook up event listeners
-    this.animation.once('finished', this.onFinished);
+    // Use on() instead of once() for 'finished' to avoid allocating a
+    // wrapper closure. The listener is removed via unregisterAnimation()
+    // when the animation stops, or stays registered across reverse cycles.
+    this.animation.on('finished', this.onFinished);
     this.animation.on('animating', this.onAnimating);
     this.animation.on('tick', this.onTick);
     this.animation.on('destroyed', this.onDestroy);
@@ -109,7 +112,7 @@ export class CoreAnimationController
     this.animation.off('finished', this.onFinished);
     this.animation.off('animating', this.onAnimating);
     this.animation.off('tick', this.onTick);
-    this.animation.off('destroy', this.onDestroy);
+    this.animation.off('destroyed', this.onDestroy);
   }
 
   private makeStoppedPromise(): void {
@@ -130,7 +133,6 @@ export class CoreAnimationController
     const { loop, stopMethod } = this.animation.settings;
 
     if (stopMethod === 'reverse') {
-      this.animation.once('finished', this.onFinished);
       this.animation.reverse();
       return;
     }


### PR DESCRIPTION
## Summary

Replace `once('finished', ...)` with `on('finished', ...)` in `registerAnimation()` to avoid the wrapper closure allocation, and fix a pre-existing event name mismatch bug.

## Changes

### 1. Replace `once()` with `on()` for the `finished` event

`EventEmitter.once()` internally creates a wrapper closure on every call:
```ts
once(event, listener) {
  const onceListener = (target, data) => {  // <-- new closure allocated
    this.off(event, onceListener);
    listener(target, data);
  };
  this.on(event, onceListener);
}
```

This wrapper is unnecessary because `unregisterAnimation()` already calls `off('finished', this.onFinished)` to clean up the listener. Switching to `on()` eliminates 1 closure allocation per animation start.

For `stopMethod: 'reverse'`, the listener now naturally persists across reverse cycles. Previously it called `this.animation.once('finished', this.onFinished)` to re-register after each reverse -- that's no longer needed.

### 2. Fix `'destroy'` -> `'destroyed'` event name bug

`registerAnimation()` registered `on('destroyed', ...)` but `unregisterAnimation()` tried to remove `off('destroy', ...)`. The event names didn't match, so the `destroyed` listener was never actually removed during unregistration. Fixed to use `'destroyed'` consistently.

## Testing

- All 378 existing tests pass
- Build passes, no lint errors