### PR TITLE
Improve canvas text

### DIFF
--- a/src/core/CoreTextNode.ts
+++ b/src/core/CoreTextNode.ts
@@ -295,7 +295,7 @@ export class CoreTextNode extends CoreNode implements CoreTextNodeProps {
 
       this.texture = this.stage.txManager.createTexture('ImageTexture', {
         premultiplyAlpha: true,
-        src: result.imageData as ImageData,
+        src: result.imageData,
       });
 
       this.props.w = width;

--- a/src/core/platforms/Platform.ts
+++ b/src/core/platforms/Platform.ts
@@ -58,7 +58,7 @@ export abstract class Platform {
     };
 
     // If a canvas was provided in the settings, use it. Otherwise, create a new one.
-    this.canvas = settings.canvas || document.createElement('canvas');
+    this.canvas = settings.canvas || this.createCanvas();
   }
 
   /**

--- a/src/core/platforms/Platform.ts
+++ b/src/core/platforms/Platform.ts
@@ -62,7 +62,7 @@ export abstract class Platform {
   }
 
   /**
-   * Creates a new canvas.
+   * Creates a new canvas element.
    * @returns The created HTMLCanvasElement.
    */
   abstract createCanvas(): HTMLCanvasElement;

--- a/src/core/platforms/Platform.ts
+++ b/src/core/platforms/Platform.ts
@@ -58,14 +58,14 @@ export abstract class Platform {
     };
 
     // If a canvas was provided in the settings, use it. Otherwise, create a new one.
-    this.canvas = settings.canvas || this.createCanvas();
+    this.canvas = settings.canvas || document.createElement('canvas');
   }
 
   /**
-   * Creates a new canvas element.
-   * @returns The created HTMLCanvasElement.
+   * Creates a new canvas.
+   * @returns The created HTMLCanvasElement or OffscreenCanvas.
    */
-  abstract createCanvas(): HTMLCanvasElement;
+  abstract createCanvas(): HTMLCanvasElement | OffscreenCanvas;
 
   /**
    * Create new rendering context (only for WebGL, Canvas does not require a context)

--- a/src/core/platforms/Platform.ts
+++ b/src/core/platforms/Platform.ts
@@ -67,7 +67,7 @@ export abstract class Platform {
    */
   abstract createCanvas(): HTMLCanvasElement;
 
-  abstract createOffscreenCanvas(): OffscreenCanvas | HTMLCanvasElement;
+  abstract createOffscreenCanvas(): OffscreenCanvas | null;
 
   /**
    * Create new rendering context (only for WebGL, Canvas does not require a context)

--- a/src/core/platforms/Platform.ts
+++ b/src/core/platforms/Platform.ts
@@ -63,9 +63,11 @@ export abstract class Platform {
 
   /**
    * Creates a new canvas.
-   * @returns The created HTMLCanvasElement or OffscreenCanvas.
+   * @returns The created HTMLCanvasElement.
    */
