### PR TITLE
perf: skip redundant setter calls in CoreNode constructor

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -828,7 +828,6 @@ export class CoreNode extends EventEmitter {
 
   constructor(readonly stage: Stage, props: CoreNodeProps) {
     super();
-    const p = (this.props = {} as CoreNodeProps);
 
     // Initialize the renderOpTextures array with a capacity of 16 (typical max textures)
     this.renderOpTextures = [];
@@ -836,6 +835,8 @@ export class CoreNode extends EventEmitter {
     //inital update type
     let initialUpdateType =
       UpdateType.Local | UpdateType.RenderBounds | UpdateType.RenderState;
+
+    const p = (this.props = {} as CoreNodeProps);
 
     // Fast-path assign only known keys
     p.x = props.x;
@@ -892,7 +893,6 @@ export class CoreNode extends EventEmitter {
     p.srcY = props.srcY;
     p.srcWidth = props.srcWidth;
     p.srcHeight = props.srcHeight;
-    p.autosize = props.autosize;
 
     p.parent = props.parent;
     p.texture = null;
@@ -910,13 +910,34 @@ export class CoreNode extends EventEmitter {
       props.parent.addChild(this);
     }
 
-    // Assign props to instances
-    this.texture = props.texture;
-    this.shader = props.shader;
-    this.src = props.src;
-    this.rtt = props.rtt;
-    this.boundsMargin = props.boundsMargin;
-    this.interactive = props.interactive;
+    // Assign saved values through setters only when they differ from
+    // defaults. In the common path most nodes are created with null texture,
+    // default shader, no src, rtt=false, no boundsMargin, and
+    // interactive=false — skipping the setter avoids equality checks,
+    // setUpdateType traversals, and redundant texture/shader operations.
+    if (props.texture !== null) {
+      this.texture = props.texture;
+    }
+    if (props.shader === null || props.shader === this.stage.defShaderNode) {
+      // Default shader — bypass the setter entirely; just point props at
+      // the default shader node without triggering setUpdateType or
+      // attachNode.
+      p.shader = this.stage.defShaderNode;
+    } else {
+      this.shader = props.shader;
+    }
+    if (props.src !== null) {
+      this.src = props.src;
+    }
+    if (props.rtt !== false) {
+      this.rtt = props.rtt;
+    }
+    if (props.boundsMargin !== null) {
+      this.boundsMargin = props.boundsMargin;
+    }
+    if (props.interactive !== false) {
+      this.interactive = props.interactive;
+    }
 
     // Initialize autosize if enabled
     if (p.autosize === true) {


### PR DESCRIPTION
## Summary

Guards the 6 setter calls in the CoreNode constructor with default-value checks so they are skipped entirely on the common path.

### Problem

The constructor unconditionally calls setters for `texture`, `shader`, `src`, `rtt`, `boundsMargin`, and `interactive` — even when their values are the defaults (`null`, default shader, `null`, `false`, `null`, `false`). Each setter performs equality checks, `setUpdateType` parent-chain traversals, and in the case of `shader`, `attachNode` / `trackTimedNode` calls. This is wasted work for the vast majority of nodes.

### Fix

- `texture`: only call setter when `!== null`
- `shader`: when `null` or equal to `defShaderNode`, assign directly to `props.shader` bypassing the setter. Only call the setter for non-default shaders.
- `src`: only call setter when `!== null`
- `rtt`: only call setter when `!== false`
- `boundsMargin`: only call setter when `!== null`
- `interactive`: only call setter when `!== false`

Also removes a duplicate `p.autosize = props.autosize` assignment.

### Impact

In the common JSX path where nodes are created with defaults, **zero setter calls** are made during construction — no equality checks, no `setUpdateType` traversals up the parent chain, no redundant texture/shader operations.

### Testing

- All 453 unit tests pass
- Build clean (no new type errors)
- 1 file changed, 30 insertions, 9 deletions