### PR TITLE
feat: add enableDirtyRepaints toggle for PR861 behaviour, default on

### DIFF
--- a/src/core/CoreNode.test.ts
+++ b/src/core/CoreNode.test.ts
@@ -462,14 +462,20 @@ describe('CoreNode', () => {
   });
 
   describe('isQuadDirty marking (dirty quad buffer)', () => {
+    const dirtyStage = makeMockStage(
+      {
+        options: { enableDirtyRepaints: true },
+      } as unknown as Partial<import('./Stage.js').Stage>,
+      { width: 200, height: 200 },
+    );
     it('starts clean', () => {
-      const node = new CoreNode(stage, defaultProps);
+      const node = new CoreNode(dirtyStage, defaultProps);
       expect(node.isQuadDirty).toBe(false);
       expect(node.quadBufferIndex).toBe(-1);
     });
 
     it('marks isQuadDirty when a visual flag (PremultipliedColors) is processed', () => {
-      const node = new CoreNode(stage, defaultProps);
+      const node = new CoreNode(dirtyStage, defaultProps);
       node.isQuadDirty = false;
       node.color = 0xffffffff;
 
@@ -479,7 +485,7 @@ describe('CoreNode', () => {
     });
 
     it('marks isQuadDirty when a transform flag (Global) is processed', () => {
-      const node = new CoreNode(stage, defaultProps);
+      const node = new CoreNode(dirtyStage, defaultProps);
       node.isQuadDirty = false;
       node.x = 10;
 
@@ -489,7 +495,7 @@ describe('CoreNode', () => {
     });
 
     it('does not mark isQuadDirty for bookkeeping-only flags', () => {
-      const node = new CoreNode(stage, defaultProps);
+      const node = new CoreNode(dirtyStage, defaultProps);
       node.isQuadDirty = false;
       node.updateType = UpdateType.Children;
 
@@ -499,7 +505,7 @@ describe('CoreNode', () => {
     });
 
     it('does not clear an existing dirty mark for bookkeeping-only flags', () => {
-      const node = new CoreNode(stage, defaultProps);
+      const node = new CoreNode(dirtyStage, defaultProps);
       node.isQuadDirty = true;
       node.updateType = UpdateType.Children;
 
@@ -510,13 +516,23 @@ describe('CoreNode', () => {
     });
 
     it('marks isQuadDirty immediately in the texture setter', () => {
-      const node = new CoreNode(stage, defaultProps);
+      const node = new CoreNode(dirtyStage, defaultProps);
       node.isQuadDirty = false;
       node.texture = mock<ImageTexture>({
         state: 'loaded',
       });
 
       expect(node.isQuadDirty).toBe(true);
+    });
+
+    it('stays clean when dirty repaints are disabled (default)', () => {
+      const node = new CoreNode(stage, defaultProps);
+      node.isQuadDirty = false;
+      node.x = 10;
+
+      node.update(0, clippingRect);
+
+      expect(node.isQuadDirty).toBe(false);
     });
   });
 });

--- a/src/core/CoreNode.test.ts
+++ b/src/core/CoreNode.test.ts
@@ -468,6 +468,12 @@ describe('CoreNode', () => {
       } as unknown as Partial<import('./Stage.js').Stage>,
       { width: 200, height: 200 },
     );
+    const disabledStage = makeMockStage(
+      {
+        options: { enableDirtyRepaints: false },
+      } as unknown as Partial<import('./Stage.js').Stage>,
+      { width: 200, height: 200 },
+    );
     it('starts clean', () => {
       const node = new CoreNode(dirtyStage, defaultProps);
       expect(node.isQuadDirty).toBe(false);
@@ -525,8 +531,8 @@ describe('CoreNode', () => {
       expect(node.isQuadDirty).toBe(true);
     });
 
-    it('stays clean when dirty repaints are disabled (default)', () => {
-      const node = new CoreNode(stage, defaultProps);
+    it('stays clean when dirty repaints are disabled', () => {
+      const node = new CoreNode(disabledStage, defaultProps);
       node.isQuadDirty = false;
       node.x = 10;
 

--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -1491,11 +1491,14 @@ export class CoreNode extends EventEmitter {
 
     // Mark the quad dirty only when visual data (transforms, colors, alpha)
     // actually changed so the renderer re-uploads only modified slots.
+    // Skipped unless surgical dirty-quad repaints are enabled (PR #861).
     if (
+      (this.stage.options as { enableDirtyRepaints?: boolean })
+        ?.enableDirtyRepaints === true &&
       updateType &
-      (UpdateType.Global |
-        UpdateType.PremultipliedColors |
-        UpdateType.WorldAlpha)
+        (UpdateType.Global |
+          UpdateType.PremultipliedColors |
+          UpdateType.WorldAlpha)
     ) {
       this.isQuadDirty = true;
     }
@@ -2945,7 +2948,12 @@ export class CoreNode extends EventEmitter {
     }
 
     this.setUpdateType(UpdateType.IsRenderable);
-    this.isQuadDirty = true;
+    if (
+      (this.stage.options as { enableDirtyRepaints?: boolean })
+        ?.enableDirtyRepaints === true
+    ) {
+      this.isQuadDirty = true;
+    }
     this.updateIsSimple();
   }
 

--- a/src/core/CoreNode.ts
+++ b/src/core/CoreNode.ts
@@ -1493,8 +1493,7 @@ export class CoreNode extends EventEmitter {
     // actually changed so the renderer re-uploads only modified slots.
     // Skipped unless surgical dirty-quad repaints are enabled (PR #861).
     if (
-      (this.stage.options as { enableDirtyRepaints?: boolean })
-        ?.enableDirtyRepaints === true &&
+      this.stage.options.enableDirtyRepaints === true &&
       updateType &
         (UpdateType.Global |
           UpdateType.PremultipliedColors |
@@ -2948,10 +2947,7 @@ export class CoreNode extends EventEmitter {
     }
 
     this.setUpdateType(UpdateType.IsRenderable);
-    if (
-      (this.stage.options as { enableDirtyRepaints?: boolean })
-        ?.enableDirtyRepaints === true
-    ) {
+    if (this.stage.options.enableDirtyRepaints === true) {
       this.isQuadDirty = true;
     }
     this.updateIsSimple();

--- a/src/core/Stage.renderListUpdate.test.ts
+++ b/src/core/Stage.renderListUpdate.test.ts
@@ -94,7 +94,7 @@ describe('Stage.requestRenderListUpdate', () => {
     expect(stage.requestRender.mock.calls.length).toBe(1);
   });
 
-  it('skips invalidation when dirty repaints are disabled (default)', () => {
+  it('skips invalidation when dirty repaints are disabled', () => {
     const stage = makeStage(true, false);
 
     requestRenderListUpdate(stage);

--- a/src/core/Stage.renderListUpdate.test.ts
+++ b/src/core/Stage.renderListUpdate.test.ts
@@ -31,12 +31,17 @@ type FakeStage = {
   renderer: { invalidateQuadBuffer?: ReturnType<typeof vi.fn> };
   renderListDirty: boolean;
   requestRender: ReturnType<typeof vi.fn>;
+  options: { enableDirtyRepaints?: boolean };
 };
 
-const makeStage = (hasInvalidate = true): FakeStage => ({
+const makeStage = (
+  hasInvalidate = true,
+  enableDirtyRepaints = true,
+): FakeStage => ({
   renderer: hasInvalidate ? { invalidateQuadBuffer: vi.fn() } : {},
   renderListDirty: false,
   requestRender: vi.fn(),
+  options: { enableDirtyRepaints },
 });
 
 const requestRenderListUpdate = (stage: FakeStage) =>
@@ -85,6 +90,16 @@ describe('Stage.requestRenderListUpdate', () => {
 
     requestRenderListUpdate(stage);
 
+    expect(stage.renderListDirty).toBe(true);
+    expect(stage.requestRender.mock.calls.length).toBe(1);
+  });
+
+  it('skips invalidation when dirty repaints are disabled (default)', () => {
+    const stage = makeStage(true, false);
+
+    requestRenderListUpdate(stage);
+
+    expect(stage.renderer.invalidateQuadBuffer!.mock.calls.length).toBe(0);
     expect(stage.renderListDirty).toBe(true);
     expect(stage.requestRender.mock.calls.length).toBe(1);
   });

--- a/src/core/Stage.ts
+++ b/src/core/Stage.ts
@@ -698,7 +698,12 @@ export class Stage {
     this.requestRender();
     // A render list rebuild invalidates all permanent quad buffer slot
     // assignments, so the renderer must reset them and force a full upload.
-    if (this.renderer.invalidateQuadBuffer !== undefined) {
+    // Only applies when surgical dirty-quad repaints are enabled (PR #861);
+    // otherwise the renderer re-uploads the full buffer every frame anyway.
+    if (
+      this.options.enableDirtyRepaints === true &&
+      this.renderer.invalidateQuadBuffer !== undefined
+    ) {
       this.renderer.invalidateQuadBuffer();
     }
   }

--- a/src/core/renderers/webgl/WebGlRenderer.dirtyQuadBuffer.test.ts
+++ b/src/core/renderers/webgl/WebGlRenderer.dirtyQuadBuffer.test.ts
@@ -514,7 +514,7 @@ describe('WebGlRenderer dirty quad buffer — RTT isolation', () => {
   });
 });
 
-describe('WebGlRenderer dirty quad buffer — disabled (default)', () => {
+describe('WebGlRenderer dirty quad buffer — disabled (opt-out)', () => {
   it('always full uploads with STATIC_DRAW and never uses bufferSubData', () => {
     const harness = makeRenderer([], false);
     const { renderer, stage } = harness;

--- a/src/core/renderers/webgl/WebGlRenderer.dirtyQuadBuffer.test.ts
+++ b/src/core/renderers/webgl/WebGlRenderer.dirtyQuadBuffer.test.ts
@@ -110,6 +110,9 @@ const makeRenderer = (
   const renderer = Object.create(WebGlRenderer.prototype) as WebGlRenderer;
   (renderer as any).glw = glw;
   (renderer as any).stage = stage;
+  // Construction-time flag is cached in the constructor in production; the
+  // harness bypasses the constructor via Object.create, so set it explicitly.
+  (renderer as any).useDirtyRepaints = enableDirtyRepaints === true;
   (renderer as any).quadBuffer = quadBuffer;
   (renderer as any).fQuadBuffer = new Float32Array(quadBuffer);
   (renderer as any).uiQuadBuffer = new Uint32Array(quadBuffer);

--- a/src/core/renderers/webgl/WebGlRenderer.dirtyQuadBuffer.test.ts
+++ b/src/core/renderers/webgl/WebGlRenderer.dirtyQuadBuffer.test.ts
@@ -72,7 +72,10 @@ interface RendererHarness {
   stage: Stage;
 }
 
-const makeRenderer = (nodes: CoreNode[] = []): RendererHarness => {
+const makeRenderer = (
+  nodes: CoreNode[] = [],
+  enableDirtyRepaints = true,
+): RendererHarness => {
   const glw = {
     arrayBufferData: vi.fn(),
     arrayBufferSubData: vi.fn(),
@@ -91,7 +94,11 @@ const makeRenderer = (nodes: CoreNode[] = []): RendererHarness => {
   const stage = makeMockStage({
     renderListNodes: nodes,
     renderListLen: nodes.length,
-    options: { quadBufferSize: quadBuffer.byteLength, enableClear: true },
+    options: {
+      quadBufferSize: quadBuffer.byteLength,
+      enableClear: true,
+      enableDirtyRepaints,
+    },
     // A concrete default shader so reuseRenderOp batches via the
     // shaderKey==='default' fast path instead of touching shader programs.
     defShaderNode: {
@@ -501,5 +508,71 @@ describe('WebGlRenderer dirty quad buffer — RTT isolation', () => {
     expect(renderer.needsFullUpload).toBe(true);
     expect(renderer.lastUploadedBufferSize).toBe(0);
     expect(renderer.renderToTextureActive).toBe(false);
+  });
+});
+
+describe('WebGlRenderer dirty quad buffer — disabled (default)', () => {
+  it('always full uploads with STATIC_DRAW and never uses bufferSubData', () => {
+    const harness = makeRenderer([], false);
+    const { renderer, stage } = harness;
+    const { glw } = harness;
+    const a = makeNode(stage);
+    const b = makeNode(stage);
+    stage.renderListNodes = [a, b];
+    stage.renderListLen = 2;
+
+    renderer.reset();
+    renderer.addQuad(a);
+    renderer.addQuad(b);
+    // No slot bookkeeping when disabled.
+    expect(a.quadBufferIndex).toBe(-1);
+    expect(b.quadBufferIndex).toBe(-1);
+    expect(renderer.dirtyQuadCount).toBe(0);
+
+    // Even with dirty flags set manually, the legacy path ignores them.
+    a.isQuadDirty = true;
+    b.isQuadDirty = true;
+    renderer.render();
+
+    expect(glw.arrayBufferData).toHaveBeenCalledTimes(1);
+    const [, , usage] = glw.arrayBufferData.mock.calls[0]!;
+    expect(usage).toBe(glw.STATIC_DRAW);
+    expect(glw.arrayBufferSubData).not.toHaveBeenCalled();
+  });
+
+  it('invalidateQuadBuffer is a no-op when disabled', () => {
+    const harness = makeRenderer([], false);
+    const { renderer, stage } = harness;
+    const a = makeNode(stage);
+    stage.renderListNodes = [a];
+    stage.renderListLen = 1;
+
+    a.quadBufferIndex = 42;
+    a.isQuadDirty = false;
+    renderer.needsFullUpload = false;
+    renderer.lastUploadedBufferSize = 60;
+    renderer.curBufferIdx = 20;
+
+    renderer.invalidateQuadBuffer();
+
+    expect(a.quadBufferIndex).toBe(42);
+    expect(a.isQuadDirty).toBe(false);
+    expect(renderer.needsFullUpload).toBe(false);
+    expect(renderer.lastUploadedBufferSize).toBe(60);
+    expect(renderer.curBufferIdx).toBe(20);
+  });
+
+  it('writes RTT quads into the shared buffer when disabled', () => {
+    const harness = makeRenderer([], false);
+    const { renderer, stage } = harness;
+    const child = makeNode(stage);
+
+    renderer.renderToTextureActive = true;
+    renderer.addQuad(child);
+
+    expect(renderer.rttQuadBuffer).toBeNull();
+    expect(renderer.curBufferIdx).toBe(20);
+    expect(renderer.fQuadBuffer[0]).toBe(child.renderCoords!.x1);
+    renderer.renderToTextureActive = false;
   });
 });

--- a/src/core/renderers/webgl/WebGlRenderer.ts
+++ b/src/core/renderers/webgl/WebGlRenderer.ts
@@ -196,12 +196,7 @@ export class WebGlRenderer extends CoreRenderer {
    * When disabled, `addQuad`/`render`/`renderRTTNodes` use the legacy full
    * buffer upload path and all slot/dirty bookkeeping stays inert.
    */
-  private get useDirtyRepaints(): boolean {
-    return (
-      (this.stage.options as { enableDirtyRepaints?: boolean })
-        ?.enableDirtyRepaints === true
-    );
-  }
+  private readonly useDirtyRepaints: boolean;
 
   //// Shared SDF Text Batching
   /**
@@ -277,6 +272,8 @@ export class WebGlRenderer extends CoreRenderer {
 
   constructor(stage: Stage) {
     super(stage);
+
+    this.useDirtyRepaints = stage.options.enableDirtyRepaints === true;
 
     this.quadBuffer = new ArrayBuffer(stage.options.quadBufferSize);
     this.fQuadBuffer = new Float32Array(this.quadBuffer);
@@ -1161,60 +1158,15 @@ export class WebGlRenderer extends CoreRenderer {
    * @param surface
    */
   render(_surface: 'screen' | CoreContextTexture = 'screen'): void {
-    const { glw, quadBuffer } = this;
+    const { quadBuffer } = this;
 
     const buffer = this.quadBufferCollection.getBuffer('a_position') || null;
     const BYTES = Float32Array.BYTES_PER_ELEMENT;
 
     if (this.useDirtyRepaints === false) {
-      // Legacy path (pre-PR #861): re-upload the entire quad buffer.
-      const arr = new Float32Array(quadBuffer, 0, this.curBufferIdx);
-      glw.arrayBufferData(buffer, arr, glw.STATIC_DRAW);
+      this.uploadFullLegacy(buffer, quadBuffer);
     } else {
-      // Structural realloc (needsFullUpload) or buffer growth past the last
-      // uploaded size always forces a full upload.
-      let fullUpload =
-        this.needsFullUpload || this.curBufferIdx > this.lastUploadedBufferSize;
-
-      // Otherwise decide adaptively: if more than 40% of the render list would
-      // need a surgical upload, a single bulk bufferData is cheaper than that
-      // many bufferSubData calls. The count was accumulated for free during the
-      // addQuad pass, so no separate counting loop is needed here.
-      if (fullUpload === false) {
-        fullUpload =
-          this.dirtyQuadCount >
-          this.stage.renderListLen * FULL_UPLOAD_DIRTY_RATIO;
-      }
-
-      const nodes = this.stage.renderListNodes;
-
-      if (fullUpload === true) {
-        const arr = new Float32Array(quadBuffer, 0, this.curBufferIdx);
-        glw.arrayBufferData(buffer, arr, glw.DYNAMIC_DRAW);
-        this.needsFullUpload = false;
-        this.lastUploadedBufferSize = this.curBufferIdx;
-
-        // Everything is on the GPU now; clear the dirty flags.
-        for (let i = 0; i < this.stage.renderListLen; i++) {
-          nodes[i]!.isQuadDirty = false;
-        }
-      } else {
-        // Surgical: copy each dirty slot into the preallocated scratch buffer
-        // and upload only those 20 floats. No per-node allocation.
-        const scratch = this._quadScratchF;
-        const f = this.fQuadBuffer;
-        for (let i = 0; i < this.stage.renderListLen; i++) {
-          const node = nodes[i]!;
-          if (node.isQuadDirty === true && node.quadBufferIndex !== -1) {
-            const slot = node.quadBufferIndex;
-            for (let j = 0; j < 20; j++) {
-              scratch[j] = f[slot + j]!;
-            }
-            glw.arrayBufferSubData(buffer, slot * BYTES, scratch);
-            node.isQuadDirty = false;
-          }
-        }
-      }
+      this.uploadDirtyAdaptive(buffer, quadBuffer, BYTES);
     }
 
     // Upload the shared SDF buffers (each layout skips the driver copy when
@@ -1239,6 +1191,80 @@ export class WebGlRenderer extends CoreRenderer {
     // Calculate the size of each quad in bytes (4 vertices per quad) times the size of each vertex in bytes
     const QUAD_SIZE_IN_BYTES = 4 * (QUAD_VERTEX_STRIDE * BYTES);
     this.numQuadsRendered = this.quadBufferUsage / QUAD_SIZE_IN_BYTES;
+  }
+
+  private uploadFullLegacy(
+    buffer: WebGLBuffer | null,
+    quadBuffer: ArrayBuffer,
+  ): void {
+    const { glw } = this;
+    // Legacy path (pre-PR #861): re-upload the entire quad buffer.
+    const arr = new Float32Array(quadBuffer, 0, this.curBufferIdx);
+    glw.arrayBufferData(buffer, arr, glw.STATIC_DRAW);
+  }
+
+  private uploadDirtyAdaptive(
+    buffer: WebGLBuffer | null,
+    quadBuffer: ArrayBuffer,
+    BYTES: number,
+  ): void {
+    // Structural realloc (needsFullUpload) or buffer growth past the last
+    // uploaded size always forces a full upload.
+    let fullUpload =
+      this.needsFullUpload || this.curBufferIdx > this.lastUploadedBufferSize;
+
+    // Otherwise decide adaptively: if more than 40% of the render list would
+    // need a surgical upload, a single bulk bufferData is cheaper than that
+    // many bufferSubData calls. The count was accumulated for free during the
+    // addQuad pass, so no separate counting loop is needed here.
+    if (fullUpload === false) {
+      fullUpload =
+        this.dirtyQuadCount >
+        this.stage.renderListLen * FULL_UPLOAD_DIRTY_RATIO;
+    }
+
+    if (fullUpload === true) {
+      this.uploadFullDirty(buffer, quadBuffer);
+      return;
+    }
+    this.uploadSurgicalQuads(buffer, BYTES);
+  }
+
+  private uploadFullDirty(
+    buffer: WebGLBuffer | null,
+    quadBuffer: ArrayBuffer,
+  ): void {
+    const { glw } = this;
+    const nodes = this.stage.renderListNodes;
+    const arr = new Float32Array(quadBuffer, 0, this.curBufferIdx);
+    glw.arrayBufferData(buffer, arr, glw.DYNAMIC_DRAW);
+    this.needsFullUpload = false;
+    this.lastUploadedBufferSize = this.curBufferIdx;
+
+    // Everything is on the GPU now; clear the dirty flags.
+    for (let i = 0; i < this.stage.renderListLen; i++) {
+      nodes[i]!.isQuadDirty = false;
+    }
+  }
+
+  private uploadSurgicalQuads(buffer: WebGLBuffer | null, BYTES: number): void {
+    const { glw } = this;
+    const nodes = this.stage.renderListNodes;
+    // Surgical: copy each dirty slot into the preallocated scratch buffer
+    // and upload only those 20 floats. No per-node allocation.
+    const scratch = this._quadScratchF;
+    const f = this.fQuadBuffer;
+    for (let i = 0; i < this.stage.renderListLen; i++) {
+      const node = nodes[i]!;
+      if (node.isQuadDirty === true && node.quadBufferIndex !== -1) {
+        const slot = node.quadBufferIndex;
+        for (let j = 0; j < 20; j++) {
+          scratch[j] = f[slot + j]!;
+        }
+        glw.arrayBufferSubData(buffer, slot * BYTES, scratch);
+        node.isQuadDirty = false;
+      }
+    }
   }
 
   getQuadCount(): number {

--- a/src/core/renderers/webgl/WebGlRenderer.ts
+++ b/src/core/renderers/webgl/WebGlRenderer.ts
@@ -188,6 +188,21 @@ export class WebGlRenderer extends CoreRenderer {
     this._quadScratchBuffer,
   );
 
+  /**
+   * Whether surgical dirty-quad repaints (PR #861) are enabled.
+   *
+   * @remarks
+   * Construction-time only via `enableDirtyRepaints` (default `false`).
+   * When disabled, `addQuad`/`render`/`renderRTTNodes` use the legacy full
+   * buffer upload path and all slot/dirty bookkeeping stays inert.
+   */
+  private get useDirtyRepaints(): boolean {
+    return (
+      (this.stage.options as { enableDirtyRepaints?: boolean })
+        ?.enableDirtyRepaints === true
+    );
+  }
+
   //// Shared SDF Text Batching
   /**
    * Shared SDF vertex buffers — one per GPU layout.
@@ -478,10 +493,11 @@ export class WebGlRenderer extends CoreRenderer {
    * The function updates the length and number of quads in the current render operation, and updates the current buffer index.
    */
   addQuad(node: CoreNode) {
+    const useDirty = this.useDirtyRepaints;
     const isRTT = this.renderToTextureActive === true;
     let f = this.fQuadBuffer;
     let u = this.uiQuadBuffer;
-    if (isRTT === true) {
+    if (useDirty === true && isRTT === true) {
       if (this.fRttQuadBuffer === null) {
         this.rttQuadBuffer = new ArrayBuffer(this.stage.options.quadBufferSize);
         this.fRttQuadBuffer = new Float32Array(this.rttQuadBuffer);
@@ -502,8 +518,10 @@ export class WebGlRenderer extends CoreRenderer {
     // Main scene: assign a permanent slot so render() can surgically
     // re-upload only dirty nodes. RTT: use ephemeral sequential slots and
     // leave the node's main-scene slot bookkeeping untouched.
+    // Skipped entirely when dirty repaints are disabled (legacy path writes
+    // sequentially into the shared buffer).
     let i = this.curBufferIdx;
-    if (isRTT === false) {
+    if (useDirty === true && isRTT === false) {
       node.quadBufferIndex = i;
     }
     this.curBufferIdx = i + 20;
@@ -522,7 +540,7 @@ export class WebGlRenderer extends CoreRenderer {
 
     // Accumulate the main-scene dirty count during the pass so render() can
     // pick full vs surgical upload without a second walk over the render list.
-    if (isRTT === false && node.isQuadDirty === true) {
+    if (useDirty === true && isRTT === false && node.isQuadDirty === true) {
       this.dirtyQuadCount++;
     }
 
@@ -1148,47 +1166,53 @@ export class WebGlRenderer extends CoreRenderer {
     const buffer = this.quadBufferCollection.getBuffer('a_position') || null;
     const BYTES = Float32Array.BYTES_PER_ELEMENT;
 
-    // Structural realloc (needsFullUpload) or buffer growth past the last
-    // uploaded size always forces a full upload.
-    let fullUpload =
-      this.needsFullUpload || this.curBufferIdx > this.lastUploadedBufferSize;
-
-    // Otherwise decide adaptively: if more than 40% of the render list would
-    // need a surgical upload, a single bulk bufferData is cheaper than that
-    // many bufferSubData calls. The count was accumulated for free during the
-    // addQuad pass, so no separate counting loop is needed here.
-    if (fullUpload === false) {
-      fullUpload =
-        this.dirtyQuadCount >
-        this.stage.renderListLen * FULL_UPLOAD_DIRTY_RATIO;
-    }
-
-    const nodes = this.stage.renderListNodes;
-
-    if (fullUpload === true) {
+    if (this.useDirtyRepaints === false) {
+      // Legacy path (pre-PR #861): re-upload the entire quad buffer.
       const arr = new Float32Array(quadBuffer, 0, this.curBufferIdx);
-      glw.arrayBufferData(buffer, arr, glw.DYNAMIC_DRAW);
-      this.needsFullUpload = false;
-      this.lastUploadedBufferSize = this.curBufferIdx;
-
-      // Everything is on the GPU now; clear the dirty flags.
-      for (let i = 0; i < this.stage.renderListLen; i++) {
-        nodes[i]!.isQuadDirty = false;
-      }
+      glw.arrayBufferData(buffer, arr, glw.STATIC_DRAW);
     } else {
-      // Surgical: copy each dirty slot into the preallocated scratch buffer
-      // and upload only those 20 floats. No per-node allocation.
-      const scratch = this._quadScratchF;
-      const f = this.fQuadBuffer;
-      for (let i = 0; i < this.stage.renderListLen; i++) {
-        const node = nodes[i]!;
-        if (node.isQuadDirty === true && node.quadBufferIndex !== -1) {
-          const slot = node.quadBufferIndex;
-          for (let j = 0; j < 20; j++) {
-            scratch[j] = f[slot + j]!;
+      // Structural realloc (needsFullUpload) or buffer growth past the last
+      // uploaded size always forces a full upload.
+      let fullUpload =
+        this.needsFullUpload || this.curBufferIdx > this.lastUploadedBufferSize;
+
+      // Otherwise decide adaptively: if more than 40% of the render list would
+      // need a surgical upload, a single bulk bufferData is cheaper than that
+      // many bufferSubData calls. The count was accumulated for free during the
+      // addQuad pass, so no separate counting loop is needed here.
+      if (fullUpload === false) {
+        fullUpload =
+          this.dirtyQuadCount >
+          this.stage.renderListLen * FULL_UPLOAD_DIRTY_RATIO;
+      }
+
+      const nodes = this.stage.renderListNodes;
+
+      if (fullUpload === true) {
+        const arr = new Float32Array(quadBuffer, 0, this.curBufferIdx);
+        glw.arrayBufferData(buffer, arr, glw.DYNAMIC_DRAW);
+        this.needsFullUpload = false;
+        this.lastUploadedBufferSize = this.curBufferIdx;
+
+        // Everything is on the GPU now; clear the dirty flags.
+        for (let i = 0; i < this.stage.renderListLen; i++) {
+          nodes[i]!.isQuadDirty = false;
+        }
+      } else {
+        // Surgical: copy each dirty slot into the preallocated scratch buffer
+        // and upload only those 20 floats. No per-node allocation.
+        const scratch = this._quadScratchF;
+        const f = this.fQuadBuffer;
+        for (let i = 0; i < this.stage.renderListLen; i++) {
+          const node = nodes[i]!;
+          if (node.isQuadDirty === true && node.quadBufferIndex !== -1) {
+            const slot = node.quadBufferIndex;
+            for (let j = 0; j < 20; j++) {
+              scratch[j] = f[slot + j]!;
+            }
+            glw.arrayBufferSubData(buffer, slot * BYTES, scratch);
+            node.isQuadDirty = false;
           }
-          glw.arrayBufferSubData(buffer, slot * BYTES, scratch);
-          node.isQuadDirty = false;
         }
       }
     }
@@ -1307,10 +1331,12 @@ export class WebGlRenderer extends CoreRenderer {
 
   renderRTTNodes() {
     const { glw } = this;
+    const useDirty = this.useDirtyRepaints;
 
     // Save main-scene buffer index so RTT rendering doesn't interfere with
-    // the dirty quad buffer optimization.
-    const savedBufferIdx = this.curBufferIdx;
+    // the dirty quad buffer optimization. Only needed when dirty repaints
+    // are enabled; the legacy path shares one buffer for both passes.
+    const savedBufferIdx = useDirty === true ? this.curBufferIdx : 0;
 
     // Render all associated RTT nodes to their textures
     for (let i = 0; i < this.rttNodes.length; i++) {
@@ -1348,10 +1374,12 @@ export class WebGlRenderer extends CoreRenderer {
       glw.clearColor(0, 0, 0, 0);
       glw.clear();
 
-      // RTT uses its own sequential buffer from index 0, keeping the main
-      // scene's permanent slot assignments untouched.
-      this.curBufferIdx = 0;
-      this.curRenderOp = null;
+      if (useDirty === true) {
+        // RTT uses its own sequential buffer from index 0, keeping the main
+        // scene's permanent slot assignments untouched.
+        this.curBufferIdx = 0;
+        this.curRenderOp = null;
+      }
 
       // Render all associated quads to the texture
       for (let i = 0; i < node.children.length; i++) {
@@ -1366,7 +1394,11 @@ export class WebGlRenderer extends CoreRenderer {
       }
 
       // Render all associated quads to the texture
-      this.renderRTT();
+      if (useDirty === true) {
+        this.renderRTT();
+      } else {
+        this.render();
+      }
 
       // Force a re-upload on the next pass: the main pass appends to these
       // same shared buffers, and an exact cache-hit fill could otherwise
@@ -1379,13 +1411,15 @@ export class WebGlRenderer extends CoreRenderer {
       node.hasRTTupdates = false;
     }
 
-    // Restore the main-scene buffer index. The RTT pass replaced the GPU
-    // buffer with a smaller RTT-sized buffer, so the main pass must re-upload
-    // everything rather than only dirty slots.
-    this.curBufferIdx = savedBufferIdx;
-    this.curRenderOp = null;
-    this.needsFullUpload = true;
-    this.lastUploadedBufferSize = 0;
+    if (useDirty === true) {
+      // Restore the main-scene buffer index. The RTT pass replaced the GPU
+      // buffer with a smaller RTT-sized buffer, so the main pass must re-upload
+      // everything rather than only dirty slots.
+      this.curBufferIdx = savedBufferIdx;
+      this.curRenderOp = null;
+      this.needsFullUpload = true;
+      this.lastUploadedBufferSize = 0;
+    }
 
     const clearColor = this.clearColor.normalized;
     // Restore the default clear color
@@ -1443,6 +1477,9 @@ export class WebGlRenderer extends CoreRenderer {
   // structurally (node added, removed, or reordered). After this call, the
   // next addQuad() pass reassigns compact, contiguous slots starting from 0.
   override invalidateQuadBuffer(): void {
+    if (this.useDirtyRepaints === false) {
+      return;
+    }
     const nodes = this.stage.renderListNodes;
     for (let i = 0; i < this.stage.renderListLen; i++) {
       const node = nodes[i]!;

--- a/src/core/renderers/webgl/WebGlRenderer.ts
+++ b/src/core/renderers/webgl/WebGlRenderer.ts
@@ -192,7 +192,7 @@ export class WebGlRenderer extends CoreRenderer {
    * Whether surgical dirty-quad repaints (PR #861) are enabled.
    *
    * @remarks
-   * Construction-time only via `enableDirtyRepaints` (default `false`).
+   * Construction-time only via `enableDirtyRepaints` (default `true`).
    * When disabled, `addQuad`/`render`/`renderRTTNodes` use the legacy full
    * buffer upload path and all slot/dirty bookkeeping stays inert.
    */
@@ -1164,9 +1164,28 @@ export class WebGlRenderer extends CoreRenderer {
     const BYTES = Float32Array.BYTES_PER_ELEMENT;
 
     if (this.useDirtyRepaints === false) {
-      this.uploadFullLegacy(buffer, quadBuffer);
+      this.uploadFullBuffer(buffer, quadBuffer);
     } else {
-      this.uploadDirtyAdaptive(buffer, quadBuffer, BYTES);
+      // Structural realloc (needsFullUpload) or buffer growth past the last
+      // uploaded size always forces a full upload.
+      let fullUpload =
+        this.needsFullUpload || this.curBufferIdx > this.lastUploadedBufferSize;
+
+      // Otherwise decide adaptively: if more than 40% of the render list would
+      // need a surgical upload, a single bulk bufferData is cheaper than that
+      // many bufferSubData calls. The count was accumulated for free during the
+      // addQuad pass, so no separate counting loop is needed here.
+      if (fullUpload === false) {
+        fullUpload =
+          this.dirtyQuadCount >
+          this.stage.renderListLen * FULL_UPLOAD_DIRTY_RATIO;
+      }
+
+      if (fullUpload === true) {
+        this.uploadFullDirty(buffer, quadBuffer);
+      } else {
+        this.uploadSurgicalQuads(buffer, BYTES);
+      }
     }
 
     // Upload the shared SDF buffers (each layout skips the driver copy when
@@ -1193,43 +1212,22 @@ export class WebGlRenderer extends CoreRenderer {
     this.numQuadsRendered = this.quadBufferUsage / QUAD_SIZE_IN_BYTES;
   }
 
-  private uploadFullLegacy(
+  // Full upload for the disabled (opt-out) path: re-uploads the entire quad
+  // buffer with a STATIC_DRAW hint and touches no slot/dirty bookkeeping,
+  // which stays inert while dirty repaints are disabled.
+  private uploadFullBuffer(
     buffer: WebGLBuffer | null,
     quadBuffer: ArrayBuffer,
   ): void {
     const { glw } = this;
-    // Legacy path (pre-PR #861): re-upload the entire quad buffer.
     const arr = new Float32Array(quadBuffer, 0, this.curBufferIdx);
     glw.arrayBufferData(buffer, arr, glw.STATIC_DRAW);
   }
 
-  private uploadDirtyAdaptive(
-    buffer: WebGLBuffer | null,
-    quadBuffer: ArrayBuffer,
-    BYTES: number,
-  ): void {
-    // Structural realloc (needsFullUpload) or buffer growth past the last
-    // uploaded size always forces a full upload.
-    let fullUpload =
-      this.needsFullUpload || this.curBufferIdx > this.lastUploadedBufferSize;
-
-    // Otherwise decide adaptively: if more than 40% of the render list would
-    // need a surgical upload, a single bulk bufferData is cheaper than that
-    // many bufferSubData calls. The count was accumulated for free during the
-    // addQuad pass, so no separate counting loop is needed here.
-    if (fullUpload === false) {
-      fullUpload =
-        this.dirtyQuadCount >
-        this.stage.renderListLen * FULL_UPLOAD_DIRTY_RATIO;
-    }
-
-    if (fullUpload === true) {
-      this.uploadFullDirty(buffer, quadBuffer);
-      return;
-    }
-    this.uploadSurgicalQuads(buffer, BYTES);
-  }
-
+  // Full upload within the enabled path: same bulk bytes as uploadFullBuffer
+  // but with a DYNAMIC_DRAW hint, and it resets the slot/dirty bookkeeping
+  // (upload cursor + dirty flags) so later surgical frames know exactly what
+  // is already on the GPU.
   private uploadFullDirty(
     buffer: WebGLBuffer | null,
     quadBuffer: ArrayBuffer,

--- a/src/main-api/Renderer.ts
+++ b/src/main-api/Renderer.ts
@@ -358,6 +358,20 @@ export type RendererMainSettings = RendererRuntimeSettings &
     quadBufferSize: number;
 
     /**
+     * Enable surgical dirty-quad repaints (PR #861).
+     *
+     * @remarks
+     * When enabled, only the quads that changed are re-uploaded to the GPU
+     * via `bufferSubData` instead of re-uploading the entire quad buffer on
+     * every frame.
+     *
+     * Construction-time only: changing it after construction has no effect.
+     *
+     * @defaultValue `false` (disabled, full buffer upload every frame)
+     */
+    enableDirtyRepaints: boolean;
+
+    /**
      * Font Engines
      *
      * @remarks
@@ -534,6 +548,7 @@ export class RendererMain extends EventEmitter {
       inspectorOptions: settings.inspectorOptions ?? {},
       renderEngine: settings.renderEngine,
       quadBufferSize: settings.quadBufferSize ?? 4 * 1024 * 1024,
+      enableDirtyRepaints: settings.enableDirtyRepaints ?? false,
       fontEngines: settings.fontEngines ?? [],
       textureProcessingTimeLimit: settings.textureProcessingTimeLimit || 42,
       maxTextureUploadsDuringAnimation:
@@ -588,6 +603,7 @@ export class RendererMain extends EventEmitter {
       textureMemory: resolvedTxSettings,
       eventBus: this,
       quadBufferSize: settings.quadBufferSize!,
+      enableDirtyRepaints: settings.enableDirtyRepaints!,
       fontEngines: settings.fontEngines!,
       inspector: settings.inspector !== null,
       targetFPS: settings.targetFPS!,

--- a/src/main-api/Renderer.ts
+++ b/src/main-api/Renderer.ts
@@ -365,9 +365,12 @@ export type RendererMainSettings = RendererRuntimeSettings &
      * via `bufferSubData` instead of re-uploading the entire quad buffer on
      * every frame.
      *
+     * Set to `false` to opt out and restore the legacy behavior of
+     * re-uploading the entire quad buffer on every frame.
+     *
      * Construction-time only: changing it after construction has no effect.
      *
-     * @defaultValue `false` (disabled, full buffer upload every frame)
+     * @defaultValue `true` (enabled, surgical dirty-quad uploads)
      */
     enableDirtyRepaints: boolean;
 
@@ -548,7 +551,7 @@ export class RendererMain extends EventEmitter {
       inspectorOptions: settings.inspectorOptions ?? {},
       renderEngine: settings.renderEngine,
       quadBufferSize: settings.quadBufferSize ?? 4 * 1024 * 1024,
-      enableDirtyRepaints: settings.enableDirtyRepaints ?? false,
+      enableDirtyRepaints: settings.enableDirtyRepaints ?? true,
       fontEngines: settings.fontEngines ?? [],
       textureProcessingTimeLimit: settings.textureProcessingTimeLimit || 42,
       maxTextureUploadsDuringAnimation:


### PR DESCRIPTION
## Summary

Adds a construction-time `enableDirtyRepaints` setting (default `true`) that toggles the surgical dirty-quad repaint behaviour introduced in PR #861.

- `true` (default): PR #861 behaviour — permanent quad slots, dirty-ratio heuristic, surgical `bufferSubData` uploads, dedicated RTT buffer + `renderRTT()` split.
- `false`: opt-out legacy path — full quad buffer re-upload every frame via a single `bufferData(STATIC_DRAW)`; all slot/dirty bookkeeping stays inert.

WebGL-only: `CanvasRenderer` always uses full uploads and is unaffected by this flag.

## Changes

- `src/main-api/Renderer.ts` — new `enableDirtyRepaints` field on `RendererMainSettings` with JSDoc; resolved with `?? true` and forwarded to `Stage`.
- `src/core/Stage.ts` — `requestRenderListUpdate()` only calls `invalidateQuadBuffer()` when enabled.
- `src/core/CoreNode.ts` — both `isQuadDirty` writes (visual-flag block in `update()`, texture setter) gated on the flag.
- `src/core/renderers/webgl/WebGlRenderer.ts` — cached readonly `useDirtyRepaints` flag (set once in the constructor); gates in `addQuad`, `render`, `renderRTTNodes`, `invalidateQuadBuffer`. Upload split into `uploadFullBuffer` (disabled path, no bookkeeping), `uploadFullDirty` (enabled full upload + bookkeeping reset) and `uploadSurgicalQuads`.

## Tests

- Dirty-quad suites run enabled by default, matching the new default.
- Coverage for the disabled opt-out path: full upload with `STATIC_DRAW`, no `bufferSubData`, `invalidateQuadBuffer` no-op, RTT writes into the shared buffer; `CoreNode` stays clean and `Stage` skips invalidation when disabled.
- Verification: `pnpm vitest run` — 17 files / 292 tests pass; eslint 0 errors; prettier clean (`tsc --build` shows only the pre-existing happy-dom type error, also present on clean HEAD).

Refs: #861