### PR TITLE
Handle possibly undefined letter spacing

### DIFF
--- a/src/core/text-rendering/CanvasFontHandler.ts
+++ b/src/core/text-rendering/CanvasFontHandler.ts
@@ -225,7 +225,7 @@ export const processFontMetrics = (
 
 export const measureText = (
   text: string,
-  fontFamily: string,
+  _fontFamily: string, // Unused, but necessary to match SdfFontHandler's signature
   letterSpacing: number,
 ) => {
   if (letterSpacing === 0) {

--- a/src/core/text-rendering/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/CanvasTextRenderer.ts
@@ -147,7 +147,7 @@ const renderText = (props: CoreTextNodeProps): TextRenderInfo => {
 
   const metrics = CanvasFontHandler.getFontMetrics(fontFamily, fontSize);
 
-  const letterSpacing = props.letterSpacing;
+  const letterSpacing = props.letterSpacing || 0;
 
   const [
     lines,

--- a/src/core/text-rendering/SdfTextRenderer.ts
+++ b/src/core/text-rendering/SdfTextRenderer.ts
@@ -252,7 +252,7 @@ const generateTextLayout = (
     lines,
     remainingLines,
     hasRemainingText,
-    bareLineHeight,
+    _bareLineHeight,
     lineHeightPx,
     effectiveWidth,
     effectiveHeight,
@@ -270,9 +270,6 @@ const generateTextLayout = (
     maxWidth,
     maxHeight,
   );
-
-  // Suppress unused-variable warning for bareLineHeight (consumed by mapTextLayout tuple).
-  void bareLineHeight;
 
   // --- Pre-compute decoration offsets in design-unit space ---
   // commonFontData.base is the BMFont "base" value: the y-distance from the top of the


### PR DESCRIPTION
We have some code that is doing:
```ts
textElement.letterSpacing = config.letterSpacing;
```
where `config.letterSpacing` can be `undefined`.

Now, I know, we need to fix this on our side and do something like:
```ts
textElement.letterSpacing = config.letterSpacing || 0;
```
And we've already done this.

However, this works in L2, so I thought we might as well make the L3 text layout engine a little more robust and handle it as well.