### PR TITLE
perf: animation-aware texture processing with unified ref counter

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -250,6 +250,39 @@ function flush() {
 }
 ```
 
+### Animation-Aware Texture Processing
+
+The renderer uses a global `activeAnimationCount` on `Stage` to throttle texture uploads during animations. When the count is above zero, only one texture is uploaded per frame to preserve the frame budget. When zero, the full time budget is used.
+
+Both internal and external animations share the same counter:
+
+- **Internal**: `AnimationManager.registerAnimation()` / `unregisterAnimation()` increment/decrement the counter automatically when animations are created/stopped via `node.animate()`.
+- **External**: External animation libraries (AnimeJS, GSAP, custom tween loops) call `renderer.registerAnimation()` / `renderer.unregisterAnimation()` to participate in the same mechanism.
+
+```typescript
+// AnimeJS example — single animation
+anime({
+  targets: myProps,
+  x: 500,
+  duration: 1000,
+  begin: () => renderer.registerAnimation(),
+  complete: () => renderer.unregisterAnimation(),
+  update: () => {
+    node.x = myProps.x;
+  },
+});
+
+// AnimeJS example — timeline (one ref-count for the whole sequence)
+const tl = anime.timeline({
+  begin: () => renderer.registerAnimation(),
+  complete: () => renderer.unregisterAnimation(),
+});
+tl.add({ targets: myProps, x: 100, duration: 500 });
+tl.add({ targets: myProps, y: 200, duration: 500 });
+```
+
+Every `registerAnimation()` call must have a matching `unregisterAnimation()` call. Concurrent animations naturally overlap — the count stays above zero until the last one completes.
+
 ## Code Patterns
 
 ### Class-Based Pattern

--- a/src/core/CoreTextureManager.ts
+++ b/src/core/CoreTextureManager.ts
@@ -384,14 +384,20 @@ export class CoreTextureManager extends EventEmitter {
    * Process a limited number of uploads.
    *
    * @param maxProcessingTime - The maximum processing time in milliseconds
+   * @param maxCount - The maximum number of textures to process in this call
    */
-  async processSome(maxProcessingTime: number): Promise<void> {
+  async processSome(
+    maxProcessingTime: number,
+    maxCount: number,
+  ): Promise<void> {
     const platform = this.platform;
     const startTime = platform.getTimeStamp();
+    let count = 0;
 
     // Process uploads - await each upload to prevent GPU overload
     while (
       this.uploadTextureQueue.size > 0 &&
+      count < maxCount &&
       platform.getTimeStamp() - startTime < maxProcessingTime
     ) {
       const texture = this.uploadTextureQueue.dequeue();
@@ -402,6 +408,7 @@ export class CoreTextureManager extends EventEmitter {
         console.error('Failed to upload texture:', error);
         // Continue with next texture instead of stopping entire queue
       }
+      count++;
     }
   }
 

--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -112,6 +112,21 @@ export class Stage {
   public preloadBound: Bound;
   public readonly defaultTexture: Texture | null = null;
   public pixelRatio: number;
+
+  /**
+   * Global count of active animations (internal + external).
+   *
+   * @remarks
+   * Incremented by AnimationManager when an internal animation starts,
+   * decremented when it stops. External animation libraries (e.g. AnimeJS,
+   * GSAP) increment/decrement this counter via
+   * {@link RendererMain.registerAnimation} / {@link RendererMain.unregisterAnimation}.
+   *
+   * Used by the render loop to throttle texture uploads during animations:
+   * when > 0, only one texture is uploaded per frame to preserve the frame
+   * budget.
+   */
+  public activeAnimationCount = 0;
   // Pre-allocated frameTick payload -- reused every frame to avoid per-frame {} allocation
   private readonly frameTickPayload: { time: number; delta: number } = {
     time: 0,
@@ -208,7 +223,7 @@ export class Stage {
 
     this.txMemManager = new TextureMemoryManager(this, textureMemory);
 
-    this.animationManager = new AnimationManager();
+    this.animationManager = new AnimationManager(this);
     this.contextSpy = enableContextSpy ? new ContextSpy() : null;
 
     // Set initial frame buckets and FPS update interval for FPS tracking
@@ -485,11 +500,13 @@ export class Stage {
       root.update(this.deltaTime, root.clippingRect);
     }
 
-    // Process some textures asynchronously but don't block the frame
-    // Use a background task to prevent frame drops
+    // Process some textures asynchronously but don't block the frame.
+    // During active animations, limit to 1 texture per frame to preserve
+    // the frame budget. When idle, use the full time budget.
     if (this.txManager.hasUpdates() === true) {
+      const maxCount = this.activeAnimationCount > 0 ? 1 : 0x7fffffff;
       this.txManager
-        .processSome(this.options.textureProcessingTimeLimit)
+        .processSome(this.options.textureProcessingTimeLimit, maxCount)
         .catch((err) => {
           console.error('Error processing textures:', err);
         });

--- a/src/core/animations/AnimationManager.test.ts
+++ b/src/core/animations/AnimationManager.test.ts
@@ -21,6 +21,14 @@ import { describe, expect, it, vi } from 'vitest';
 import { AnimationManager } from './AnimationManager.js';
 import type { CoreNode } from '../CoreNode.js';
 import type { IAnimationController } from '../../common/IAnimationController.js';
+import type { Stage } from '../Stage.js';
+
+/**
+ * Create a minimal mock stage that satisfies AnimationManager's needs.
+ */
+function createMockStage(): Stage {
+  return { activeAnimationCount: 0 } as unknown as Stage;
+}
 
 /**
  * Create a minimal mock node that satisfies CoreAnimation's needs.
@@ -45,7 +53,7 @@ function createMockNode(overrides: Record<string, unknown> = {}): CoreNode {
 describe('AnimationManager', () => {
   describe('object pooling', () => {
     it('should create fresh objects when pool is empty', () => {
-      const manager = new AnimationManager();
+      const manager = new AnimationManager(createMockStage());
       const node = createMockNode();
 
       const controller1 = manager.createAnimation(
@@ -64,7 +72,7 @@ describe('AnimationManager', () => {
     });
 
     it('should reuse objects from the pool after stop()', () => {
-      const manager = new AnimationManager();
+      const manager = new AnimationManager(createMockStage());
       const node = createMockNode();
 
       // Create and start an animation
@@ -91,7 +99,7 @@ describe('AnimationManager', () => {
     });
 
     it('should properly reinitialize recycled objects', () => {
-      const manager = new AnimationManager();
+      const manager = new AnimationManager(createMockStage());
       const node = createMockNode();
 
       // Create, start, and stop
@@ -119,7 +127,7 @@ describe('AnimationManager', () => {
     });
 
     it('should clear event listeners on recycled objects', () => {
-      const manager = new AnimationManager();
+      const manager = new AnimationManager(createMockStage());
       const node = createMockNode();
 
       // Create and add a user listener
@@ -155,7 +163,7 @@ describe('AnimationManager', () => {
     });
 
     it('should release to pool on natural animation finish', () => {
-      const manager = new AnimationManager();
+      const manager = new AnimationManager(createMockStage());
       const node = createMockNode();
 
       const controller = manager.createAnimation(
@@ -179,7 +187,7 @@ describe('AnimationManager', () => {
     });
 
     it('should release to pool on node destruction', () => {
-      const manager = new AnimationManager();
+      const manager = new AnimationManager(createMockStage());
       const node = createMockNode();
 
       const controller = manager.createAnimation(
@@ -204,7 +212,7 @@ describe('AnimationManager', () => {
     });
 
     it('should NOT release looping animations to pool on finish', () => {
-      const manager = new AnimationManager();
+      const manager = new AnimationManager(createMockStage());
       const node = createMockNode();
 
       const controller = manager.createAnimation(
@@ -228,7 +236,7 @@ describe('AnimationManager', () => {
     });
 
     it('should handle multiple pool cycles', () => {
-      const manager = new AnimationManager();
+      const manager = new AnimationManager(createMockStage());
       const node = createMockNode();
 
       // Cycle 1
@@ -252,7 +260,7 @@ describe('AnimationManager', () => {
     });
 
     it('should grow pool independently for concurrent animations', () => {
-      const manager = new AnimationManager();
+      const manager = new AnimationManager(createMockStage());
       const node = createMockNode();
 
       // Create 3 concurrent animations

--- a/src/core/animations/AnimationManager.ts
+++ b/src/core/animations/AnimationManager.ts
@@ -21,9 +21,11 @@ import type { CoreNode, CoreNodeAnimateProps } from '../CoreNode.js';
 import { CoreAnimation, type AnimationSettings } from './CoreAnimation.js';
 import { CoreAnimationController } from './CoreAnimationController.js';
 import type { IAnimationController } from '../../common/IAnimationController.js';
+import type { Stage } from '../Stage.js';
 
 export class AnimationManager {
   private activeAnimations: CoreAnimation[] = [];
+  private stage: Stage;
 
   /**
    * Pool of reusable CoreAnimation instances.
@@ -37,9 +39,14 @@ export class AnimationManager {
    */
   private controllerPool: CoreAnimationController[] = [];
 
+  constructor(stage: Stage) {
+    this.stage = stage;
+  }
+
   registerAnimation(animation: CoreAnimation) {
     animation.activeIndex = this.activeAnimations.length;
     this.activeAnimations.push(animation);
+    this.stage.activeAnimationCount++;
   }
 
   unregisterAnimation(animation: CoreAnimation) {
@@ -57,6 +64,7 @@ export class AnimationManager {
     }
     animations.pop();
     animation.activeIndex = -1;
+    this.stage.activeAnimationCount--;
   }
 
   update(dt: number) {

--- a/src/main-api/Renderer.ts
+++ b/src/main-api/Renderer.ts
@@ -1010,6 +1010,65 @@ export class RendererMain extends EventEmitter {
   }
 
   /**
+   * Register an active animation with the renderer.
+   *
+   * @remarks
+   * This increments a global animation counter shared by both the internal
+   * animation engine and external animation libraries. While the counter is
+   * above zero, the renderer throttles texture uploads to one per frame to
+   * preserve the frame budget.
+   *
+   * Call {@link unregisterAnimation} when the animation completes, is
+   * cancelled, or is otherwise no longer driving per-frame updates.
+   *
+   * The renderer's own {@link INode.animate} method handles this
+   * automatically. This API is intended for external animation libraries
+   * such as AnimeJS, GSAP, or custom tween loops.
+   *
+   * @example
+   * ```typescript
+   * // AnimeJS integration
+   * import anime from 'animejs';
+   *
+   * anime({
+   *   targets: myProps,
+   *   x: 500,
+   *   duration: 1000,
+   *   begin: () => renderer.registerAnimation(),
+   *   complete: () => renderer.unregisterAnimation(),
+   *   update: () => { node.x = myProps.x; },
+   * });
+   *
+   * // For AnimeJS timelines, use timeline-level hooks:
+   * const tl = anime.timeline({
+   *   begin: () => renderer.registerAnimation(),
+   *   complete: () => renderer.unregisterAnimation(),
+   * });
+   * tl.add({ targets: node, x: 100, duration: 500 });
+   * tl.add({ targets: node, y: 200, duration: 500 });
+   * ```
+   */
+  registerAnimation(): void {
+    this.stage.activeAnimationCount++;
+  }
+
+  /**
+   * Unregister a previously registered animation.
+   *
+   * @remarks
+   * Decrements the global animation counter. When the counter reaches zero,
+   * the renderer resumes full-budget texture processing.
+   *
+   * Must be called exactly once for each corresponding
+   * {@link registerAnimation} call.
+   */
+  unregisterAnimation(): void {
+    if (this.stage.activeAnimationCount > 0) {
+      this.stage.activeAnimationCount--;
+    }
+  }
+
+  /**
    * Close and destroy the renderer, releasing all resources.
    *
    * @remarks


### PR DESCRIPTION
## Summary

Introduces a unified animation reference counter that throttles texture uploads during animations to preserve the frame budget on embedded devices.

### Architecture

A single `activeAnimationCount` integer on `Stage` is the source of truth for "are animations running". Both internal and external animations share the same counter:

- **Internal**: `AnimationManager.registerAnimation()` / `unregisterAnimation()` automatically increment/decrement the counter when animations start/stop via `node.animate()`.
- **External**: Animation libraries (AnimeJS, GSAP, custom tween loops) call `renderer.registerAnimation()` / `renderer.unregisterAnimation()` to participate in the same mechanism.

### Behaviour

- When `activeAnimationCount > 0`: only **1 texture** is uploaded per frame (preserves the 16.6ms frame budget)
- When `activeAnimationCount === 0`: full time budget is used for texture uploads (fast loading when idle)

### External library integration

```typescript
// AnimeJS — single animation
anime({
  targets: myProps,
  x: 500,
  duration: 1000,
  begin: () => renderer.registerAnimation(),
  complete: () => renderer.unregisterAnimation(),
  update: () => { node.x = myProps.x; },
});

// AnimeJS — timeline (one ref-count for the whole sequence)
const tl = anime.timeline({
  begin: () => renderer.registerAnimation(),
  complete: () => renderer.unregisterAnimation(),
});
tl.add({ targets: myProps, x: 100, duration: 500 });
tl.add({ targets: myProps, y: 200, duration: 500 });
```

### Changes

- `Stage.ts`: add `activeAnimationCount`, pass `maxCount` to `processSome()`
- `CoreTextureManager.ts`: add `maxCount` parameter to `processSome()`
- `AnimationManager.ts`: accept `Stage` in constructor, increment/decrement the shared counter
- `Renderer.ts`: expose `registerAnimation()` / `unregisterAnimation()` on the public API
- `copilot-instructions.md`: document the architecture and integration patterns

### Testing

- All 453 unit tests pass
- Build clean (only pre-existing CanvasTextRenderer TS errors unrelated to this change)
- No breaking changes — `registerAnimation`/`unregisterAnimation` are additive public API