### PR TITLE
fix: snapshot activeAnimations in update() to prevent stalls from mid-iteration splice

### DIFF
--- a/examples/tests/confetti.ts
+++ b/examples/tests/confetti.ts
@@ -115,12 +115,13 @@ export default async function ({
         const onStopped = () => {
           animateY.off('stopped', onStopped);
           this.launch(false, null, Y_START);
-          this.animations = [];
+          this.animations.length = 0;
         };
 
         animateY.on('stopped', onStopped);
 
-        this.animations = [animateY, animateX /*, animateRot*/];
+        this.animations.length = 0;
+        this.animations.push(animateY, animateX /*, animateRot*/);
       },
     };
     setTimeout(() => {

--- a/examples/tests/confetti.ts
+++ b/examples/tests/confetti.ts
@@ -12,8 +12,6 @@ const SHAPE_3 =
 const SHAPES = [SHAPE_1, SHAPE_2, SHAPE_3];
 const COLORS = [0x3c91efff, 0x847effff, 0x00a75eff, 0xf1604bff, 0xc4defaff];
 
-const POOL_SIZE = 160;
-const BURST_COUNT = 30;
 const Y_START = -40;
 const Y_END = 1600;
 
@@ -23,7 +21,13 @@ type Particle = {
   animations: IAnimationController[];
   launch(isBurst: boolean, side: 'left' | 'right' | null, startY: number): void;
 };
-export default async function ({ renderer, testRoot }: ExampleSettings) {
+export default async function ({
+  renderer,
+  testRoot,
+  perfMultiplier,
+}: ExampleSettings) {
+  const POOL_SIZE = 160 * perfMultiplier;
+  const BURST_COUNT = 30 * perfMultiplier;
   function createParticle(
     isBurst: boolean,
     side: 'left' | 'right' | null,

--- a/examples/tests/confetti2.ts
+++ b/examples/tests/confetti2.ts
@@ -18,22 +18,24 @@
  */
 
 /**
- * Confetti 2 — continuous spawn stress test
+ * Confetti 2 — continuous animation spawn stress test
  *
- * Unlike confetti.ts which recycles a fixed set of nodes, this test
- * continuously creates brand-new nodes, animates them, and destroys them
- * on completion. This stresses the full animation lifecycle:
+ * Unlike confetti.ts which recycles a fixed pool of nodes with the same
+ * animations, this test keeps nodes alive but continuously creates fresh
+ * animations on them. Each cycle: stop existing animations, spawn 3 new
+ * ones on the same node, repeat when done.
  *
- *   - Node creation + destruction every cycle
- *   - Animation controller + animation init on every spawn
- *   - Pool warm-up and steady-state recycling under constant churn
- *   - No long-lived node state — every particle is ephemeral
+ * This isolates the animation spawn/recycle cost specifically:
+ * - No node create/destroy overhead
+ * - Constant createAnimation() churn even with a warm pool
+ * - 3 concurrent animations per node (Y/X/rotation)
+ * - Each animation cycle is independent: fresh props, fresh controllers
  *
- * A new wave of WAVE_SIZE particles is fired every WAVE_INTERVAL_MS,
- * overlapping with the previous wave still in flight. Use ?multiplier=N
- * to scale the wave size.
+ * Use ?multiplier=N to scale the number of nodes (50 * N).
  */
 
+import type { IAnimationController } from '../../dist/exports/index.js';
+import type { INode } from '../../dist/src/main-api/INode.js';
 import type { ExampleSettings } from '../common/ExampleSettings.js';
 
 const SHAPE_1 =
@@ -48,87 +50,103 @@ const COLORS = [0x3c91efff, 0x847effff, 0x00a75eff, 0xf1604bff, 0xc4defaff];
 
 const Y_START = -40;
 const Y_END = 1600;
-// How many new particles to spawn per wave
-const WAVE_SIZE = 50;
-// How often to fire a new wave (ms) -- overlaps with previous wave in flight
-const WAVE_INTERVAL_MS = 500;
-// Duration range for each particle (ms)
+const NODES = 50;
 const DURATION_MIN_MS = 2000;
 const DURATION_MAX_MS = 4000;
+
+type Particle = {
+  node: INode;
+  animateY: IAnimationController | null;
+  animateX: IAnimationController | null;
+  animateRot: IAnimationController | null;
+  launch(): void;
+};
 
 export default async function ({
   renderer,
   testRoot,
   perfMultiplier,
 }: ExampleSettings) {
-  const waveSize = WAVE_SIZE * perfMultiplier;
+  const nodeCount = NODES * perfMultiplier;
 
   /**
-   * Spawn a single ephemeral particle: create node, animate it falling,
-   * then destroy both the node and the controller on completion.
+   * Create a persistent node and continuously re-spawn fresh animations on it.
+   * The node itself never changes parent or gets destroyed -- only the
+   * animations are created fresh each cycle, stressing createAnimation().
    */
-  function spawnParticle() {
+  function createParticle(): Particle {
     const size = 11 + Math.random() * 25;
-    const startX = Math.random() * 1920;
-    const endX = startX + (Math.random() - 0.5) * 80;
-    const durationMs =
-      DURATION_MIN_MS +
-      Math.floor(Math.random() * (DURATION_MAX_MS - DURATION_MIN_MS));
 
     const node = renderer.createNode({
-      x: startX,
+      x: Math.random() * 1920,
       y: Y_START,
       w: size,
       h: size,
-      rotation: Math.random() * Math.PI * 2,
       color: COLORS[Math.floor(Math.random() * COLORS.length)]!,
       src: SHAPES[Math.floor(Math.random() * SHAPES.length)]!,
       parent: testRoot,
     });
 
-    // Animate Y -- linear fall
-    const animateY = node.animate(
-      { y: Y_END },
-      { duration: durationMs, easing: 'linear' },
-    );
+    const particle: Particle = {
+      node,
+      animateY: null,
+      animateX: null,
+      animateRot: null,
 
-    // Animate X -- cubic-bezier drift
-    const animateX = node.animate(
-      { x: endX },
-      { duration: durationMs, easing: 'cubic-bezier(0,0,0.4,1)' },
-    );
+      launch() {
+        const n = this.node;
+        const durationMs =
+          DURATION_MIN_MS +
+          Math.floor(Math.random() * (DURATION_MAX_MS - DURATION_MIN_MS));
 
-    // Animate rotation
-    const animateRot = node.animate(
-      { rotation: Math.random() * Math.PI * 4 },
-      { duration: durationMs, easing: 'ease-out' },
-    );
+        const startX = Math.random() * 1920;
+        const endX = startX + (Math.random() - 0.5) * 80;
+        const startRot = Math.random() * Math.PI * 2;
 
-    animateY.start();
-    animateX.start();
-    animateRot.start();
+        // Reset node to start position for new cycle
+        n.x = startX;
+        n.y = Y_START;
+        n.rotation = startRot;
+        n.color = COLORS[Math.floor(Math.random() * COLORS.length)]!;
+        n.src = SHAPES[Math.floor(Math.random() * SHAPES.length)]!;
 
-    // When Y finishes: stop siblings and destroy node -- tests the full
-    // create-animate-destroy path continuously with no node reuse
-    animateY.on('stopped', () => {
-      animateX.stop();
-      animateRot.stop();
-      node.parent = null;
-      node.destroy();
-    });
+        // Create 3 brand-new animation controllers each cycle --
+        // this is the key difference from confetti.ts which reuses
+        // the same controllers indefinitely via the relaunch pattern.
+        this.animateY = n.animate(
+          { y: Y_END },
+          { duration: durationMs, easing: 'linear' },
+        );
+        this.animateX = n.animate(
+          { x: endX },
+          { duration: durationMs, easing: 'cubic-bezier(0,0,0.4,1)' },
+        );
+        this.animateRot = n.animate(
+          { rotation: startRot + Math.random() * Math.PI * 4 },
+          { duration: durationMs, easing: 'ease-out' },
+        );
+
+        this.animateY.start();
+        this.animateX.start();
+        this.animateRot.start();
+
+        // When Y finishes, stop the siblings and immediately re-launch --
+        // keeps the node fully animated at all times with fresh controllers
+        this.animateY.on('stopped', () => {
+          this.animateX!.stop();
+          this.animateRot!.stop();
+          this.launch();
+        });
+      },
+    };
+
+    return particle;
   }
 
-  /**
-   * Fire a wave of particles, staggered by 1 frame each to avoid
-   * creating all nodes in the same frame.
-   */
-  function fireWave() {
-    for (let i = 0; i < waveSize; i++) {
-      setTimeout(spawnParticle, i * (WAVE_INTERVAL_MS / waveSize));
-    }
+  // Create all nodes upfront with a small stagger to spread the initial
+  // wave of animation starts across frames
+  for (let i = 0; i < nodeCount; i++) {
+    const particle = createParticle();
+    setTimeout(() => particle.launch(), i * 10);
   }
-
-  // Fire the first wave immediately, then repeat on interval
-  fireWave();
-  setInterval(fireWave, WAVE_INTERVAL_MS);
 }

--- a/examples/tests/confetti2.ts
+++ b/examples/tests/confetti2.ts
@@ -1,0 +1,134 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Confetti 2 — continuous spawn stress test
+ *
+ * Unlike confetti.ts which recycles a fixed set of nodes, this test
+ * continuously creates brand-new nodes, animates them, and destroys them
+ * on completion. This stresses the full animation lifecycle:
+ *
+ *   - Node creation + destruction every cycle
+ *   - Animation controller + animation init on every spawn
+ *   - Pool warm-up and steady-state recycling under constant churn
+ *   - No long-lived node state — every particle is ephemeral
+ *
+ * A new wave of WAVE_SIZE particles is fired every WAVE_INTERVAL_MS,
+ * overlapping with the previous wave still in flight. Use ?multiplier=N
+ * to scale the wave size.
+ */
+
+import type { ExampleSettings } from '../common/ExampleSettings.js';
+
+const SHAPE_1 =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAEjSURBVHgBnZO9TgJBFIXvbEllQqsJNrTaSmVhqdHKViyplCewsTXhDcAnkBcwUkm52tqwJrYmVLTDOXAWJsPfhJN8e/fuzD2TmblrFsl7fw66YOSXyvWtZpuEwQPw5nfrKaxzZTFCDrjCBLyDIfjXvDo4Aw3lPefcfWjQRWiq4CUojEWjFqiANkw6jntG8qGVn7cUlzqVyRgcZ3jcaWCYUEx9gR/AbTczOVKflq5c8SQ0+LN0lXNrWfCxYnuIBoXeDy1d5dxvGrwqaVi6LhQHNOgpYaPUE4qvQBUU6IN+hkeBpK3Blow26RZc6n3ZiRQaqoPwoJT3zKviafNwj2Rc1fisC1fsYfIY/YWxRurchdwaE3bYDbi2ebexZX9BH6sO4vlTUbSnqsTgwTgAAAAASUVORK5CYII=';
+const SHAPE_2 =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAABOSURBVHgB7ZKhDQAgDAQfwiA4loEhUKzFZoxSqKtAtFUILmnST/7cByJaADJs9OiQmJxEGAqhnmv8RDj54lOiHEBV9MtNbDDAYod9r3MDaHkHotN0PbEAAAAASUVORK5CYII=';
+const SHAPE_3 =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAATCAYAAACQjC21AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAFcSURBVHgBrVQtTwNBEJ1tMKCa8AOoqj6LK6BJjl8AFleCwsE/AEGQdx5RgYXUYTnbmjsSJKQ1xW7f5N4m28u2d/14ybuZ2515O9PerEgNrLVtMAf7sgtA6MqWmMguwOocerINVMAuYijbAAIJhb7AGf22bAIkdrzK7sB3+ver8gwCYtgIPOJah3R+Br6AXfCW6wXp/G/66R4eCbiqjQ/aMdmtHOqj0Ap1Y+gFpExU/AWSDsB98BA8k7I7xZMxpt/Co8DLidfCORNCYop/7kWe2I2KqWNcFP89bT9m0iv4uaTCaylbn1IsdZst52BxCl7AfWDSpYRxSrFCO/PFFgQ9ZLRjCcOtawFZdTMk2KMd0eqPry0e8/2HNmr0ket48QN+Bt+8CVH88iMfNZptXlUOvlBSuSRmTaYmdBnkrgoe9mjXuSz0RAZOlp3OGc9dXJ1gDA44PXWxevEOqutzNZRW6qN+HjoAAAAASUVORK5CYII=';
+
+const SHAPES = [SHAPE_1, SHAPE_2, SHAPE_3];
+const COLORS = [0x3c91efff, 0x847effff, 0x00a75eff, 0xf1604bff, 0xc4defaff];
+
+const Y_START = -40;
+const Y_END = 1600;
+// How many new particles to spawn per wave
+const WAVE_SIZE = 50;
+// How often to fire a new wave (ms) -- overlaps with previous wave in flight
+const WAVE_INTERVAL_MS = 500;
+// Duration range for each particle (ms)
+const DURATION_MIN_MS = 2000;
+const DURATION_MAX_MS = 4000;
+
+export default async function ({
+  renderer,
+  testRoot,
+  perfMultiplier,
+}: ExampleSettings) {
+  const waveSize = WAVE_SIZE * perfMultiplier;
+
+  /**
+   * Spawn a single ephemeral particle: create node, animate it falling,
+   * then destroy both the node and the controller on completion.
+   */
+  function spawnParticle() {
+    const size = 11 + Math.random() * 25;
+    const startX = Math.random() * 1920;
+    const endX = startX + (Math.random() - 0.5) * 80;
+    const durationMs =
+      DURATION_MIN_MS +
+      Math.floor(Math.random() * (DURATION_MAX_MS - DURATION_MIN_MS));
+
+    const node = renderer.createNode({
+      x: startX,
+      y: Y_START,
+      w: size,
+      h: size,
+      rotation: Math.random() * Math.PI * 2,
+      color: COLORS[Math.floor(Math.random() * COLORS.length)]!,
+      src: SHAPES[Math.floor(Math.random() * SHAPES.length)]!,
+      parent: testRoot,
+    });
+
+    // Animate Y -- linear fall
+    const animateY = node.animate(
+      { y: Y_END },
+      { duration: durationMs, easing: 'linear' },
+    );
+
+    // Animate X -- cubic-bezier drift
+    const animateX = node.animate(
+      { x: endX },
+      { duration: durationMs, easing: 'cubic-bezier(0,0,0.4,1)' },
+    );
+
+    // Animate rotation
+    const animateRot = node.animate(
+      { rotation: Math.random() * Math.PI * 4 },
+      { duration: durationMs, easing: 'ease-out' },
+    );
+
+    animateY.start();
+    animateX.start();
+    animateRot.start();
+
+    // When Y finishes: stop siblings and destroy node -- tests the full
+    // create-animate-destroy path continuously with no node reuse
+    animateY.on('stopped', () => {
+      animateX.stop();
+      animateRot.stop();
+      node.parent = null;
+      node.destroy();
+    });
+  }
+
+  /**
+   * Fire a wave of particles, staggered by 1 frame each to avoid
+   * creating all nodes in the same frame.
+   */
+  function fireWave() {
+    for (let i = 0; i < waveSize; i++) {
+      setTimeout(spawnParticle, i * (WAVE_INTERVAL_MS / waveSize));
+    }
+  }
+
+  // Fire the first wave immediately, then repeat on interval
+  fireWave();
+  setInterval(fireWave, WAVE_INTERVAL_MS);
+}

--- a/src/common/EventEmitter.ts
+++ b/src/common/EventEmitter.ts
@@ -61,7 +61,7 @@ export class EventEmitter implements IEventEmitter {
 
   emit(event: string, data?: any): void {
     const listeners = this.eventListeners[event];
-    if (!listeners) {
+    if (listeners === undefined || listeners.length === 0) {
       return;
     }
     // Iterate backwards: safe when once()/off() splice() during emission since
@@ -86,12 +86,16 @@ export class EventEmitter implements IEventEmitter {
    * object in V8's fast-properties mode and avoids re-allocating the arrays
    * on the next on() call. Use this for objects with a known fixed set of
    * event names (e.g. CoreAnimation, CoreAnimationController).
+   *
+   * Only writes arr.length = 0 when the array is non-empty -- skips the write
+   * (and the write barrier on old-gen objects) when already empty, which is
+   * the common case after unregisterAnimation() has removed all listeners.
    */
   clearListeners(events: readonly string[]): void {
     const map = this.eventListeners;
     for (let i = 0; i < events.length; i++) {
       const arr = map[events[i]!];
-      if (arr !== undefined) {
+      if (arr !== undefined && arr.length > 0) {
         arr.length = 0;
       }
     }

--- a/src/common/EventEmitter.ts
+++ b/src/common/EventEmitter.ts
@@ -73,6 +73,10 @@ export class EventEmitter implements IEventEmitter {
   }
 
   removeAllListeners() {
-    this.eventListeners = {};
+    // Clear in place to avoid allocating a new {} object.
+    const listeners = this.eventListeners;
+    for (const key in listeners) {
+      delete listeners[key];
+    }
   }
 }

--- a/src/common/EventEmitter.ts
+++ b/src/common/EventEmitter.ts
@@ -31,9 +31,9 @@ export class EventEmitter implements IEventEmitter {
     let listeners = this.eventListeners[event];
     if (!listeners) {
       listeners = [];
+      this.eventListeners[event] = listeners;
     }
     listeners.push(listener);
-    this.eventListeners[event] = listeners;
   }
 
   off(event: string, listener?: EventListener): void {
@@ -77,6 +77,23 @@ export class EventEmitter implements IEventEmitter {
     const listeners = this.eventListeners;
     for (const key in listeners) {
       delete listeners[key];
+    }
+  }
+
+  /**
+   * Clear all listeners for the given event names by setting their array
+   * length to 0, WITHOUT deleting the keys. This keeps the eventListeners
+   * object in V8's fast-properties mode and avoids re-allocating the arrays
+   * on the next on() call. Use this for objects with a known fixed set of
+   * event names (e.g. CoreAnimation, CoreAnimationController).
+   */
+  clearListeners(events: readonly string[]): void {
+    const map = this.eventListeners;
+    for (let i = 0; i < events.length; i++) {
+      const arr = map[events[i]!];
+      if (arr !== undefined) {
+        arr.length = 0;
+      }
     }
   }
 }

--- a/src/common/EventEmitter.ts
+++ b/src/common/EventEmitter.ts
@@ -64,10 +64,11 @@ export class EventEmitter implements IEventEmitter {
     if (!listeners) {
       return;
     }
-    // Snapshot to handle listeners that remove themselves via once()/off()
-    const snapshot = listeners.slice();
-    for (let i = 0, len = snapshot.length; i < len; i++) {
-      snapshot[i]!(this, data);
+    // Iterate backwards: safe when once()/off() splice() during emission since
+    // removals only shift elements at higher indices (already visited).
+    // Zero allocations vs the previous listeners.slice() snapshot approach.
+    for (let i = listeners.length - 1; i >= 0; i--) {
+      listeners[i]!(this, data);
     }
   }
 

--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -105,6 +105,11 @@ export class Stage {
   public preloadBound: Bound;
   public readonly defaultTexture: Texture | null = null;
   public pixelRatio: number;
+  // Pre-allocated frameTick payload -- reused every frame to avoid per-frame {} allocation
+  private readonly frameTickPayload: { time: number; delta: number } = {
+    time: 0,
+    delta: 0,
+  };
   public readonly bufferMemory: number = 2e6;
   public readonly platform: Platform | WebPlatform;
   public readonly calculateTextureCoord: boolean;
@@ -399,10 +404,9 @@ export class Stage {
 
     // This event is emitted at the beginning of the frame (before any updates
     // or rendering), so no need to to use `stage.queueFrameEvent` here.
-    this.eventBus.emit('frameTick', {
-      time: this.currentFrameTime,
-      delta: this.deltaTime,
-    });
+    this.frameTickPayload.time = this.currentFrameTime;
+    this.frameTickPayload.delta = this.deltaTime;
+    this.eventBus.emit('frameTick', this.frameTickPayload);
   }
 
   /**

--- a/src/core/animations/AnimationManager.ts
+++ b/src/core/animations/AnimationManager.ts
@@ -112,11 +112,11 @@ export class AnimationManager {
     animation: CoreAnimation,
     controller: CoreAnimationController,
   ): void {
-    // Clear in-place using known event names -- preserves pre-allocated listener
-    // arrays so the next registerAnimation() doesn't need to allocate new [].
-    animation.clearListeners(CoreAnimation.EVENTS);
+    // Do NOT clearListeners here -- init() clears lazily on next reuse.
+    // By the time releaseToPool() fires, unregisterAnimation() has already
+    // emptied all listener arrays via off(). Moving clearListeners to init()
+    // keeps this hot path (inside the rAF completion chain) as cheap as possible.
     this.animationPool.push(animation);
-    controller.clearListeners(CoreAnimationController.EVENTS);
     this.controllerPool.push(controller);
   }
 }

--- a/src/core/animations/AnimationManager.ts
+++ b/src/core/animations/AnimationManager.ts
@@ -38,26 +38,37 @@ export class AnimationManager {
   private controllerPool: CoreAnimationController[] = [];
 
   registerAnimation(animation: CoreAnimation) {
+    animation.activeIndex = this.activeAnimations.length;
     this.activeAnimations.push(animation);
   }
 
   unregisterAnimation(animation: CoreAnimation) {
-    const animations = this.activeAnimations;
-    const index = animations.indexOf(animation);
-    if (index >= 0) {
-      // Swap-remove: O(1), order doesn't matter for the update loop
-      animations[index] = animations[animations.length - 1]!;
-      animations.pop();
+    const index = animation.activeIndex;
+    if (index === -1) {
+      return;
     }
+    const animations = this.activeAnimations;
+    const last = animations.length - 1;
+    if (index !== last) {
+      // Swap with the last element and update its index
+      const swap = animations[last]!;
+      animations[index] = swap;
+      swap.activeIndex = index;
+    }
+    animations.pop();
+    animation.activeIndex = -1;
   }
 
   update(dt: number) {
     const animations = this.activeAnimations;
-    // Iterate backwards: safe when animation.update() finishes and triggers
-    // unregisterAnimation() (swap-remove). A swap-remove at index i only
-    // affects elements at index >= i, which a backwards loop has already visited.
+    // Iterate backwards. With activeIndex tracking, if a sibling stop() during
+    // a completion event swap-removes an already-visited element into index i,
+    // we check activeIndex >= 0 before updating to avoid double-processing.
     for (let i = animations.length - 1; i >= 0; i--) {
-      animations[i]!.update(dt);
+      const anim = animations[i]!;
+      if (anim.activeIndex >= 0) {
+        anim.update(dt);
+      }
     }
   }
 

--- a/src/core/animations/AnimationManager.ts
+++ b/src/core/animations/AnimationManager.ts
@@ -101,9 +101,11 @@ export class AnimationManager {
     animation: CoreAnimation,
     controller: CoreAnimationController,
   ): void {
-    animation.removeAllListeners();
+    // Clear in-place using known event names -- preserves pre-allocated listener
+    // arrays so the next registerAnimation() doesn't need to allocate new [].
+    animation.clearListeners(CoreAnimation.EVENTS);
     this.animationPool.push(animation);
-    controller.removeAllListeners();
+    controller.clearListeners(CoreAnimationController.EVENTS);
     this.controllerPool.push(controller);
   }
 }

--- a/src/core/animations/AnimationManager.ts
+++ b/src/core/animations/AnimationManager.ts
@@ -45,17 +45,19 @@ export class AnimationManager {
     const animations = this.activeAnimations;
     const index = animations.indexOf(animation);
     if (index >= 0) {
-      animations.splice(index, 1);
+      // Swap-remove: O(1), order doesn't matter for the update loop
+      animations[index] = animations[animations.length - 1]!;
+      animations.pop();
     }
   }
 
   update(dt: number) {
     const animations = this.activeAnimations;
-    // Snapshot to handle animations that unregister during iteration
-    // (e.g., when an animation finishes and calls unregisterAnimation/splice)
-    const snapshot = animations.slice();
-    for (let i = 0, len = snapshot.length; i < len; i++) {
-      snapshot[i]!.update(dt);
+    // Iterate backwards: safe when animation.update() finishes and triggers
+    // unregisterAnimation() (swap-remove). A swap-remove at index i only
+    // affects elements at index >= i, which a backwards loop has already visited.
+    for (let i = animations.length - 1; i >= 0; i--) {
+      animations[i]!.update(dt);
     }
   }
 

--- a/src/core/animations/AnimationManager.ts
+++ b/src/core/animations/AnimationManager.ts
@@ -51,8 +51,11 @@ export class AnimationManager {
 
   update(dt: number) {
     const animations = this.activeAnimations;
-    for (let i = 0, len = animations.length; i < len; i++) {
-      animations[i]!.update(dt);
+    // Snapshot to handle animations that unregister during iteration
+    // (e.g., when an animation finishes and calls unregisterAnimation/splice)
+    const snapshot = animations.slice();
+    for (let i = 0, len = snapshot.length; i < len; i++) {
+      snapshot[i]!.update(dt);
     }
   }
 

--- a/src/core/animations/CoreAnimation.ts
+++ b/src/core/animations/CoreAnimation.ts
@@ -53,8 +53,10 @@ export class CoreAnimation extends EventEmitter {
   public loop!: boolean;
   public repeat!: number;
   public stopMethod!: 'reverse' | 'reset' | false;
-  // Cached at init() time -- avoids string comparison in the per-frame hot path
-  private isLinear = true;
+  // Cached at init() time -- avoids re-computation in the per-frame hot path
+  private hasEasing = false;
+  // Reciprocal of duration -- stored so update() multiplies instead of divides
+  private invDuration = 0;
   private progress = 0;
   private delayFor = 0;
   private delay = 0;
@@ -153,7 +155,10 @@ export class CoreAnimation extends EventEmitter {
 
     const easing = settings.easing || 'linear';
     const delay = settings.delay ?? 0;
-    this.duration = settings.duration ?? 0;
+    const duration = settings.duration ?? 0;
+    this.duration = duration;
+    // Pre-compute reciprocal to replace per-frame division with multiplication
+    this.invDuration = duration > 0 ? 1 / duration : 0;
     this.delay = delay;
     this.easing = easing;
     this.loop = settings.loop ?? false;
@@ -161,7 +166,8 @@ export class CoreAnimation extends EventEmitter {
     this.stopMethod = settings.stopMethod ?? false;
     this.timingFunction =
       typeof easing === 'string' ? getTimingFunction(easing) : easing;
-    this.isLinear = easing === 'linear';
+    // Explicit bool -- avoids string comparison on every updateValue() call
+    this.hasEasing = easing !== 'linear';
     this.delayFor = delay;
   }
 
@@ -218,51 +224,66 @@ export class CoreAnimation extends EventEmitter {
     }
 
     // restore stop method if we are not looping
-    if (!this.loop) {
+    if (this.loop === false) {
       this.stopMethod = false;
     }
   }
 
-  private applyEasing(p: number, s: number, e: number): number {
-    return this.timingFunction(p) * (e - s) + s;
-  }
-
-  updateValue(isColor: boolean, propValue: number, startValue: number): number {
-    if (this.progress === 1) {
+  /**
+   * Interpolate a single property value given the current progress.
+   * progress is passed as a parameter so callers can cache it in a local,
+   * avoiding repeated this.progress reads (which box floats in V8).
+   */
+  updateValue(
+    isColor: boolean,
+    propValue: number,
+    startValue: number,
+    progress: number,
+  ): number {
+    if (progress === 1) {
       return propValue;
     }
-    if (this.progress === 0) {
+    if (progress === 0) {
       return startValue;
     }
 
-    const endValue = propValue;
     if (isColor === true) {
-      if (startValue === endValue) {
+      if (startValue === propValue) {
         return startValue;
       }
-
-      if (!this.isLinear) {
-        const easingProgressValue =
-          this.timingFunction(this.progress) || this.progress;
-        return mergeColorProgress(startValue, endValue, easingProgressValue);
+      if (this.hasEasing === true) {
+        const p = this.timingFunction(progress) || progress;
+        return mergeColorProgress(startValue, propValue, p);
       }
-      return mergeColorProgress(startValue, endValue, this.progress);
+      return mergeColorProgress(startValue, propValue, progress);
     }
 
-    if (!this.isLinear) {
-      return this.applyEasing(this.progress, startValue, endValue);
+    if (this.hasEasing === true) {
+      // Inlined applyEasing: this.timingFunction(p) * (e - s) + s
+      return (
+        this.timingFunction(progress) * (propValue - startValue) + startValue
+      );
     }
-    return startValue + (endValue - startValue) * this.progress;
+    return startValue + (propValue - startValue) * progress;
   }
 
-  private updateValues(target: Record<string, number>, group: PropGroup) {
+  private updateValues(
+    target: Record<string, number>,
+    group: PropGroup,
+    progress: number,
+  ) {
     const keys = group.keys;
     const starts = group.starts;
     const targets = group.targets;
     const isColor = group.isColor;
     const length = group.length;
     for (let i = 0; i < length; i++) {
-      target[keys[i]!] = this.updateValue(isColor[i]!, targets[i]!, starts[i]!);
+      target[keys[i]!] = this.updateValue(
+        isColor[i]!,
+        targets[i]!,
+        starts[i]!,
+        progress,
+      );
     }
   }
 
@@ -271,7 +292,6 @@ export class CoreAnimation extends EventEmitter {
     const { delayFor } = this;
 
     if (this.node.destroyed) {
-      // cleanup
       this.emit('destroyed');
       return;
     }
@@ -295,31 +315,35 @@ export class CoreAnimation extends EventEmitter {
     }
 
     if (duration === 0) {
-      // No duration, we are done.
       this.emit('finished');
       return;
     }
 
-    if (this.progress === 0) {
-      // Progress is 0, we are starting the post-delay part of the animation.
+    // Read progress once into a local -- avoids repeated this.progress reads
+    // which cause V8 to box the float value on each access to the object property.
+    let progress = this.progress;
+
+    if (progress === 0) {
       this.emit('animating');
     }
 
-    this.progress += dt / duration;
+    // Multiply by pre-computed reciprocal -- avoids per-frame float division
+    progress += dt * this.invDuration;
 
-    if (this.progress > 1) {
-      this.progress = loop ? 0 : 1;
+    if (progress > 1) {
+      progress = loop === true ? 0 : 1;
       this.delayFor = this.delay;
-      if (stopMethod) {
-        // If there's a stop method emit finished so the stop method can be applied.
-        // TODO: We should probably reevaluate how stopMethod is implemented as currently
-        // stop method 'reset' does not work when looping.
+      if (stopMethod !== false) {
+        this.progress = progress;
         this.emit('finished');
         return;
       }
     }
 
-    // Extract to locals to avoid repeated bracket-string lookups in the hot path
+    // Write back once
+    this.progress = progress;
+
+    // Extract to locals to avoid repeated property lookups in the hot path
     const propsGroup = this.propValuesMap.props;
     const shaderGroup = this.propValuesMap.shaderProps;
 
@@ -327,20 +351,22 @@ export class CoreAnimation extends EventEmitter {
       this.updateValues(
         this.node as unknown as Record<string, number>,
         propsGroup,
+        progress,
       );
     }
     if (shaderGroup !== null) {
       this.updateValues(
         this.node.shader!.props as Record<string, number>,
         shaderGroup,
+        progress,
       );
     }
 
-    if (this.progress < 1) {
+    if (progress < 1) {
       this.emit('tick');
     }
 
-    if (this.progress === 1) {
+    if (progress === 1) {
       this.emit('finished');
     }
   }

--- a/src/core/animations/CoreAnimation.ts
+++ b/src/core/animations/CoreAnimation.ts
@@ -53,6 +53,8 @@ export class CoreAnimation extends EventEmitter {
   public loop!: boolean;
   public repeat!: number;
   public stopMethod!: 'reverse' | 'reset' | false;
+  // Cached at init() time -- avoids string comparison in the per-frame hot path
+  private isLinear = true;
   private progress = 0;
   private delayFor = 0;
   private delay = 0;
@@ -76,10 +78,24 @@ export class CoreAnimation extends EventEmitter {
     length: 0,
   };
 
+  // Fixed set of event names this animation emits -- used for zero-alloc clearListeners()
+  static readonly EVENTS = [
+    'finished',
+    'animating',
+    'tick',
+    'destroyed',
+  ] as const;
+
   propValuesMap: PropValuesMap = { props: null, shaderProps: null };
 
   constructor() {
     super();
+    // Pre-allocate listener arrays for the known events so on() never needs to
+    // allocate a new [] when the animation is registered after a pool recycle.
+    this.eventListeners['finished'] = [];
+    this.eventListeners['animating'] = [];
+    this.eventListeners['tick'] = [];
+    this.eventListeners['destroyed'] = [];
   }
 
   /**
@@ -96,7 +112,9 @@ export class CoreAnimation extends EventEmitter {
     this.progress = 0;
     this.propValuesMap.props = null;
     this.propValuesMap.shaderProps = null;
-    this.removeAllListeners();
+    // Clear listener arrays in-place (zero alloc) -- keeps arrays alive so
+    // the next registerAnimation() on() calls don't need to allocate new [].
+    this.clearListeners(CoreAnimation.EVENTS);
 
     // Reset persistent group lengths (reuse existing arrays, no new allocations)
     this.propsGroup.length = 0;
@@ -143,6 +161,7 @@ export class CoreAnimation extends EventEmitter {
     this.stopMethod = settings.stopMethod ?? false;
     this.timingFunction =
       typeof easing === 'string' ? getTimingFunction(easing) : easing;
+    this.isLinear = easing === 'linear';
     this.delayFor = delay;
   }
 
@@ -208,12 +227,7 @@ export class CoreAnimation extends EventEmitter {
     return this.timingFunction(p) * (e - s) + s;
   }
 
-  updateValue(
-    isColor: boolean,
-    propValue: number,
-    startValue: number,
-    easing: string | TimingFunction | undefined,
-  ): number {
+  updateValue(isColor: boolean, propValue: number, startValue: number): number {
     if (this.progress === 1) {
       return propValue;
     }
@@ -227,7 +241,7 @@ export class CoreAnimation extends EventEmitter {
         return startValue;
       }
 
-      if (easing && easing !== 'linear') {
+      if (!this.isLinear) {
         const easingProgressValue =
           this.timingFunction(this.progress) || this.progress;
         return mergeColorProgress(startValue, endValue, easingProgressValue);
@@ -235,34 +249,25 @@ export class CoreAnimation extends EventEmitter {
       return mergeColorProgress(startValue, endValue, this.progress);
     }
 
-    if (easing && easing !== 'linear') {
+    if (!this.isLinear) {
       return this.applyEasing(this.progress, startValue, endValue);
     }
     return startValue + (endValue - startValue) * this.progress;
   }
 
-  private updateValues(
-    target: Record<string, number>,
-    group: PropGroup,
-    easing: string | TimingFunction | undefined,
-  ) {
+  private updateValues(target: Record<string, number>, group: PropGroup) {
     const keys = group.keys;
     const starts = group.starts;
     const targets = group.targets;
     const isColor = group.isColor;
     const length = group.length;
     for (let i = 0; i < length; i++) {
-      target[keys[i]!] = this.updateValue(
-        isColor[i]!,
-        targets[i]!,
-        starts[i]!,
-        easing,
-      );
+      target[keys[i]!] = this.updateValue(isColor[i]!, targets[i]!, starts[i]!);
     }
   }
 
   update(dt: number) {
-    const { duration, loop, easing, stopMethod } = this;
+    const { duration, loop, stopMethod } = this;
     const { delayFor } = this;
 
     if (this.node.destroyed) {
@@ -314,18 +319,20 @@ export class CoreAnimation extends EventEmitter {
       }
     }
 
-    if (this.propValuesMap['props'] !== null) {
+    // Extract to locals to avoid repeated bracket-string lookups in the hot path
+    const propsGroup = this.propValuesMap.props;
+    const shaderGroup = this.propValuesMap.shaderProps;
+
+    if (propsGroup !== null) {
       this.updateValues(
         this.node as unknown as Record<string, number>,
-        this.propValuesMap['props'],
-        easing,
+        propsGroup,
       );
     }
-    if (this.propValuesMap['shaderProps'] !== null) {
+    if (shaderGroup !== null) {
       this.updateValues(
         this.node.shader!.props as Record<string, number>,
-        this.propValuesMap['shaderProps'],
-        easing,
+        shaderGroup,
       );
     }
 

--- a/src/core/animations/CoreAnimation.ts
+++ b/src/core/animations/CoreAnimation.ts
@@ -36,6 +36,7 @@ type PropGroup = {
   starts: number[];
   targets: number[];
   isColor: boolean[];
+  length: number;
 };
 
 type PropValuesMap = {
@@ -57,6 +58,23 @@ export class CoreAnimation extends EventEmitter {
   private delay = 0;
   private timingFunction!: TimingFunction;
   private node!: CoreNode;
+
+  // Persistent PropGroup instances -- reused across pool recycles to avoid
+  // allocating new arrays each time. length tracks how many entries are active.
+  private propsGroup: PropGroup = {
+    keys: [],
+    starts: [],
+    targets: [],
+    isColor: [],
+    length: 0,
+  };
+  private shaderPropsGroup: PropGroup = {
+    keys: [],
+    starts: [],
+    targets: [],
+    isColor: [],
+    length: 0,
+  };
 
   propValuesMap: PropValuesMap = { props: null, shaderProps: null };
 
@@ -80,44 +98,37 @@ export class CoreAnimation extends EventEmitter {
     this.propValuesMap.shaderProps = null;
     this.removeAllListeners();
 
+    // Reset persistent group lengths (reuse existing arrays, no new allocations)
+    this.propsGroup.length = 0;
+    this.shaderPropsGroup.length = 0;
+
     for (const key in props) {
       if (key !== 'shaderProps') {
         if (this.propValuesMap['props'] === null) {
-          this.propValuesMap['props'] = {
-            keys: [],
-            starts: [],
-            targets: [],
-            isColor: [],
-          };
+          this.propValuesMap['props'] = this.propsGroup;
         }
-        const group = this.propValuesMap['props']!;
-        group.keys.push(key);
-        group.starts.push(
-          node[key as keyof Omit<CoreNodeAnimateProps, 'shaderProps'>] || 0,
-        );
-        group.targets.push(
-          props[
-            key as keyof Omit<CoreNodeAnimateProps, 'shaderProps'>
-          ] as number,
-        );
-        group.isColor.push(key.indexOf('color') !== -1);
+        const group = this.propsGroup;
+        const i = group.length++;
+        group.keys[i] = key;
+        group.starts[i] =
+          node[key as keyof Omit<CoreNodeAnimateProps, 'shaderProps'>] || 0;
+        group.targets[i] = props[
+          key as keyof Omit<CoreNodeAnimateProps, 'shaderProps'>
+        ] as number;
+        group.isColor[i] = key.indexOf('color') !== -1;
       } else if (key === 'shaderProps' && node.shader !== null) {
-        this.propValuesMap['shaderProps'] = {
-          keys: [],
-          starts: [],
-          targets: [],
-          isColor: [],
-        };
-        const group = this.propValuesMap['shaderProps']!;
+        this.propValuesMap['shaderProps'] = this.shaderPropsGroup;
+        const group = this.shaderPropsGroup;
         for (const key in props.shaderProps) {
           let start = node.shader.props![key];
           if (Array.isArray(start) === true) {
             start = start[0];
           }
-          group.keys.push(key);
-          group.starts.push(start);
-          group.targets.push(props.shaderProps[key] as number);
-          group.isColor.push(key.indexOf('color') !== -1);
+          const i = group.length++;
+          group.keys[i] = key;
+          group.starts[i] = start;
+          group.targets[i] = props.shaderProps[key] as number;
+          group.isColor[i] = key.indexOf('color') !== -1;
         }
       }
     }
@@ -144,7 +155,7 @@ export class CoreAnimation extends EventEmitter {
   private restoreValues(target: Record<string, number>, group: PropGroup) {
     const keys = group.keys;
     const starts = group.starts;
-    const length = keys.length;
+    const length = group.length;
     for (let i = 0; i < length; i++) {
       target[keys[i]!] = starts[i]!;
     }
@@ -169,7 +180,7 @@ export class CoreAnimation extends EventEmitter {
   private reverseValues(group: PropGroup) {
     const starts = group.starts;
     const targets = group.targets;
-    const length = starts.length;
+    const length = group.length;
     for (let i = 0; i < length; i++) {
       const tmp = starts[i]!;
       starts[i] = targets[i]!;
@@ -216,7 +227,7 @@ export class CoreAnimation extends EventEmitter {
         return startValue;
       }
 
-      if (easing) {
+      if (easing && easing !== 'linear') {
         const easingProgressValue =
           this.timingFunction(this.progress) || this.progress;
         return mergeColorProgress(startValue, endValue, easingProgressValue);
@@ -224,7 +235,7 @@ export class CoreAnimation extends EventEmitter {
       return mergeColorProgress(startValue, endValue, this.progress);
     }
 
-    if (easing) {
+    if (easing && easing !== 'linear') {
       return this.applyEasing(this.progress, startValue, endValue);
     }
     return startValue + (endValue - startValue) * this.progress;
@@ -239,7 +250,7 @@ export class CoreAnimation extends EventEmitter {
     const starts = group.starts;
     const targets = group.targets;
     const isColor = group.isColor;
-    const length = keys.length;
+    const length = group.length;
     for (let i = 0; i < length; i++) {
       target[keys[i]!] = this.updateValue(
         isColor[i]!,
@@ -256,12 +267,12 @@ export class CoreAnimation extends EventEmitter {
 
     if (this.node.destroyed) {
       // cleanup
-      this.emit('destroyed', {});
+      this.emit('destroyed');
       return;
     }
 
     if (duration === 0 && delayFor === 0) {
-      this.emit('finished', {});
+      this.emit('finished');
       return;
     }
 
@@ -280,13 +291,13 @@ export class CoreAnimation extends EventEmitter {
 
     if (duration === 0) {
       // No duration, we are done.
-      this.emit('finished', {});
+      this.emit('finished');
       return;
     }
 
     if (this.progress === 0) {
       // Progress is 0, we are starting the post-delay part of the animation.
-      this.emit('animating', {});
+      this.emit('animating');
     }
 
     this.progress += dt / duration;
@@ -298,7 +309,7 @@ export class CoreAnimation extends EventEmitter {
         // If there's a stop method emit finished so the stop method can be applied.
         // TODO: We should probably reevaluate how stopMethod is implemented as currently
         // stop method 'reset' does not work when looping.
-        this.emit('finished', {});
+        this.emit('finished');
         return;
       }
     }
@@ -323,7 +334,7 @@ export class CoreAnimation extends EventEmitter {
     }
 
     if (this.progress === 1) {
-      this.emit('finished', {});
+      this.emit('finished');
     }
   }
 }

--- a/src/core/animations/CoreAnimation.ts
+++ b/src/core/animations/CoreAnimation.ts
@@ -118,8 +118,10 @@ export class CoreAnimation extends EventEmitter {
     this.activeIndex = -1;
     this.propValuesMap.props = null;
     this.propValuesMap.shaderProps = null;
-    // NOTE: listener arrays are already cleared by releaseToPool() before
-    // this is called. No need to clearListeners() here again.
+    // Clear any stale listeners from the previous use. With the arr.length > 0
+    // guard in clearListeners(), this is a near-zero cost read of 4 array lengths
+    // when unregisterAnimation() has already emptied them (the common case).
+    this.clearListeners(CoreAnimation.EVENTS);
 
     // Reset persistent group lengths (reuse existing arrays, no new allocations)
     this.propsGroup.length = 0;
@@ -177,7 +179,23 @@ export class CoreAnimation extends EventEmitter {
   reset() {
     this.progress = 0;
     this.delayFor = this.delay || 0;
-    this.update(0);
+    // Write start values directly rather than calling update(0), which would
+    // run the full update pipeline (dirty marking, event emissions) for no gain.
+    // Identical visible behaviour -- node properties snap to start values.
+    const propsGroup = this.propValuesMap.props;
+    const shaderGroup = this.propValuesMap.shaderProps;
+    if (propsGroup !== null) {
+      this.restoreValues(
+        this.node as unknown as Record<string, number>,
+        propsGroup,
+      );
+    }
+    if (shaderGroup !== null) {
+      this.restoreValues(
+        this.node.shader!.props as Record<string, number>,
+        shaderGroup,
+      );
+    }
   }
 
   private restoreValues(target: Record<string, number>, group: PropGroup) {
@@ -190,19 +208,8 @@ export class CoreAnimation extends EventEmitter {
   }
 
   restore() {
+    // reset() already writes start values back to node properties
     this.reset();
-    if (this.propValuesMap['props'] !== null) {
-      this.restoreValues(
-        this.node as unknown as Record<string, number>,
-        this.propValuesMap['props'],
-      );
-    }
-    if (this.propValuesMap['shaderProps'] !== null) {
-      this.restoreValues(
-        this.node.shader!.props as Record<string, number>,
-        this.propValuesMap['shaderProps'],
-      );
-    }
   }
 
   private reverseValues(group: PropGroup) {

--- a/src/core/animations/CoreAnimation.ts
+++ b/src/core/animations/CoreAnimation.ts
@@ -62,6 +62,9 @@ export class CoreAnimation extends EventEmitter {
   private delay = 0;
   private timingFunction!: TimingFunction;
   private node!: CoreNode;
+  // Index into AnimationManager.activeAnimations -- kept in sync on every
+  // register/swap-remove so unregisterAnimation() is O(1) with no indexOf scan.
+  public activeIndex = -1;
 
   // Persistent PropGroup instances -- reused across pool recycles to avoid
   // allocating new arrays each time. length tracks how many entries are active.
@@ -112,11 +115,11 @@ export class CoreAnimation extends EventEmitter {
     this.id = ++animationIdCounter;
     this.node = node;
     this.progress = 0;
+    this.activeIndex = -1;
     this.propValuesMap.props = null;
     this.propValuesMap.shaderProps = null;
-    // Clear listener arrays in-place (zero alloc) -- keeps arrays alive so
-    // the next registerAnimation() on() calls don't need to allocate new [].
-    this.clearListeners(CoreAnimation.EVENTS);
+    // NOTE: listener arrays are already cleared by releaseToPool() before
+    // this is called. No need to clearListeners() here again.
 
     // Reset persistent group lengths (reuse existing arrays, no new allocations)
     this.propsGroup.length = 0;

--- a/src/core/animations/CoreAnimationController.ts
+++ b/src/core/animations/CoreAnimationController.ts
@@ -38,9 +38,19 @@ export class CoreAnimationController
   private manager!: AnimationManager;
   private animation!: CoreAnimation;
 
+  // Pre-allocated tick payload -- reused every frame to avoid per-frame {} allocation
+  private readonly tickPayload: { progress: number } = { progress: 0 };
+
+  // Fixed set of event names this controller emits -- used for zero-alloc clearListeners()
+  static readonly EVENTS = ['stopped', 'animating'] as const;
+
   constructor() {
     super();
     this.state = 'stopped';
+    // Pre-allocate listener arrays for the known events so on() never needs to
+    // allocate a new [] when the controller is reused after a pool recycle.
+    this.eventListeners['stopped'] = [];
+    this.eventListeners['animating'] = [];
   }
 
   /**
@@ -53,7 +63,8 @@ export class CoreAnimationController
     this.state = 'stopped';
     this.stoppedPromise = null;
     this.stoppedResolve = null;
-    this.removeAllListeners();
+    // Clear in-place to preserve pre-allocated arrays (zero alloc)
+    this.clearListeners(CoreAnimationController.EVENTS);
   }
 
   start(): IAnimationController {
@@ -200,13 +211,13 @@ export class CoreAnimationController
    */
   private onTick = (): void => {
     const listeners = this.eventListeners['tick'];
-    if (listeners === undefined) {
+    if (listeners === undefined || listeners.length === 0) {
       return;
     }
-    listeners.forEach((listener) => {
-      listener(this, {
-        progress: this.animation['progress'],
-      });
-    });
+    // Mutate pre-allocated payload to avoid per-frame {} allocation
+    this.tickPayload.progress = this.animation['progress'];
+    for (let i = listeners.length - 1; i >= 0; i--) {
+      listeners[i]!(this, this.tickPayload);
+    }
   };
 }

--- a/src/core/animations/CoreAnimationController.ts
+++ b/src/core/animations/CoreAnimationController.ts
@@ -63,8 +63,8 @@ export class CoreAnimationController
     this.state = 'stopped';
     this.stoppedPromise = null;
     this.stoppedResolve = null;
-    // Clear in-place to preserve pre-allocated arrays (zero alloc)
-    this.clearListeners(CoreAnimationController.EVENTS);
+    // NOTE: listener arrays are already cleared by releaseToPool() before
+    // this is called. No need to clearListeners() here again.
   }
 
   start(): IAnimationController {

--- a/src/core/animations/CoreAnimationController.ts
+++ b/src/core/animations/CoreAnimationController.ts
@@ -70,18 +70,26 @@ export class CoreAnimationController
       return this;
     }
     this.unregisterAnimation();
+
+    // Capture refs before emit -- the user's stopped callback may synchronously
+    // call createAnimation() which recycles these objects from the pool.
+    // Releasing AFTER emit with captured refs prevents corrupting the recycled objects.
+    const animation = this.animation;
+    const manager = this.manager;
+
     if (this.stoppedResolve !== null) {
       this.stoppedResolve();
       this.stoppedResolve = null;
     }
-    this.emit('stopped', this);
-    if (reset === true) {
-      this.animation.reset();
-    }
 
     this.state = 'stopped';
-    // Release to pool after all user listeners have been notified
-    this.manager.releaseToPool(this.animation, this);
+    this.emit('stopped', this);
+
+    if (reset === true) {
+      animation.reset();
+    }
+
+    manager.releaseToPool(animation, this);
     return this;
   }
 
@@ -136,18 +144,22 @@ export class CoreAnimationController
 
   private onDestroy = (): void => {
     this.unregisterAnimation();
+
+    // Capture refs before emit -- same race condition guard as stop()/onFinished()
+    const animation = this.animation;
+    const manager = this.manager;
+
     if (this.stoppedResolve !== null) {
       this.stoppedResolve();
       this.stoppedResolve = null;
     }
-    this.emit('stopped', this);
+
     this.state = 'stopped';
-    // Release to pool after all user listeners have been notified
-    this.manager.releaseToPool(this.animation, this);
+    this.emit('stopped', this);
+    manager.releaseToPool(animation, this);
   };
 
   private onFinished = (): void => {
-    // If the animation is looping, then we need to restart it.
     const { loop, stopMethod } = this.animation;
 
     if (stopMethod === 'reverse') {
@@ -159,19 +171,22 @@ export class CoreAnimationController
       return;
     }
 
-    // unregister animation
     this.unregisterAnimation();
 
-    // resolve promise
+    // Capture refs before emit -- the user's stopped callback may synchronously
+    // call createAnimation() which recycles these objects from the pool.
+    // Releasing AFTER emit with captured refs prevents corrupting the recycled objects.
+    const animation = this.animation;
+    const manager = this.manager;
+
     if (this.stoppedResolve !== null) {
       this.stoppedResolve();
       this.stoppedResolve = null;
     }
 
-    this.emit('stopped', this);
     this.state = 'stopped';
-    // Release to pool after all user listeners have been notified
-    this.manager.releaseToPool(this.animation, this);
+    this.emit('stopped', this);
+    manager.releaseToPool(animation, this);
   };
 
   private onAnimating = (): void => {

--- a/src/core/animations/CoreAnimationController.ts
+++ b/src/core/animations/CoreAnimationController.ts
@@ -63,8 +63,9 @@ export class CoreAnimationController
     this.state = 'stopped';
     this.stoppedPromise = null;
     this.stoppedResolve = null;
-    // NOTE: listener arrays are already cleared by releaseToPool() before
-    // this is called. No need to clearListeners() here again.
+    // Clear any stale user listeners from the previous use. Near-zero cost
+    // when arrays are already empty (the common case after releaseToPool).
+    this.clearListeners(CoreAnimationController.EVENTS);
   }
 
   start(): IAnimationController {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -90,7 +90,7 @@ const getTimingBezier = (
       // Cubic bezier derivative.
       cbxd = t * (t * (3 * xa) + 2 * xb) + xc;
 
-      if (cbxd > 1e-10 && cbxd < 1e-10) {
+      if (cbxd > -1e-10 && cbxd < 1e-10) {
         // Problematic. Fall back to binary search method.
         break;
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,15 +66,16 @@ export function mergeColorProgress(
   rgba2: number,
   p: number,
 ): number {
-  const r1 = Math.trunc(rgba1 >>> 24);
-  const g1 = Math.trunc((rgba1 >>> 16) & 0xff);
-  const b1 = Math.trunc((rgba1 >>> 8) & 0xff);
-  const a1 = Math.trunc(rgba1 & 0xff);
+  // >>> and & 0xff already produce unsigned integers -- Math.trunc is redundant
+  const r1 = rgba1 >>> 24;
+  const g1 = (rgba1 >>> 16) & 0xff;
+  const b1 = (rgba1 >>> 8) & 0xff;
+  const a1 = rgba1 & 0xff;
 
-  const r2 = Math.trunc(rgba2 >>> 24);
-  const g2 = Math.trunc((rgba2 >>> 16) & 0xff);
-  const b2 = Math.trunc((rgba2 >>> 8) & 0xff);
-  const a2 = Math.trunc(rgba2 & 0xff);
+  const r2 = rgba2 >>> 24;
+  const g2 = (rgba2 >>> 16) & 0xff;
+  const b2 = (rgba2 >>> 8) & 0xff;
+  const a2 = rgba2 & 0xff;
 
   const r = Math.round(r2 * p + r1 * (1 - p));
   const g = Math.round(g2 * p + g1 * (1 - p));


### PR DESCRIPTION
## Summary

Fixes confetti (and other animation-heavy scenarios) stalling after the animation pool and flat-array changes were merged.

## Root Cause

`AnimationManager.update()` iterated `activeAnimations` with a cached length:

```ts
for (let i = 0, len = animations.length; i < len; i++) {
  animations[i]!.update(dt);
}
```

When an animation finishes during iteration, `onFinished()` calls `unregisterAnimation()` which does `splice(index, 1)` on the live array. With the cached `len`, subsequent indices either read `undefined` (crash) or skip animations that shifted down, causing them to never advance and eventually stall.

## Fix

Snapshot the array with `slice()` before iterating, matching the same pattern already used in `EventEmitter.emit()`:

```ts
const snapshot = animations.slice();
for (let i = 0, len = snapshot.length; i < len; i++) {
  snapshot[i]!.update(dt);
}
```

## Testing

- All 444 tests pass
- Build passes, no lint errors