### PR TITLE
Make `CanvasRenderer` treat clearColor as RGBA, like `WebGlRenderer`

### DIFF
--- a/src/core/lib/colorCache.ts
+++ b/src/core/lib/colorCache.ts
@@ -3,18 +3,24 @@ import { parseToAbgrString, parseToRgbaString } from './colorParser.js';
 const parsedArgbColors: Map<number, string> = new Map();
 const parsedRgbaColors: Map<number, string> = new Map();
 
-export function normalizeCanvasColor(color: number, isRGBA: boolean = true) {
-  let targetCache = isRGBA === true ? parsedRgbaColors : parsedArgbColors;
-  let out = targetCache.get(color);
+export function normalizeCanvasColor(rgbaColor: number) {
+  let out = parsedRgbaColors.get(rgbaColor);
   if (out !== undefined) {
     return out;
   }
 
-  if (isRGBA === true) {
-    out = parseToRgbaString(color);
-  } else {
-    out = parseToAbgrString(color);
+  out = parseToRgbaString(rgbaColor);
+  parsedRgbaColors.set(rgbaColor, out);
+  return out;
+}
+
+export function normalizeCanvasColorArgb(argbColor: number) {
+  let out = parsedArgbColors.get(argbColor);
+  if (out !== undefined) {
+    return out;
   }
-  targetCache.set(color, out);
+
+  out = parseToAbgrString(argbColor);
+  parsedArgbColors.set(argbColor, out);
   return out;
 }

--- a/src/core/lib/colorCache.ts
+++ b/src/core/lib/colorCache.ts
@@ -3,7 +3,7 @@ import { parseToAbgrString, parseToRgbaString } from './colorParser.js';
 const parsedArgbColors: Map<number, string> = new Map();
 const parsedRgbaColors: Map<number, string> = new Map();
 
-export function normalizeCanvasColor(color: number, isRGBA: boolean = false) {
+export function normalizeCanvasColor(color: number, isRGBA: boolean = true) {
   let targetCache = isRGBA === true ? parsedRgbaColors : parsedArgbColors;
   let out = targetCache.get(color);
   if (out !== undefined) {

--- a/src/core/lib/colorParser.ts
+++ b/src/core/lib/colorParser.ts
@@ -80,6 +80,6 @@ export function parseColorRgba(rgba: number): IParsedColor {
 /**
  * Format a parsed color into a rgba CSS color
  */
-export function formatRgba({ a, r, g, b }: IParsedColor): string {
-  return `rgba(${r},${g},${b},${a})`;
+export function formatRgba(color: IParsedColor): string {
+  return `rgba(${color.r},${color.g},${color.b},${color.a})`;
 }

--- a/src/core/lib/colorParser.ts
+++ b/src/core/lib/colorParser.ts
@@ -41,25 +41,25 @@ export function parseColor(abgr: number): IParsedColor {
     return WHITE;
   }
   const a = ((abgr >>> 24) & 0xff) / 255;
-  const b = (abgr >>> 16) & 0xff & 0xff;
-  const g = (abgr >>> 8) & 0xff & 0xff;
-  const r = abgr & 0xff & 0xff;
+  const b = (abgr >>> 16) & 0xff;
+  const g = (abgr >>> 8) & 0xff;
+  const r = abgr & 0xff;
   return { isWhite: false, a, r, g, b };
 }
 
 export function parseToAbgrString(abgr: number): string {
   const a = ((abgr >>> 24) & 0xff) / 255;
-  const b = (abgr >>> 16) & 0xff & 0xff;
-  const g = (abgr >>> 8) & 0xff & 0xff;
-  const r = abgr & 0xff & 0xff;
+  const b = (abgr >>> 16) & 0xff;
+  const g = (abgr >>> 8) & 0xff;
+  const r = abgr & 0xff;
   return `rgba(${r},${g},${b},${a})`;
 }
 
 export function parseToRgbaString(rgba: number): string {
   const r = (rgba >>> 24) & 0xff;
-  const g = (rgba >>> 16) & 0xff & 0xff;
-  const b = (rgba >>> 8) & 0xff & 0xff;
-  const a = (rgba & 0xff & 0xff) / 255;
+  const g = (rgba >>> 16) & 0xff;
+  const b = (rgba >>> 8) & 0xff;
+  const a = (rgba & 0xff) / 255;
   return `rgba(${r},${g},${b},${a})`;
 }
 
@@ -71,9 +71,9 @@ export function parseColorRgba(rgba: number): IParsedColor {
     return WHITE;
   }
   const r = (rgba >>> 24) & 0xff;
-  const g = (rgba >>> 16) & 0xff & 0xff;
-  const b = (rgba >>> 8) & 0xff & 0xff;
-  const a = (rgba & 0xff & 0xff) / 255;
+  const g = (rgba >>> 16) & 0xff;
+  const b = (rgba >>> 8) & 0xff;
+  const a = (rgba & 0xff) / 255;
   return { isWhite: false, r, g, b, a };
 }
 

--- a/src/core/renderers/CoreRenderer.ts
+++ b/src/core/renderers/CoreRenderer.ts
@@ -87,7 +87,7 @@ export abstract class CoreRenderer {
    * Insert a begin-rounded-clip sentinel into the render op list before a
    * node's children are added. No-op on non-WebGL renderers.
    */
-   
+
   beginRoundedClip(_node: CoreNode): void {
     // no-op default — overridden by WebGlRenderer
   }
@@ -96,7 +96,7 @@ export abstract class CoreRenderer {
    * Insert an end-rounded-clip sentinel after a node's children have been
    * added. No-op on non-WebGL renderers.
    */
-   
+
   endRoundedClip(_node: CoreNode): void {
     // no-op default — overridden by WebGlRenderer
   }

--- a/src/core/renderers/canvas/CanvasRenderer.ts
+++ b/src/core/renderers/canvas/CanvasRenderer.ts
@@ -24,7 +24,7 @@ import { CoreRenderer } from '../CoreRenderer.js';
 import { CanvasTexture } from './CanvasTexture.js';
 import { parseColor } from '../../lib/colorParser.js';
 import { CanvasShaderNode, type CanvasShaderType } from './CanvasShaderNode.js';
-import { normalizeCanvasColor } from '../../lib/colorCache.js';
+import { normalizeCanvasColor, normalizeCanvasColorArgb } from '../../lib/colorCache.js';
 import type { Stage } from '../../Stage.js';
 
 export class CanvasRenderer extends CoreRenderer {
@@ -218,12 +218,12 @@ export class CanvasRenderer extends CoreRenderer {
         endColor = node.premultipliedColorTr;
       }
       const gradient = this.context.createLinearGradient(tx, ty, endX, endY);
-      gradient.addColorStop(0, normalizeCanvasColor(color, false));
-      gradient.addColorStop(1, normalizeCanvasColor(endColor, false));
+      gradient.addColorStop(0, normalizeCanvasColorArgb(color));
+      gradient.addColorStop(1, normalizeCanvasColorArgb(endColor));
       this.context.fillStyle = gradient;
       this.context.fillRect(tx, ty, width, height);
     } else {
-      this.context.fillStyle = normalizeCanvasColor(color, false);
+      this.context.fillStyle = normalizeCanvasColorArgb(color);
       this.context.fillRect(tx, ty, width, height);
     }
   }

--- a/src/core/renderers/canvas/CanvasRenderer.ts
+++ b/src/core/renderers/canvas/CanvasRenderer.ts
@@ -44,7 +44,7 @@ export class CanvasRenderer extends CoreRenderer {
     this.canvas = canvas as HTMLCanvasElement;
     this.context = canvas.getContext('2d') as CanvasRenderingContext2D;
     this.pixelRatio = stage.pixelRatio;
-    this.clearColor = normalizeCanvasColor(stage.clearColor, true);
+    this.clearColor = normalizeCanvasColor(stage.clearColor);
   }
 
   reset(): void {
@@ -218,12 +218,12 @@ export class CanvasRenderer extends CoreRenderer {
         endColor = node.premultipliedColorTr;
       }
       const gradient = this.context.createLinearGradient(tx, ty, endX, endY);
-      gradient.addColorStop(0, normalizeCanvasColor(color));
-      gradient.addColorStop(1, normalizeCanvasColor(endColor));
+      gradient.addColorStop(0, normalizeCanvasColor(color, false));
+      gradient.addColorStop(1, normalizeCanvasColor(endColor, false));
       this.context.fillStyle = gradient;
       this.context.fillRect(tx, ty, width, height);
     } else {
-      this.context.fillStyle = normalizeCanvasColor(color);
+      this.context.fillStyle = normalizeCanvasColor(color, false);
       this.context.fillRect(tx, ty, width, height);
     }
   }
@@ -273,7 +273,7 @@ export class CanvasRenderer extends CoreRenderer {
    * @param color - The color to set as the clear color.
    */
   updateClearColor(color: number) {
-    this.clearColor = normalizeCanvasColor(color, true);
+    this.clearColor = normalizeCanvasColor(color);
   }
 
   override updateViewport(): void {

--- a/src/core/renderers/canvas/CanvasRenderer.ts
+++ b/src/core/renderers/canvas/CanvasRenderer.ts
@@ -44,7 +44,7 @@ export class CanvasRenderer extends CoreRenderer {
     this.canvas = canvas as HTMLCanvasElement;
     this.context = canvas.getContext('2d') as CanvasRenderingContext2D;
     this.pixelRatio = stage.pixelRatio;
-    this.clearColor = normalizeCanvasColor(stage.clearColor);
+    this.clearColor = normalizeCanvasColor(stage.clearColor, true);
   }
 
   reset(): void {
@@ -273,7 +273,7 @@ export class CanvasRenderer extends CoreRenderer {
    * @param color - The color to set as the clear color.
    */
   updateClearColor(color: number) {
-    this.clearColor = normalizeCanvasColor(color);
+    this.clearColor = normalizeCanvasColor(color, true);
   }
 
   override updateViewport(): void {

--- a/src/core/renderers/canvas/CanvasShaderNode.ts
+++ b/src/core/renderers/canvas/CanvasShaderNode.ts
@@ -90,6 +90,6 @@ export class CanvasShaderNode<
   }
 
   toColorString(rgba: number) {
-    return normalizeCanvasColor(rgba, true);
+    return normalizeCanvasColor(rgba);
   }
 }

--- a/src/core/text-rendering/CanvasTextRenderer.ts
+++ b/src/core/text-rendering/CanvasTextRenderer.ts
@@ -218,7 +218,7 @@ const renderText = (props: CoreTextNodeProps): TextRenderInfo => {
 
     // CSS color string for uncolored spans — inherits the node's text color.
     // normalizeCanvasColor caches the string, so no allocation in hot path.
-    const nodeColor = normalizeCanvasColor(color, true);
+    const nodeColor = normalizeCanvasColor(color);
 
     let strippedPos = 0;
     let curSpanIdx = 0;
@@ -290,9 +290,7 @@ const renderText = (props: CoreTextNodeProps): TextRenderInfo => {
 
           // Colored span uses span.color; uncolored span inherits node color.
           const spanFillStyle =
-            span.color !== 0
-              ? normalizeCanvasColor(span.color, true)
-              : nodeColor;
+            span.color !== 0 ? normalizeCanvasColor(span.color) : nodeColor;
 
           if (spanFillStyle !== activeFillStyle) {
             context.fillStyle = spanFillStyle;


### PR DESCRIPTION
Currently if we do `stage.setClearColor(0x000000FF)` in WebGL the background is black, but in Canvas it's white (because it thinks we're using ARGB instead of RGBA). Let's change this so that both WebGL and Canvas are consistent. And also so that `app.props.color = 0x000000FF` is consistent with `app.stage.setClearColor(0x000000FF)`.