### PR TITLE
feat: make texture upload throttle during animations configurable

### DIFF
--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -123,8 +123,9 @@ export class Stage {
    * {@link RendererMain.registerAnimation} / {@link RendererMain.unregisterAnimation}.
    *
    * Used by the render loop to throttle texture uploads during animations:
-   * when > 0, only one texture is uploaded per frame to preserve the frame
-   * budget.
+   * while > 0, at most `maxTextureUploadsDuringAnimation` textures are
+   * uploaded per frame to preserve the frame budget. When zero, the full
+   * time budget is used.
    */
   public activeAnimationCount = 0;
   // Pre-allocated frameTick payload -- reused every frame to avoid per-frame {} allocation
@@ -517,10 +518,13 @@ export class Stage {
     }
 
     // Process some textures asynchronously but don't block the frame.
-    // During active animations, limit to 1 texture per frame to preserve
-    // the frame budget. When idle, use the full time budget.
+    // During active animations, limit texture uploads per frame (configurable
+    // via `maxTextureUploadsDuringAnimation`) to preserve the frame budget.
+    // When idle, use the full time budget.
     if (this.txManager.hasUpdates() === true) {
-      const maxCount = this.activeAnimationCount > 0 ? 1 : 0x7fffffff;
+      const cap = this.options.maxTextureUploadsDuringAnimation;
+      const maxCount =
+        this.activeAnimationCount > 0 && cap > 0 ? cap : 0x7fffffff;
       this.txManager
         .processSome(this.options.textureProcessingTimeLimit, maxCount)
         .catch((err) => {

--- a/src/main-api/Renderer.ts
+++ b/src/main-api/Renderer.ts
@@ -285,6 +285,20 @@ export interface RendererRuntimeSettings {
   textureProcessingTimeLimit: number;
 
   /**
+   * Maximum number of textures uploaded per frame while an animation is active.
+   *
+   * @remarks
+   * During animations, texture uploads are throttled to preserve the frame
+   * budget. Set this to a higher value on devices that can afford to upload
+   * multiple textures per frame without dropping frames. Set to `0` to disable
+   * the restriction entirely; uploads are then only limited by
+   * {@link textureProcessingTimeLimit}.
+   *
+   * @defaultValue `1`
+   */
+  maxTextureUploadsDuringAnimation: number;
+
+  /**
    * Target FPS for the global render loop
    *
    * @remarks
@@ -522,6 +536,8 @@ export class RendererMain extends EventEmitter {
       quadBufferSize: settings.quadBufferSize ?? 4 * 1024 * 1024,
       fontEngines: settings.fontEngines ?? [],
       textureProcessingTimeLimit: settings.textureProcessingTimeLimit || 42,
+      maxTextureUploadsDuringAnimation:
+        settings.maxTextureUploadsDuringAnimation ?? 1,
       canvas: settings.canvas,
       createImageBitmapSupport: settings.createImageBitmapSupport || 'full',
       platform: settings.platform || WebPlatform,
@@ -576,6 +592,8 @@ export class RendererMain extends EventEmitter {
       inspector: settings.inspector !== null,
       targetFPS: settings.targetFPS!,
       textureProcessingTimeLimit: settings.textureProcessingTimeLimit!,
+      maxTextureUploadsDuringAnimation:
+        settings.maxTextureUploadsDuringAnimation!,
       createImageBitmapSupport: settings.createImageBitmapSupport!,
       platform,
       maxRetryCount: settings.maxRetryCount ?? 5,
@@ -1015,8 +1033,9 @@ export class RendererMain extends EventEmitter {
    * @remarks
    * This increments a global animation counter shared by both the internal
    * animation engine and external animation libraries. While the counter is
-   * above zero, the renderer throttles texture uploads to one per frame to
-   * preserve the frame budget.
+   * above zero, the renderer throttles texture uploads (configurable via the
+   * {@link RendererMainSettings.maxTextureUploadsDuringAnimation} setting,
+   * which defaults to one per frame) to preserve the frame budget.
    *
    * Call {@link unregisterAnimation} when the animation completes, is
    * cancelled, or is otherwise no longer driving per-frame updates.
@@ -1057,7 +1076,8 @@ export class RendererMain extends EventEmitter {
    *
    * @remarks
    * Decrements the global animation counter. When the counter reaches zero,
-   * the renderer resumes full-budget texture processing.
+   * the renderer resumes full-budget texture processing (only limited by the
+   * {@link RendererMainSettings.textureProcessingTimeLimit}).
    *
    * Must be called exactly once for each corresponding
    * {@link registerAnimation} call.


### PR DESCRIPTION
## Summary
Makes the texture-upload throttle applied during animations configurable via a new `maxTextureUploadsDuringAnimation` renderer setting, instead of the hardcoded cap of 1 texture per frame.

Some devices can afford to upload multiple textures per frame without dropping frames, while others need the stricter restriction. This allows per-device tuning at construction time.

## Behavior
- `1` (default) — preserves current behavior: while animating, at most 1 texture is uploaded per frame.
- `> 1` — allows that many uploads per frame during animations.
- `0` — disables the restriction entirely; uploads are only limited by `textureProcessingTimeLimit` (same as the idle path).

## Changes
- `src/main-api/Renderer.ts`
  - Adds `maxTextureUploadsDuringAnimation` to `RendererRuntimeSettings` with JSDoc.
  - Defaults it to `1` in the settings resolution and forwards it to the `Stage` constructor.
  - Updates `registerAnimation`/`unregisterAnimation` JSDoc to reference the configurable cap.
- `src/core/Stage.ts`
  - `drawFrame` uses `options.maxTextureUploadsDuringAnimation` instead of the hardcoded `1`.
  - Updates the `activeAnimationCount` JSDoc.

## Verification
- `tsc --build` passes
- prettier + eslint clean (only pre-existing warnings)
- animation / texture tests pass (66 passed)

Related: `perf/animation-aware-texture-processing` introduced the hardcoded throttle this makes configurable.