### PR TITLE
feat: add runtime shader unregister/update lifecycle

### DIFF
--- a/src/core/CoreShaderManager.test.ts
+++ b/src/core/CoreShaderManager.test.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 Comcast Cable Communications Management, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { CoreShaderManager } from './CoreShaderManager.js';
+import type { Stage } from './Stage.js';
+import type { CoreShaderProgram } from './renderers/CoreShaderProgram.js';
+
+function makeProgram(): CoreShaderProgram & {
+  destroy: ReturnType<typeof vi.fn>;
+} {
+  return {
+    attach: vi.fn(),
+    detach: vi.fn(),
+    destroy: vi.fn(),
+  };
+}
+
+function makeStage(
+  opts: {
+    mode?: 'webgl' | 'canvas';
+    createProgramImpl?: (shType: any, props: any) => CoreShaderProgram | null;
+  } = {},
+) {
+  const programs: CoreShaderProgram[] = [];
+  const renderer = {
+    mode: opts.mode ?? 'webgl',
+    supportsShaderType: vi.fn().mockReturnValue(true),
+    createShaderProgram: vi.fn(
+      (shType: any, props: any): CoreShaderProgram | null => {
+        if (opts.createProgramImpl) {
+          return opts.createProgramImpl(shType, props);
+        }
+        const p = makeProgram();
+        programs.push(p);
+        return p;
+      },
+    ),
+    createShaderNode: vi.fn(
+      (shaderKey: string, shType: any, props: any, program: any) =>
+        ({ shaderKey, shType, props, program } as any),
+    ),
+  };
+  const stage = {
+    renderer,
+    defShaderNode: { shaderKey: 'default' },
+    requestRender: vi.fn(),
+  } as unknown as Stage;
+  return { stage, renderer, programs };
+}
+
+describe('CoreShaderManager dynamic runtime shaders', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('reuses compiled programs via createShader', () => {
+    const { stage, renderer } = makeStage();
+    const manager = new CoreShaderManager(stage);
+    manager.registerShaderType('Live', { fragment: 'v1' } as any);
+
+    manager.createShader('Live' as never);
+    manager.createShader('Live' as never);
+
+    expect(renderer.createShaderProgram).toHaveBeenCalledTimes(1);
+  });
+
+  it('unregister destroys cached programs including cache-marker variants', () => {
+    const { stage } = makeStage();
+    const manager = new CoreShaderManager(stage);
+    manager.registerShaderType('Grad', {
+      fragment: 'src',
+      props: { colors: [0xffffffff] },
+      getCacheMarkers: (props: any) => `colors:${props.colors.length}`,
+    } as any);
+
+    manager.createShader('Grad' as never, { colors: [1] } as any);
+    manager.createShader('Grad' as never, { colors: [1, 2] } as any);
+    const cache = (manager as any).shCache as Map<string, CoreShaderProgram>;
+    expect(cache.size).toBe(2);
+    const destroyed = [...cache.values()].map(
+      (p) => p.destroy as ReturnType<typeof vi.fn>,
+    );
+
+    manager.unregisterShaderType('Grad');
+
+    expect(destroyed[0]).toHaveBeenCalledTimes(1);
+    expect(destroyed[1]).toHaveBeenCalledTimes(1);
+    expect(cache.size).toBe(0);
+    // Same name can be registered again after unregister
+    manager.registerShaderType('Grad', { fragment: 'v2' } as any);
+    expect((manager as any).shTypes['Grad']).toBeDefined();
+  });
+
+  it('update replaces the definition so next createShader compiles new source', () => {
+    const seen: unknown[] = [];
+    const { stage, renderer } = makeStage({
+      createProgramImpl: (shType) => {
+        seen.push((shType as any).fragment);
+        return makeProgram();
+      },
+    });
+    const manager = new CoreShaderManager(stage);
+    manager.registerShaderType('Live', { fragment: 'v1' } as any);
+    manager.createShader('Live' as never);
+
+    manager.updateShaderType('Live', { fragment: 'v2' } as any);
+    manager.createShader('Live' as never);
+
+    expect(seen).toEqual(['v1', 'v2']);
+    expect(renderer.createShaderProgram).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to default shader when compilation throws', () => {
+    const { stage } = makeStage({
+      createProgramImpl: () => {
+        throw new Error('compile failed');
+      },
+    });
+    const manager = new CoreShaderManager(stage);
+    manager.registerShaderType('Bad', { fragment: 'bad glsl' } as any);
+
+    const node = manager.createShader('Bad' as never);
+
+    expect(node).toBe(stage.defShaderNode);
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('unregister of unknown name warns without throwing', () => {
+    const { stage } = makeStage();
+    const manager = new CoreShaderManager(stage);
+    expect(() => manager.unregisterShaderType('Missing')).not.toThrow();
+    expect(console.warn).toHaveBeenCalled();
+  });
+});

--- a/src/core/CoreShaderManager.ts
+++ b/src/core/CoreShaderManager.ts
@@ -76,6 +76,60 @@ export class CoreShaderManager {
   }
 
   /**
+   * Remove a shader type and destroy its compiled programs.
+   *
+   * @remarks
+   * Enables dynamic runtime shaders and hot-reload: after unregistering,
+   * the same name can be registered again with new GLSL source and
+   * re-created via {@link createShader}. Existing shader nodes hold a
+   * direct program reference and are not auto-migrated — callers must
+   * re-create them with `createShader` and reassign `node.shader`.
+   *
+   * Cache entries derived from `getCacheMarkers` (`name-marker`) are
+   * evicted together with the base name.
+   */
+  unregisterShaderType(name: string): void {
+    if (this.shTypes[name] === undefined) {
+      console.warn(
+        `ShaderType not found with the name: ${name}. Nothing to unregister.`,
+      );
+      return;
+    }
+    delete this.shTypes[name];
+    for (const key of [...this.shCache.keys()]) {
+      if (key === name || key.startsWith(`${name}-`)) {
+        const program = this.shCache.get(key);
+        if (program !== undefined) {
+          if (this.attachedShader === program) {
+            this.releaseShader();
+          }
+          program.destroy?.();
+        }
+        this.shCache.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Replace a shader type definition at runtime.
+   *
+   * @remarks
+   * Equivalent to `unregisterShaderType` + `registerShaderType`. Compiled
+   * programs for the old definition are destroyed so the next
+   * {@link createShader} call compiles the new source.
+   */
+  updateShaderType(name: string, shType: CoreShaderType): void {
+    if (this.shTypes[name] === undefined) {
+      console.warn(
+        `ShaderType not found with the name: ${name}. Registering as new.`,
+      );
+    } else {
+      this.unregisterShaderType(name);
+    }
+    this.registerShaderType(name, shType);
+  }
+
+  /**
    * Loads a shader (if not already loaded) and returns a controller for it.
    *
    * @param shType
@@ -121,7 +175,15 @@ export class CoreShaderManager {
      * if shaderProgram was not found create a new one
      */
     if (shProgram === undefined) {
-      shProgram = this.stage.renderer.createShaderProgram(shType, props)!;
+      try {
+        shProgram = this.stage.renderer.createShaderProgram(shType, props)!;
+      } catch (err) {
+        console.warn(
+          `Shader "${shaderKey}" failed to compile falling back on renderer default shader`,
+          err,
+        );
+        return this.stage.defShaderNode;
+      }
       this.shCache.set(shaderKey, shProgram);
     }
 

--- a/src/core/CoreShaderManager.ts
+++ b/src/core/CoreShaderManager.ts
@@ -103,7 +103,9 @@ export class CoreShaderManager {
           if (this.attachedShader === program) {
             this.releaseShader();
           }
-          program.destroy?.();
+          if (program.destroy !== undefined) {
+            program.destroy();
+          }
         }
         this.shCache.delete(key);
       }

--- a/src/core/renderers/CoreShaderProgram.ts
+++ b/src/core/renderers/CoreShaderProgram.ts
@@ -20,4 +20,6 @@
 export interface CoreShaderProgram {
   attach?: () => void;
   detach?: () => void;
+  destroy?: () => void;
+  isDestroyed?: boolean;
 }

--- a/src/main-api/Renderer.ts
+++ b/src/main-api/Renderer.ts
@@ -29,7 +29,10 @@ import type { TextRenderer } from '../core/text-rendering/TextRenderer.js';
 import type { CanvasRenderer } from '../core/renderers/canvas/CanvasRenderer.js';
 import type { WebGlRenderer } from '../core/renderers/webgl/WebGlRenderer.js';
 import type { Inspector, InspectorOptions } from './Inspector.js';
-import type { CoreShaderNode } from '../core/renderers/CoreShaderNode.js';
+import type {
+  CoreShaderNode,
+  CoreShaderType,
+} from '../core/renderers/CoreShaderNode.js';
 import type {
   ExtractShaderProps,
   OptionalShaderProps,
@@ -781,6 +784,31 @@ export class RendererMain extends EventEmitter {
     return this.stage.shManager.createShader(shType, props) as CoreShaderNode<
       NonNullable<ExtractShaderProps<ShType>>
     >;
+  }
+
+  /**
+   * Remove a shader type and destroy its compiled programs.
+   *
+   * @remarks
+   * Enables dynamic runtime shaders and hot-reload: after unregistering,
+   * the same name can be registered again with new GLSL source via
+   * `stage.shManager.registerShaderType` and re-created via `createShader`.
+   * Existing shader nodes are not auto-migrated — re-create them and
+   * reassign `node.shader`.
+   */
+  unregisterShaderType(name: string): void {
+    this.stage.shManager.unregisterShaderType(name);
+  }
+
+  /**
+   * Replace a shader type definition at runtime.
+   *
+   * @remarks
+   * Equivalent to `unregisterShaderType` + `registerShaderType`. The next
+   * `createShader` call compiles the new source.
+   */
+  updateShaderType(name: string, shType: CoreShaderType): void {
+    this.stage.shManager.updateShaderType(name, shType);
   }
 
   /**


### PR DESCRIPTION
Enables dynamic runtime shaders and hot-reload.

Changes:
- CoreShaderManager: add unregisterShaderType (destroys cached programs incl. getCacheMarkers name-marker variants, releases attachedShader) and updateShaderType (unregister + register). Harden createShader with try/catch around createShaderProgram falling back to defShaderNode on bad GLSL.
- CoreShaderProgram: add optional destroy/isDestroyed (already implemented by WebGlShaderProgram).
- RendererMain: thin unregisterShaderType/updateShaderType wrappers.
- Tests: new CoreShaderManager.test.ts (program reuse, unregister eviction + re-register, update recompiles, compile-failure fallback, unknown-name warn).

Usage: updateShaderType(name, nextType), then createShader(name, props) and reassign node.shader. Existing nodes are not auto-migrated.

Verification: new tests 5/5 pass, full suite 292/292 pass, prettier clean, eslint 0 errors. pnpm build failure on happy-dom types is pre-existing on main.