### PR TITLE
fix: raise RecalcUniforms when node dimensions change

### DIFF
--- a/src/core/Autosizer.ts
+++ b/src/core/Autosizer.ts
@@ -34,7 +34,7 @@ export enum AutosizeUpdateType {
 const applyDimensions = (node: CoreNode, w: number, h: number) => {
   node.props.w = w;
   node.props.h = h;
-  node.setUpdateType(UpdateType.Local);
+  node.setUpdateType(UpdateType.Local | UpdateType.RecalcUniforms);
 };
 
 const getFilteredChildren = (

--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -2075,7 +2075,7 @@ export class CoreNode extends EventEmitter {
     const props = this.props;
     if (props.w !== value) {
       props.w = value;
-      let updateType = UpdateType.Local;
+      let updateType = UpdateType.Local | UpdateType.RecalcUniforms;
 
       if (
         props.texture !== null &&
@@ -2105,7 +2105,7 @@ export class CoreNode extends EventEmitter {
     const props = this.props;
     if (props.h !== value) {
       props.h = value;
-      let updateType = UpdateType.Local;
+      let updateType = UpdateType.Local | UpdateType.RecalcUniforms;
 
       if (
         props.texture !== null &&


### PR DESCRIPTION
## Summary

Correctness fix: shader uniforms that depend on node dimensions (`u_dimensions = [node.w, node.h]`) were not recalculated when a node was resized.

### Problem

The `w`/`h` setters and `Autosizer.applyDimensions()` only raised `UpdateType.Local` (which recalculates the local transform). They did not raise `UpdateType.RecalcUniforms`, so shaders like Rounded, Shadow, LinearGradient, and RadialGradient — which all read `u_dimensions` — would render with stale dimension values until something else happened to trigger a full uniform recalculation.

### Fix

Add `UpdateType.RecalcUniforms` to:
- The `w` setter
- The `h` setter  
- `Autosizer.applyDimensions()` (which writes `props.w`/`props.h` directly, bypassing the setters)

### Testing

- All 453 unit tests pass
- Build clean (no new type errors)
- 2 files changed, 3 lines modified