### PR TITLE
refactor: creating reusable mock stage object

### DIFF
--- a/src/core/CoreNode.test.ts
+++ b/src/core/CoreNode.test.ts
@@ -18,21 +18,14 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { CoreNode, type CoreNodeProps, UpdateType } from './CoreNode.js';
-import { Stage } from './Stage.js';
-import { CoreRenderer } from './renderers/CoreRenderer.js';
+import { CoreNode, UpdateType } from './CoreNode.js';
 import { mock } from 'vitest-mock-extended';
-import { type TextureOptions } from './CoreTextureManager.js';
-import { createBound } from './lib/utils.js';
 import { ImageTexture } from './textures/ImageTexture.js';
+import { makeMockStage, makeNodeProps } from '../../test/mockStage.js';
 
 describe('CoreNode', () => {
-  const defaultProps: CoreNodeProps = {
+  const defaultProps = makeNodeProps({
     alpha: 0,
-    autosize: false,
-    boundsMargin: null,
-    clipping: false,
-    clipRadius: 0,
     color: 0,
     colorBl: 0,
     colorBottom: 0,
@@ -42,28 +35,10 @@ describe('CoreNode', () => {
     colorTl: 0,
     colorTop: 0,
     colorTr: 0,
-    h: 0,
-    mount: 0,
-    mountX: 0,
-    mountY: 0,
-    parent: null,
-    pivot: 0,
-    pivotX: 0,
-    pivotY: 0,
-    rotation: 0,
-    rtt: false,
     scale: 0,
     scaleX: 0,
     scaleY: 0,
-    shader: null,
-    src: '',
-    texture: null,
-    textureOptions: {} as TextureOptions,
-    w: 0,
-    x: 0,
-    y: 0,
-    zIndex: 0,
-  };
+  });
 
   const clippingRect = {
     x: 0,
@@ -74,19 +49,7 @@ describe('CoreNode', () => {
     clipRadius: 0,
   };
 
-  const stage = mock<Stage>({
-    strictBound: createBound(0, 0, 200, 200),
-    preloadBound: createBound(0, 0, 200, 200),
-    defaultTexture: {
-      state: 'loaded',
-    },
-    interactiveNodes: {
-      add() {},
-      delete() {},
-      has: () => false,
-    } as unknown as Stage['interactiveNodes'],
-    renderer: mock<CoreRenderer>() as CoreRenderer,
-  });
+  const stage = makeMockStage({}, { width: 200, height: 200 });
 
   describe('set color()', () => {
     it('should set all color subcomponents.', () => {

--- a/src/core/CoreTextNode.test.ts
+++ b/src/core/CoreTextNode.test.ts
@@ -22,72 +22,14 @@ import { CoreTextNode, type CoreTextNodeProps } from './CoreTextNode.js';
 import { CoreNodeRenderState } from './CoreNode.js';
 import { Stage } from './Stage.js';
 import { CoreRenderer } from './renderers/CoreRenderer.js';
-import { mock } from 'vitest-mock-extended';
 import type { TextRenderer } from './text-rendering/TextRenderer.js';
-import { createBound } from './lib/utils.js';
+import { makeMockStage, makeTextProps } from '../../test/mockStage.js';
 
 describe('CoreTextNode', () => {
   let stage: Stage;
   let mockTextRenderer: TextRenderer;
 
-  const defaultTextProps: CoreTextNodeProps = {
-    // CoreNodeProps
-    alpha: 1,
-    autosize: false,
-    boundsMargin: null,
-    clipping: false,
-    clipRadius: 0,
-    color: 0xffffffff,
-    colorBl: 0xffffffff,
-    colorBottom: 0xffffffff,
-    colorBr: 0xffffffff,
-    colorLeft: 0xffffffff,
-    colorRight: 0xffffffff,
-    colorTl: 0xffffffff,
-    colorTop: 0xffffffff,
-    colorTr: 0xffffffff,
-    h: 0,
-    mount: 0,
-    mountX: 0,
-    mountY: 0,
-    parent: null,
-    pivot: 0,
-    pivotX: 0,
-    pivotY: 0,
-    rotation: 0,
-    rtt: false,
-    scale: 1,
-    scaleX: 1,
-    scaleY: 1,
-    shader: null,
-    src: '',
-    texture: null,
-    textureOptions: {},
-    w: 0,
-    x: 0,
-    y: 0,
-    zIndex: 0,
-    // TrProps
-    text: 'Test',
-    textAlign: 'left',
-    contain: 'none',
-    fontFamily: 'Arial',
-    fontStyle: 'normal',
-    fontSize: 16,
-    letterSpacing: 0,
-    lineHeight: 1,
-    maxHeight: 0,
-    maxLines: 0,
-    maxWidth: 0,
-    offsetY: 0,
-    overflowSuffix: '...',
-    verticalAlign: 'top',
-    wordBreak: 'break-word',
-    // CoreTextNodeProps specific
-    textRendererOverride: null,
-    forceLoad: false,
-    richText: false,
-  };
+  const defaultTextProps: CoreTextNodeProps = makeTextProps();
 
   const clippingRect = {
     x: 0,
@@ -99,19 +41,7 @@ describe('CoreTextNode', () => {
   };
 
   beforeEach(() => {
-    stage = mock<Stage>({
-      strictBound: createBound(0, 0, 1920, 1080),
-      preloadBound: createBound(0, 0, 1920, 1080),
-      defaultTexture: {
-        state: 'loaded',
-      },
-      interactiveNodes: {
-        add() {},
-        delete() {},
-        has: () => false,
-      } as unknown as Stage['interactiveNodes'],
-      renderer: mock<CoreRenderer>() as CoreRenderer,
-    });
+    stage = makeMockStage();
 
     // Mock text renderer with basic functionality
     mockTextRenderer = {
@@ -319,15 +249,7 @@ describe('CoreTextNode', () => {
   });
 
   function makeStageWithDeleteBuffer(deleteBuffer: ReturnType<typeof vi.fn>) {
-    return mock<Stage>({
-      strictBound: createBound(0, 0, 1920, 1080),
-      preloadBound: createBound(0, 0, 1920, 1080),
-      defaultTexture: { state: 'loaded' },
-      interactiveNodes: {
-        add() {},
-        delete() {},
-        has: () => false,
-      } as unknown as Stage['interactiveNodes'],
+    return makeMockStage({
       renderer: { deleteBuffer } as unknown as CoreRenderer,
     });
   }
@@ -598,15 +520,7 @@ describe('CoreTextNode', () => {
         STATIC_DRAW: 0x88e4,
         FLOAT: 0x1406,
       };
-      const sdfStage = mock<Stage>({
-        strictBound: createBound(0, 0, 1920, 1080),
-        preloadBound: createBound(0, 0, 1920, 1080),
-        defaultTexture: { state: 'loaded' },
-        interactiveNodes: {
-          add() {},
-          delete() {},
-          has: () => false,
-        } as unknown as Stage['interactiveNodes'],
+      const sdfStage = makeMockStage({
         renderer: { glw } as unknown as CoreRenderer,
       });
       const node = new CoreTextNode(
@@ -637,15 +551,7 @@ describe('CoreTextNode', () => {
       const setScissorTest = vi.fn();
       const scissor = vi.fn();
       const drawArrays = vi.fn();
-      const sdfStage = mock<Stage>({
-        strictBound: createBound(0, 0, 1920, 1080),
-        preloadBound: createBound(0, 0, 1920, 1080),
-        defaultTexture: { state: 'loaded' },
-        interactiveNodes: {
-          add() {},
-          delete() {},
-          has: () => false,
-        } as unknown as Stage['interactiveNodes'],
+      const sdfStage = makeMockStage({
         pixelRatio: 2,
         platform: { canvas: { width: 1920, height: 1080 } } as any,
         shManager: { useShader } as any,

--- a/src/core/renderers/webgl/WebGlRenderer.rtt.test.ts
+++ b/src/core/renderers/webgl/WebGlRenderer.rtt.test.ts
@@ -25,7 +25,6 @@
  * tested at the level of its internal bookkeeping methods only.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { mock } from 'vitest-mock-extended';
 import {
   CoreNode,
   CoreNodeRenderState,
@@ -33,68 +32,27 @@ import {
   type CoreNodeProps,
 } from '../../CoreNode.js';
 import type { Stage } from '../../Stage.js';
-import type { CoreRenderer } from '../CoreRenderer.js';
-import { createBound } from '../../lib/utils.js';
-import type { TextureOptions } from '../../CoreTextureManager.js';
-import { Texture } from '../../textures/Texture.js';
 import { WebGlRenderer } from './WebGlRenderer.js';
+import { makeMockStage, makeNodeProps } from '../../../../test/mockStage.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-const makeDefaultProps = (): CoreNodeProps => ({
-  alpha: 1,
-  autosize: false,
-  boundsMargin: null,
-  clipping: false,
-  clipRadius: 0,
-  color: 0xffffffff,
-  colorBl: 0xffffffff,
-  colorBottom: 0xffffffff,
-  colorBr: 0xffffffff,
-  colorLeft: 0xffffffff,
-  colorRight: 0xffffffff,
-  colorTl: 0xffffffff,
-  colorTop: 0xffffffff,
-  colorTr: 0xffffffff,
-  h: 100,
-  mount: 0,
-  mountX: 0,
-  mountY: 0,
-  parent: null,
-  pivot: 0.5,
-  pivotX: 0.5,
-  pivotY: 0.5,
-  rotation: 0,
-  rtt: false,
-  scale: 1,
-  scaleX: 1,
-  scaleY: 1,
-  shader: null,
-  src: '',
-  texture: null,
-  textureOptions: {} as TextureOptions,
-  w: 100,
-  x: 0,
-  y: 0,
-  zIndex: 0,
-});
+const makeDefaultProps = (): CoreNodeProps =>
+  makeNodeProps({
+    pivot: 0.5,
+    pivotX: 0.5,
+    pivotY: 0.5,
+    h: 100,
+    w: 100,
+  });
 
 /**
  * Minimal mock stage that satisfies CoreNode's constructor requirements.
  */
 const makeStage = (): Stage =>
-  mock<Stage>({
-    strictBound: createBound(0, 0, 1920, 1080),
-    preloadBound: createBound(0, 0, 1920, 1080),
-    defaultTexture: { state: 'loaded' } as unknown as Texture,
-    interactiveNodes: {
-      add() {},
-      delete() {},
-      has: () => false,
-    } as unknown as Stage['interactiveNodes'],
-    renderer: mock<CoreRenderer>() as CoreRenderer,
+  makeMockStage({
     txManager: {
       createTexture: vi.fn().mockReturnValue({
         state: 'loaded',

--- a/src/core/renderers/webgl/WebGlShaderProgram.test.ts
+++ b/src/core/renderers/webgl/WebGlShaderProgram.test.ts
@@ -18,86 +18,20 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { mock } from 'vitest-mock-extended';
 import { CoreTextNode, type CoreTextNodeProps } from '../../CoreTextNode.js';
 import type { Stage } from '../../Stage.js';
 import type { TextRenderer } from '../../text-rendering/TextRenderer.js';
-import { createBound } from '../../lib/utils.js';
-import type { CoreRenderer } from '../CoreRenderer.js';
 import { WebGlRenderer } from './WebGlRenderer.js';
 import { WebGlShaderProgram } from './WebGlShaderProgram.js';
+import {
+  makeMockStage,
+  makeTextProps as makeSharedTextProps,
+} from '../../../../test/mockStage.js';
 
-const makeStage = (): Stage =>
-  mock<Stage>({
-    strictBound: createBound(0, 0, 1920, 1080),
-    preloadBound: createBound(0, 0, 1920, 1080),
-    defaultTexture: {
-      state: 'loaded',
-    },
-    interactiveNodes: {
-      add() {},
-      delete() {},
-      has: () => false,
-    } as unknown as Stage['interactiveNodes'],
-    pixelRatio: 2,
-    renderer: mock<CoreRenderer>() as CoreRenderer,
-  });
+const makeStage = (): Stage => makeMockStage({ pixelRatio: 2 });
 
-const makeTextProps = (): CoreTextNodeProps => ({
-  alpha: 1,
-  autosize: false,
-  boundsMargin: null,
-  clipping: false,
-  clipRadius: 0,
-  color: 0xffffffff,
-  colorBl: 0xffffffff,
-  colorBottom: 0xffffffff,
-  colorBr: 0xffffffff,
-  colorLeft: 0xffffffff,
-  colorRight: 0xffffffff,
-  colorTl: 0xffffffff,
-  colorTop: 0xffffffff,
-  colorTr: 0xffffffff,
-  h: 20,
-  mount: 0,
-  mountX: 0,
-  mountY: 0,
-  parent: null,
-  pivot: 0,
-  pivotX: 0,
-  pivotY: 0,
-  rotation: 0,
-  rtt: false,
-  scale: 1,
-  scaleX: 1,
-  scaleY: 1,
-  shader: null,
-  src: '',
-  texture: null,
-  textureOptions: {},
-  w: 100,
-  x: 0,
-  y: 0,
-  zIndex: 0,
-  text: 'Test',
-  textAlign: 'left',
-  contain: 'none',
-  fontFamily: 'Arial',
-  fontStyle: 'normal',
-  fontSize: 16,
-  letterSpacing: 0,
-  lineHeight: 1,
-  maxHeight: 0,
-  maxLines: 0,
-  maxWidth: 0,
-  offsetY: 0,
-  overflowSuffix: '...',
-  verticalAlign: 'top',
-  wordBreak: 'break-word',
-  textRendererOverride: null,
-  forceLoad: false,
-  richText: false,
-});
+const makeTextProps = (): CoreTextNodeProps =>
+  makeSharedTextProps({ h: 20, w: 100 });
 
 const makeSdfTextRenderer = (): TextRenderer =>
   ({

--- a/test/mockStage.ts
+++ b/test/mockStage.ts
@@ -1,0 +1,151 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shared test scaffolding for renderer unit tests.
+ *
+ * Provides builders for the mocked {@link Stage} and default node/text props
+ * so tests compose from a single source of truth instead of copy-pasting the
+ * same setup. Lives under `test/` (not `src/`) so it is never shipped in the
+ * package nor compiled into `dist`.
+ */
+import { mock } from 'vitest-mock-extended';
+import type { Stage } from '../src/core/Stage.js';
+import type { CoreNodeProps } from '../src/core/CoreNode.js';
+import type { CoreTextNodeProps } from '../src/core/CoreTextNode.js';
+import { CoreRenderer } from '../src/core/renderers/CoreRenderer.js';
+import { createBound } from '../src/core/lib/utils.js';
+import type { TextureOptions } from '../src/core/CoreTextureManager.js';
+
+export interface MockStageDimensions {
+  width?: number;
+  height?: number;
+}
+
+/**
+ * Build a `mock<Stage>` pre-populated with the scaffolding required to
+ * construct core nodes.
+ *
+ * Defaults cover the common case (1920x1080 bounds, a loaded default texture,
+ * a no-op `interactiveNodes` set, and a `CoreRenderer` mock). Pass `overrides`
+ * to replace whole stage properties (e.g. a custom `renderer`, `txManager`,
+ * `shManager`, `platform`, or `pixelRatio`); `overrides` are shallow-merged
+ * last so they win over the defaults.
+ */
+export function makeMockStage(
+  overrides: Partial<Stage> = {},
+  { width = 1920, height = 1080 }: MockStageDimensions = {},
+): Stage {
+  return mock<Stage>({
+    strictBound: createBound(0, 0, width, height),
+    preloadBound: createBound(0, 0, width, height),
+    defaultTexture: {
+      state: 'loaded',
+    },
+    interactiveNodes: {
+      add() {},
+      delete() {},
+      has: () => false,
+    } as unknown as Stage['interactiveNodes'],
+    renderer: mock<CoreRenderer>() as CoreRenderer,
+    ...overrides,
+  });
+}
+
+/**
+ * Build a complete {@link CoreNodeProps} with sensible, visible defaults
+ * (alpha 1, white color, scale 1). Pass `overrides` for the fields a test
+ * actually cares about.
+ */
+export function makeNodeProps(
+  overrides: Partial<CoreNodeProps> = {},
+): CoreNodeProps {
+  return {
+    alpha: 1,
+    autosize: false,
+    boundsMargin: null,
+    clipping: false,
+    clipRadius: 0,
+    color: 0xffffffff,
+    colorBl: 0xffffffff,
+    colorBottom: 0xffffffff,
+    colorBr: 0xffffffff,
+    colorLeft: 0xffffffff,
+    colorRight: 0xffffffff,
+    colorTl: 0xffffffff,
+    colorTop: 0xffffffff,
+    colorTr: 0xffffffff,
+    h: 0,
+    mount: 0,
+    mountX: 0,
+    mountY: 0,
+    parent: null,
+    pivot: 0,
+    pivotX: 0,
+    pivotY: 0,
+    rotation: 0,
+    rtt: false,
+    scale: 1,
+    scaleX: 1,
+    scaleY: 1,
+    shader: null,
+    src: '',
+    texture: null,
+    textureOptions: {} as TextureOptions,
+    w: 0,
+    x: 0,
+    y: 0,
+    zIndex: 0,
+    ...overrides,
+  };
+}
+
+/**
+ * Build a complete {@link CoreTextNodeProps}: {@link makeNodeProps} defaults
+ * plus the text-rendering (`TrProps`) defaults. Pass `overrides` for the
+ * fields a test actually cares about.
+ */
+export function makeTextProps(
+  overrides: Partial<CoreTextNodeProps> = {},
+): CoreTextNodeProps {
+  return {
+    ...makeNodeProps(),
+    // TrProps
+    text: 'Test',
+    textAlign: 'left',
+    contain: 'none',
+    fontFamily: 'Arial',
+    fontStyle: 'normal',
+    fontSize: 16,
+    letterSpacing: 0,
+    lineHeight: 1,
+    maxHeight: 0,
+    maxLines: 0,
+    maxWidth: 0,
+    offsetY: 0,
+    overflowSuffix: '...',
+    verticalAlign: 'top',
+    wordBreak: 'break-word',
+    // CoreTextNodeProps specific
+    textRendererOverride: null,
+    forceLoad: false,
+    richText: false,
+    ...overrides,
+  };
+}

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -14,6 +14,7 @@
   "include": [
     "./src/**/*.ts",
     "./exports/**/*.ts",
+    "./test/**/*.ts",
     "./test/mockdata/**/*.json"
   ],
   "exclude": [


### PR DESCRIPTION
Extracting out the stage mocking process to make it reusable rather than declared in each file