### PR TITLE
fix(inspector): release node teardown state that actually leaks

### DIFF
--- a/src/main-api/Inspector.test.ts
+++ b/src/main-api/Inspector.test.ts
@@ -1,0 +1,184 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @vitest-environment happy-dom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Inspector } from './Inspector.js';
+import type { CoreNode, CoreNodeAnimateProps } from '../core/CoreNode.js';
+import type { RendererMainSettings } from './Renderer.js';
+import type { IAnimationController } from '../common/IAnimationController.js';
+import type { AnimationSettings } from '../core/animations/CoreAnimation.js';
+
+// Mock isProductionEnvironment so the Inspector actually initializes
+vi.mock('../utils.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import('../utils.js');
+  return {
+    ...actual,
+    isProductionEnvironment: false,
+  };
+});
+
+/**
+ * Stand-in for CoreNode.
+ *
+ * The properties the inspector traps have to live on the prototype, the same
+ * way they do on a real CoreNode - the trap forwards reads to the original
+ * descriptor's getter, so an own data property would read back as undefined.
+ */
+class FakeNode {
+  readonly children: FakeNode[] = [];
+  props: Record<string, unknown> = {};
+  destroyed = false;
+  on = vi.fn();
+  off = vi.fn();
+
+  constructor(private readonly _id: number) {}
+
+  get id(): number {
+    return this._id;
+  }
+
+  /** Mirrors CoreNode.destroy(): kills children first, top down. */
+  destroy(): void {
+    while (this.children.length > 0) {
+      const child = this.children.shift() as FakeNode;
+      child.destroy();
+    }
+    this.destroyed = true;
+  }
+
+  animate(
+    _props: CoreNodeAnimateProps,
+    _settings: AnimationSettings,
+  ): IAnimationController {
+    return makeController();
+  }
+}
+
+function makeController(): IAnimationController {
+  return {
+    start: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+    pause: vi.fn().mockReturnThis(),
+    restore: vi.fn().mockReturnThis(),
+    waitUntilStopped: vi.fn().mockResolvedValue(undefined),
+    state: 'scheduled',
+    on: vi.fn(),
+    off: vi.fn(),
+    once: vi.fn(),
+    emit: vi.fn(),
+  } as unknown as IAnimationController;
+}
+
+function makeSettings(
+  inspectorOptions?: Partial<RendererMainSettings['inspectorOptions']>,
+): RendererMainSettings {
+  return {
+    appWidth: 1920,
+    appHeight: 1080,
+    deviceLogicalPixelRatio: 1,
+    inspectorOptions,
+  } as unknown as RendererMainSettings;
+}
+
+/** The inspector mirrors each node onto a div hung off `node.div`. */
+function divOf(node: FakeNode): HTMLElement {
+  return (node as unknown as { div: HTMLElement }).div;
+}
+
+describe('Inspector node teardown', () => {
+  let canvas: HTMLCanvasElement;
+  let inspector: Inspector;
+
+  beforeEach(() => {
+    if (!globalThis.ResizeObserver) {
+      globalThis.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      } as unknown as typeof ResizeObserver;
+    }
+    Inspector.clearAnimationStats();
+    canvas = document.createElement('canvas');
+    document.body.appendChild(canvas);
+  });
+
+  afterEach(() => {
+    inspector?.destroy();
+    canvas.remove();
+    Inspector.clearAnimationStats();
+  });
+
+  it('removes descendant divs when a subtree is destroyed', () => {
+    inspector = new Inspector(canvas, makeSettings());
+
+    const parent = new FakeNode(1);
+    const child = new FakeNode(2);
+    parent.children.push(child);
+
+    inspector.createNode(parent as unknown as CoreNode);
+    inspector.createNode(child as unknown as CoreNode);
+
+    const parentDiv = divOf(parent);
+    const childDiv = divOf(child);
+
+    // Mirror the DOM nesting the inspector builds via the `parent` setter
+    document.body.appendChild(parentDiv);
+    parentDiv.appendChild(childDiv);
+
+    parent.destroy();
+
+    expect(child.destroyed).toBe(true);
+    // The parent div is detached first, so a lookup by id can no longer find
+    // the child - it has to be removed through its own reference.
+    expect(childDiv.parentNode).toBeNull();
+    expect(parentDiv.parentNode).toBeNull();
+    expect(parentDiv.contains(childDiv)).toBe(false);
+  });
+
+  it('drops active animations belonging to a destroyed node', () => {
+    inspector = new Inspector(
+      canvas,
+      makeSettings({ enableAnimationMonitoring: true }),
+    );
+
+    const node = new FakeNode(3);
+    inspector.createNode(node as unknown as CoreNode);
+    document.body.appendChild(divOf(node));
+
+    const controller = node.animate(
+      { x: 100 } as unknown as CoreNodeAnimateProps,
+      { duration: 10_000 } as AnimationSettings,
+    );
+    controller.start();
+
+    expect(
+      Inspector.getActiveAnimations().filter((a) => a.nodeId === 3),
+    ).toHaveLength(1);
+
+    node.destroy();
+
+    expect(
+      Inspector.getActiveAnimations().filter((a) => a.nodeId === 3),
+    ).toHaveLength(0);
+    // The animation is moved to history rather than silently dropped
+    expect(Inspector.getAnimationStats().totalAnimations).toBe(1);
+  });
+});