-  abstract createCanvas(): HTMLCanvasElement | OffscreenCanvas;
+  abstract createCanvas(): HTMLCanvasElement;
+
+  abstract createOffscreenCanvas(): OffscreenCanvas | HTMLCanvasElement;
 
   /**
    * Create new rendering context (only for WebGL, Canvas does not require a context)

--- a/src/core/platforms/web/WebPlatform.ts
+++ b/src/core/platforms/web/WebPlatform.ts
@@ -79,6 +79,10 @@ export class WebPlatform extends Platform {
   ////////////////////////
 
   override createCanvas() {
+    return document.createElement('canvas');
+  }
+
+  override createOffscreenCanvas() {
     if (typeof OffscreenCanvas !== 'undefined') {
       return new OffscreenCanvas(0, 0);
     }

--- a/src/core/platforms/web/WebPlatform.ts
+++ b/src/core/platforms/web/WebPlatform.ts
@@ -83,10 +83,7 @@ export class WebPlatform extends Platform {
   }
 
   override createOffscreenCanvas() {
-    if (typeof OffscreenCanvas !== 'undefined') {
-      return new OffscreenCanvas(0, 0);
-    }
-    return document.createElement('canvas');
+    return new OffscreenCanvas(1, 1);
   }
 
   override createContext(): GlContextWrapper {

--- a/src/core/platforms/web/WebPlatform.ts
+++ b/src/core/platforms/web/WebPlatform.ts
@@ -83,7 +83,10 @@ export class WebPlatform extends Platform {
   }
 
   override createOffscreenCanvas() {
-    return new OffscreenCanvas(1, 1);
+    if (typeof OffscreenCanvas !== 'undefined') {
+      return new OffscreenCanvas(0, 0);
+    }
+    return null;
   }
 
   override createContext(): GlContextWrapper {

--- a/src/core/platforms/web/WebPlatform.ts
+++ b/src/core/platforms/web/WebPlatform.ts
@@ -78,7 +78,10 @@ export class WebPlatform extends Platform {
   // Platform-specific methods
   ////////////////////////
 
-  override createCanvas(): HTMLCanvasElement {
+  override createCanvas() {
+    if (typeof OffscreenCanvas !== 'undefined') {
+      return new OffscreenCanvas(0, 0);
+    }
     return document.createElement('canvas');
   }
 

--- a/src/core/renderers/canvas/CanvasTexture.ts
+++ b/src/core/renderers/canvas/CanvasTexture.ts
@@ -152,8 +152,6 @@ export class CanvasTexture extends CoreContextTexture {
   private async onLoadRequest(
     data: NonNullable<NonNullable<Texture['textureData']>['data']>,
   ): Promise<Dimensions> {
-    // TODO: canvas from text renderer should be able to provide the canvas directly
-    // instead of having to re-draw it into a new canvas...
     if (data instanceof ImageData) {
       const canvas = document.createElement('canvas');
       canvas.width = data.width;
@@ -164,6 +162,8 @@ export class CanvasTexture extends CoreContextTexture {
       return { w: data.width, h: data.height };
     } else if (
       (typeof ImageBitmap !== 'undefined' && data instanceof ImageBitmap) ||
+      (typeof HTMLCanvasElement !== 'undefined' &&
+        data instanceof HTMLCanvasElement) ||
       data instanceof HTMLImageElement
     ) {
       this.image = data;

--- a/src/core/renderers/webgl/WebGlCtxSubTexture.ts
+++ b/src/core/renderers/webgl/WebGlCtxSubTexture.ts
@@ -58,6 +58,7 @@ export class WebGlCtxSubTexture extends WebGlCtxTexture {
       | SubTextureProps
       | CompressedData
       | HTMLImageElement
+      | HTMLCanvasElement
       | null,
   ): Dimensions {
     if (data === null) {

--- a/src/core/renderers/webgl/WebGlCtxTexture.ts
+++ b/src/core/renderers/webgl/WebGlCtxTexture.ts
@@ -194,13 +194,17 @@ export class WebGlCtxTexture extends CoreContextTexture {
     const memoryPadding = 1.1; // Add padding to account for GPU Padding
     const isImageBitmap =
       typeof ImageBitmap !== 'undefined' && tdata instanceof ImageBitmap;
+    const isHTMLCanvas =
+      typeof HTMLCanvasElement !== 'undefined' &&
+      tdata instanceof HTMLCanvasElement;
 
     // If textureData is null, the texture is empty (0, 0) and we don't need to
     // upload any data to the GPU.
     if (
       isImageBitmap ||
+      isHTMLCanvas ||
       tdata instanceof ImageData ||
-      // not using typeof HTMLI mageElement due to web worker
+      // not using typeof HTMLImageElement due to web worker
       isHTMLImageElement(tdata) === true
     ) {
       w = tdata.width;

--- a/src/core/text-rendering/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/CanvasTextRenderer.ts
@@ -65,10 +65,12 @@ const init = (_stage: Stage): void => {
   const dpr = stage.options.devicePhysicalPixelRatio;
 
   // Drawing canvas and context
-  canvas = stage.platform.createCanvas();
+  canvas = stage.platform.createOffscreenCanvas();
   isOffscreen =
     typeof OffscreenCanvas !== 'undefined' && canvas instanceof OffscreenCanvas;
-  context = canvas.getContext('2d');
+  context = canvas.getContext('2d') as
+    | CanvasRenderingContext2D
+    | OffscreenCanvasRenderingContext2D;
   assertTruthy(context, '.getContext(2d) failed');
 
   context.setTransform(dpr, 0, 0, dpr, 0, 0);

--- a/src/core/text-rendering/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/CanvasTextRenderer.ts
@@ -68,6 +68,9 @@ const init = (_stage: Stage): void => {
   canvas = stage.platform.createOffscreenCanvas();
   isOffscreen =
     typeof OffscreenCanvas !== 'undefined' && canvas instanceof OffscreenCanvas;
+  if (canvas === null) {
+    canvas = stage.platform.createCanvas();
+  }
   context = canvas.getContext('2d') as
     | CanvasRenderingContext2D
     | OffscreenCanvasRenderingContext2D;

--- a/src/core/text-rendering/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/CanvasTextRenderer.ts
@@ -66,11 +66,13 @@ const init = (_stage: Stage): void => {
 
   // Drawing canvas and context
   canvas = stage.platform.createOffscreenCanvas();
-  isOffscreen =
-    typeof OffscreenCanvas !== 'undefined' && canvas instanceof OffscreenCanvas;
-  if (canvas === null) {
+  if (canvas !== null) {
+    isOffscreen = true;
+  } else {
+    isOffscreen = false;
     canvas = stage.platform.createCanvas();
   }
+
   context = canvas.getContext('2d') as
     | CanvasRenderingContext2D
     | OffscreenCanvasRenderingContext2D;

--- a/src/core/text-rendering/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/CanvasTextRenderer.ts
@@ -35,11 +35,15 @@ import { normalizeCanvasColor } from '../lib/colorCache.js';
 const type = 'canvas' as const;
 const font: FontHandler = CanvasFontHandler;
 
+let stage: Stage | null = null;
 let canvas: HTMLCanvasElement | OffscreenCanvas | null = null;
 let context:
   | CanvasRenderingContext2D
   | OffscreenCanvasRenderingContext2D
   | null = null;
+
+// Whether the drawing canvas is an OffscreenCanvas (supports transferToImageBitmap)
+let isOffscreen = false;
 
 // Separate canvas and context for text measurements
 let measureCanvas: HTMLCanvasElement | OffscreenCanvas | null = null;
@@ -56,26 +60,25 @@ const renderInfoCache = new Map<string, CanvasRenderInfo>();
 const _richTextResult = new ParseResult();
 
 // Initialize the Text Renderer
-const init = (stage: Stage): void => {
+const init = (_stage: Stage): void => {
+  stage = _stage;
   const dpr = stage.options.devicePhysicalPixelRatio;
 
   // Drawing canvas and context
-  canvas = stage.platform.createCanvas() as HTMLCanvasElement | OffscreenCanvas;
-  context = canvas.getContext('2d', { willReadFrequently: true }) as
-    | CanvasRenderingContext2D
-    | OffscreenCanvasRenderingContext2D;
+  canvas = stage.platform.createCanvas();
+  isOffscreen =
+    typeof OffscreenCanvas !== 'undefined' && canvas instanceof OffscreenCanvas;
+  context = canvas.getContext('2d');
+  assertTruthy(context, '.getContext(2d) failed');
 
   context.setTransform(dpr, 0, 0, dpr, 0, 0);
   context.textRendering = 'optimizeSpeed';
 
   // Separate measuring canvas and context
-  measureCanvas = stage.platform.createCanvas() as
-    | HTMLCanvasElement
-    | OffscreenCanvas;
-  measureContext = measureCanvas.getContext('2d') as
-    | CanvasRenderingContext2D
-    | OffscreenCanvasRenderingContext2D;
-
+  measureCanvas = stage.platform.createCanvas();
+  assertTruthy(measureCanvas, 'createCanvas returned null');
+  measureContext = measureCanvas.getContext('2d');
+  assertTruthy(measureContext, '.getContext(2d) failed');
   measureContext.setTransform(dpr, 0, 0, dpr, 0, 0);
   measureContext.textRendering = 'optimizeSpeed';
 
@@ -165,8 +168,21 @@ const renderText = (props: CoreTextNodeProps): TextRenderInfo => {
   const canvasW = Math.ceil(effectiveWidth);
   const canvasH = Math.ceil(effectiveHeight);
 
-  canvas.width = canvasW;
-  canvas.height = canvasH;
+  // For OffscreenCanvas we reuse the shared canvas and snapshot via
+  // transferToImageBitmap at the end. For HTMLCanvasElement we allocate a
+  // fresh canvas per text node so it can be passed directly as the texture
+  // source — no pixel readback or intermediate copy needed.
+  let drawCanvas: HTMLCanvasElement | OffscreenCanvas;
+  if (isOffscreen) {
+    drawCanvas = canvas;
+  } else {
+    assertTruthy(stage, 'Stage is not available');
+    drawCanvas = stage.platform.createCanvas();
+    context = drawCanvas.getContext('2d') as CanvasRenderingContext2D;
+  }
+
+  drawCanvas.width = canvasW;
+  drawCanvas.height = canvasH;
   context.fillStyle = 'white';
   context.font = baseFont;
   context.textBaseline = 'hanging';
@@ -357,10 +373,26 @@ const renderText = (props: CoreTextNodeProps): TextRenderInfo => {
     }
   }
 
-  // Extract image data
-  let imageData: ImageData | null = null;
-  if (canvas.width > 0 && canvas.height > 0) {
-    imageData = context.getImageData(0, 0, canvasW, canvasH);
+  // Capture the rendered text as a texture source.
+  // OffscreenCanvas: transferToImageBitmap detaches the backing bitmap
+  //   synchronously (zero-copy). The shared canvas gets a fresh empty bitmap.
+  // HTMLCanvasElement: drawCanvas was allocated specifically for this text
+  //   node, so it can be passed directly — no copy needed.
+  let imageData: ImageBitmap | HTMLCanvasElement | null = null;
+  if (drawCanvas.width > 0 && drawCanvas.height > 0) {
+    if (isOffscreen) {
+      assertTruthy(
+        drawCanvas instanceof OffscreenCanvas,
+        'drawCanvas is not an OffscreenCanvas',
+      );
+      imageData = drawCanvas.transferToImageBitmap();
+    } else {
+      assertTruthy(
+        drawCanvas instanceof HTMLCanvasElement,
+        'drawCanvas is not an HTMLCanvasElement',
+      );
+      imageData = drawCanvas;
+    }
   }
   const renderInfo = {
     type,

--- a/src/core/text-rendering/TextRenderer.ts
+++ b/src/core/text-rendering/TextRenderer.ts
@@ -447,7 +447,7 @@ export type SdfRenderInfo = RenderInfo & {
 
 export type CanvasRenderInfo = RenderInfo & {
   type: 'canvas';
-  imageData: ImageData;
+  imageData: ImageBitmap | HTMLCanvasElement;
 };
 
 export type TextRenderInfo = SdfRenderInfo | CanvasRenderInfo;

--- a/src/core/textures/ImageTexture.ts
+++ b/src/core/textures/ImageTexture.ts
@@ -27,15 +27,21 @@ import type { CompressedImageData } from '../platforms/web/lib/textureCompressio
  */
 export interface ImageTextureProps {
   /**
-   * Source URL or ImageData for the image to be used as a texture.
+   * Source URL or image source for the image to be used as a texture.
    *
    * @remarks
-   * The ImageData type is currently only supported internally. End users should
-   * only set this property to a URL string.
+   * The ImageData, ImageBitmap, and HTMLCanvasElement types are currently only
+   * supported internally. End users should only set this property to a URL string.
    *
    * @default ''
    */
-  src?: string | Blob | ImageData | (() => ImageData | null);
+  src?:
+    | string
+    | Blob
+    | ImageData
+    | ImageBitmap
+    | HTMLCanvasElement
+    | (() => ImageData | ImageBitmap | HTMLCanvasElement | null);
   /**
    * Whether to premultiply the alpha channel into the color channels of the
    * image.
@@ -218,14 +224,9 @@ export class ImageTexture extends Texture {
         return platform.createImage(src, premultiply, sx, sy, sw, sh);
       }
 
-      if (src instanceof ImageData) {
-        return {
-          data: src,
-          premultiplyAlpha,
-        };
-      }
+      // ImageData, ImageBitmap, or HTMLCanvasElement
       return {
-        data: src(),
+        data: typeof src === 'function' ? src() : src,
         premultiplyAlpha,
       };
     }

--- a/src/core/textures/Texture.ts
+++ b/src/core/textures/Texture.ts
@@ -102,6 +102,7 @@ export interface TextureData {
   data:
     | ImageBitmap
     | ImageData
+    | HTMLCanvasElement
     | SubTextureProps
     | CompressedData
     | HTMLImageElement


### PR DESCRIPTION
This pull request refactors the text rendering pipeline to improve performance and flexibility by allowing the use of `ImageBitmap` and `HTMLCanvasElement` as texture sources, in addition to `ImageData`. The changes optimize how text is rendered and transferred to GPU textures, reduce unnecessary pixel readbacks and copies, and add support for offscreen and onscreen canvas workflows. The most important changes are grouped below:

### Text rendering pipeline improvements

* The text renderer now uses `ImageBitmap` (for `OffscreenCanvas`) or a dedicated `HTMLCanvasElement` (for onscreen rendering) as the texture source, instead of always using `ImageData`. This enables zero-copy transfers to the GPU and avoids unnecessary pixel readbacks. (`src/core/text-rendering/CanvasTextRenderer.ts`, `src/core/text-rendering/TextRenderer.ts`) [[1]](diffhunk://#diff-c081f16bdf2e2f0533b14c35c16be687b481721ec1466f82ba3d51dec7a32a6aL168-R187) [[2]](diffhunk://#diff-c081f16bdf2e2f0533b14c35c16be687b481721ec1466f82ba3d51dec7a32a6aL360-R397) [[3]](diffhunk://#diff-5acc33a0a74e36d288fe276a50b4000ed7676771e37ce6b06a2527dc297ec158L450-R450)
* The renderer distinguishes between offscreen and onscreen canvases, using `transferToImageBitmap()` for `OffscreenCanvas` and allocating a new `HTMLCanvasElement` per text node otherwise. (`src/core/text-rendering/CanvasTextRenderer.ts`) [[1]](diffhunk://#diff-c081f16bdf2e2f0533b14c35c16be687b481721ec1466f82ba3d51dec7a32a6aL59-R83) [[2]](diffhunk://#diff-c081f16bdf2e2f0533b14c35c16be687b481721ec1466f82ba3d51dec7a32a6aL168-R187) [[3]](diffhunk://#diff-c081f16bdf2e2f0533b14c35c16be687b481721ec1466f82ba3d51dec7a32a6aL360-R397)

### Texture and image source handling

* The `ImageTexture` and `TextureData` types now support `ImageBitmap` and `HTMLCanvasElement` as valid texture sources, in addition to `ImageData`. (`src/core/textures/ImageTexture.ts`, `src/core/textures/Texture.ts`) [[1]](diffhunk://#diff-ca3674570d5d7438de002ad1563c6b4e924359ad05d340266bece8998c419bb8L30-R44) [[2]](diffhunk://#diff-ca3674570d5d7438de002ad1563c6b4e924359ad05d340266bece8998c419bb8L221-R229) [[3]](diffhunk://#diff-f9f430d688c53da97e951f0777acff38cac17f20b9d16a51cff3b4fe6c150407R105)
* The texture uploaders in both Canvas and WebGL renderers are updated to handle `HTMLCanvasElement` as a valid image source for textures. (`src/core/renderers/canvas/CanvasTexture.ts`, `src/core/renderers/webgl/WebGlCtxTexture.ts`, `src/core/renderers/webgl/WebGlCtxSubTexture.ts`) [[1]](diffhunk://#diff-0701268aba888a04cf48be075e508ab00e3f1bb538ec30ec4b21dc414dd18125R165-R166) [[2]](diffhunk://#diff-79ce09430b3b74dbd944984ac0c0e6ec07f382d66cedeefe1dc6b7f372551414R197-R205) [[3]](diffhunk://#diff-5f43f34171d4cafd6050e1c3f347a608a12316de281cca4a0b2e0cab5cf9ab50R61)

### Platform and canvas management

* The platform abstraction is updated to provide both `createCanvas()` (for onscreen) and `createOffscreenCanvas()` (for offscreen or worker rendering), and the web platform implements both methods. The renderer now uses these appropriately. (`src/core/platforms/Platform.ts`, `src/core/platforms/web/WebPlatform.ts`) [[1]](diffhunk://#diff-7f1d80e83b4cfb7db74e0396c035ed77809d98b36d9a9cd7247c446e73d7e39fL61-R71) [[2]](diffhunk://#diff-efb9f24aad4373adaadb4d80c4b24b10bfef3b7a5bd5f1bfe2fa29bf72d7fa11L81-R88)

These changes collectively make the text rendering pipeline more efficient, flexible, and compatible with modern browser features.