### PR TITLE
Iterate over children with for loop inside `destroy`

### DIFF
--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -2017,12 +2017,12 @@ export class CoreNode extends EventEmitter {
       this.stage.untrackTimedNode(this);
     }
 
+    const { children, parent } = this;
     // Kill children
-    while (this.children.length > 0) {
-      this.children[0]!.destroy();
+    for (let i = children.length - 1; i > -1; i--) {
+      children[i]!.destroy();
     }
 
-    const parent = this.parent;
     if (parent !== null) {
       parent.removeChild(this);
     }


### PR DESCRIPTION
This is a super rare edge case but due to a programming mistake a `destroyed` node may be re-attached.
Calling `destroy` on that node's parent would freeze the app due to the combination of the while loop and `destroy`'s top guard.
https://github.com/lightning-js/renderer/blob/345ca62ca00e1b4241603ce4def41872c24d15e7/src/core/CoreNode.ts#L2020-L2023
https://github.com/lightning-js/renderer/blob/345ca62ca00e1b4241603ce4def41872c24d15e7/src/core/CoreNode.ts#L2003-L2006