--- a/src/main-api/Inspector.test.ts
+++ b/src/main-api/Inspector.test.ts
@@ -1,22 +1,3 @@
-/*
- * If not stated otherwise in this file or this component's LICENSE file the
- * following copyright and licenses apply:
- *
- * Copyright 2023 Comcast Cable Communications Management, LLC.
- *
- * Licensed under the Apache License, Version 2.0 (the License);
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // @vitest-environment happy-dom
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';

--- a/src/main-api/Inspector.ts
+++ b/src/main-api/Inspector.ts
@@ -243,7 +243,10 @@ export class Inspector {
   private width = 1920;
   private scaleX = 1;
   private scaleY = 1;
-  private textureMetrics = new Map<Texture, TextureMetrics>();
+  // Keyed weakly: a texture that is swapped off a node is never revisited by
+  // the inspector, and a strong map would pin it (and its bitmap) for the
+  // lifetime of the renderer.
+  private textureMetrics = new WeakMap<Texture, TextureMetrics>();
 
   // Performance monitoring for frequent setter calls
   private static setterCallCount = new Map<
@@ -962,7 +965,20 @@ export class Inspector {
         });
         coreNodeListeners.clear();
 
-        this.destroyNode(node.id);
+        // Animations that are still running when the node goes away never emit
+        // `stopped`, so their entries - and the controllers they hold - would
+        // stay in the static activeAnimations map forever.
+        Inspector.activeAnimations.forEach((animation, animationId) => {
+          if (animation.nodeId === node.id) {
+            this.trackAnimationEnd(animationId, 'cancelled');
+          }
+        });
+
+        // Remove the div through the direct reference rather than by id:
+        // destroy() is recursive and the parent div is detached first, so
+        // getElementById() no longer finds any of the descendants.
+        div.parentNode?.removeChild(div);
+
         originalDestroy.call(node);
       },
       configurable: true,
@@ -1114,7 +1130,9 @@ export class Inspector {
         if (value.id === value.stage.root.id) {
           this.root.appendChild(div);
         } else {
-          value.div.appendChild(div);
+          // A parent that was never passed through the inspector has no div;
+          // skip rather than throwing out of an app-level property assignment.
+          value.div?.appendChild(div);
         }
       } else {
         div.parentNode?.removeChild(div);


### PR DESCRIPTION
Alternative to #846, which is chasing the same class of bug in `Inspector.ts`. Same goal, narrower diff, with tests that fail without the fix.

## What leaks

All three are only reachable with the inspector enabled.

**1. `activeAnimations` never releases animations killed by destroy.** `Inspector.activeAnimations` is a `static` Map holding the `IAnimationController`. Entries are only removed by `trackAnimationEnd`, which runs on `stop`/`restore`/`waitUntilStopped` or the controller's `stopped` event. A node destroyed mid-animation fires none of those, so the entry and the controller it holds are retained by a static root for the lifetime of the page.

Destroy now ends those animations as `cancelled` rather than deleting them outright, so `getAnimationStats()` / `animationHistory` stay consistent — `restore()` already records `cancelled` for the same situation.

**2. Descendant divs survive a recursive destroy.** `CoreNode.destroy()` detaches the parent before recursing into children, so by the time each child's trap runs, `document.getElementById(childId)` returns `null` and the child div is left attached to the detached subtree. Fixed by removing the div through the reference the trap already closes over.

**3. `textureMetrics` pinned every texture ever used.** It was a strong `Map<Texture, TextureMetrics>` on an object that lives as long as the renderer. `setupTextureListeners` detaches the old texture's listeners on every swap but never dropped its metrics entry, and destroy only cleaned the texture a node happened to hold at that moment. Every texture ever swapped off a node stayed reachable, bitmap included. Now a `WeakMap` — nothing iterates it, so the API is unchanged.

## Also

`updateNodeProperty`'s `parent` branch did `value.div.appendChild(div)` unguarded. A parent that never went through the inspector (or is already torn down) has no `div`, and throwing out of an app-level property assignment is the worst possible failure mode for a debug-only tool. Now `value.div?.`.

## What this deliberately does not do

#846 also nulls `node.div` / `div.node` and `delete`s all the `defineProperty` traps to "release closures". Those are cycles *within* the node/div group — V8 is a tracing collector and reclaims unreachable cycles, so neither step changes what gets collected. Nulling `node.div` does help in one case (app code leaks the `CoreNode`, so the div subtree goes with it), but that's defense against a leak elsewhere, and it introduces the `value.div` crash above. Left out to keep the diff to things with a demonstrable retainer path.

## Tests

New `src/main-api/Inspector.test.ts` (happy-dom, follows the mocking pattern in `Renderer.test.ts`). Both cases fail on `main` and pass here:

- `removes descendant divs when a subtree is destroyed` → `expected <div><div></div></div> to be null`
- `drops active animations belonging to a destroyed node` → `expected [ { nodeId: 3, … } ] to have a length of +0 but got 1`

`pnpm test` is green (227 tests), `tsc --noEmit` clean, no new eslint warnings. Prettier reports the file as unformatted both before and after — that's a pre-existing block at `createProxy`, left alone to keep the diff readable.

## Known leaks not addressed here

- `Inspector.setterCallCount` — static, keyed `${nodeId}_${setter}`, never pruned. Grows with node churn when `enablePerformanceMonitoring` is on. Pruning per-destroy would mean an O(n) scan on every teardown, so it needs an index or a periodic sweep rather than a one-liner.
- `wrapAnimationController` registers `controller.on('animating'|'stopped')` listeners that are never removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
