### PR TITLE
chore(deps-dev): bump typescript to 6.0.3 and fix mockStage DeepPartial inference (supersedes #889)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lint-staged": "^17.4.1",
     "prettier": "^2.8.8",
     "typedoc": "^0.28.20",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "vitest": "^3.2.7",
     "vitest-mock-extended": "^3.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,10 +13,10 @@ importers:
         version: 26.4.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.69.0
-        version: 8.69.0(@typescript-eslint/parser@8.69.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5)(typescript@5.9.3)
+        version: 8.69.0(@typescript-eslint/parser@8.69.0(eslint@9.39.5)(typescript@6.0.3))(eslint@9.39.5)(typescript@6.0.3)
       '@typescript-eslint/parser':
         specifier: ^8.69.0
-        version: 8.69.0(eslint@9.39.5)(typescript@5.9.3)
+        version: 8.69.0(eslint@9.39.5)(typescript@6.0.3)
       '@vitest/coverage-v8':
         specifier: ^3.2.7
         version: 3.2.7(vitest@3.2.7(@types/node@26.4.1)(happy-dom@20.14.0)(terser@5.36.0)(yaml@2.9.0))
@@ -43,16 +43,16 @@ importers:
         version: 2.8.8
       typedoc:
         specifier: ^0.28.20
-        version: 0.28.20(typescript@5.9.3)
+        version: 0.28.20(typescript@6.0.3)
       typescript:
-        specifier: ~5.9.3
-        version: 5.9.3
+        specifier: ~6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
         version: 3.2.7(@types/node@26.4.1)(happy-dom@20.14.0)(terser@5.36.0)(yaml@2.9.0)
       vitest-mock-extended:
         specifier: ^3.1.1
-        version: 3.1.1(typescript@5.9.3)(vitest@3.2.7(@types/node@26.4.1)(happy-dom@20.14.0)(terser@5.36.0)(yaml@2.9.0))
+        version: 3.1.1(typescript@6.0.3)(vitest@3.2.7(@types/node@26.4.1)(happy-dom@20.14.0)(terser@5.36.0)(yaml@2.9.0))
 
   examples:
     dependencies:
@@ -3168,8 +3168,8 @@ packages:
     peerDependencies:
       typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -5593,40 +5593,40 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.69.0(@typescript-eslint/parser@8.69.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.69.0(@typescript-eslint/parser@8.69.0(eslint@9.39.5)(typescript@6.0.3))(eslint@9.39.5)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.69.0(eslint@9.39.5)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.69.0(eslint@9.39.5)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.69.0
-      '@typescript-eslint/type-utils': 8.69.0(eslint@9.39.5)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.69.0(eslint@9.39.5)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.69.0(eslint@9.39.5)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.69.0(eslint@9.39.5)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.69.0
       eslint: 9.39.5
       ignore: 7.0.8
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.69.0(eslint@9.39.5)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.69.0(eslint@9.39.5)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.69.0
       '@typescript-eslint/types': 8.69.0
-      '@typescript-eslint/typescript-estree': 8.69.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.69.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.69.0
       debug: 4.4.3
       eslint: 9.39.5
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.69.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.69.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.69.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.69.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.69.0
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5635,47 +5635,47 @@ snapshots:
       '@typescript-eslint/types': 8.69.0
       '@typescript-eslint/visitor-keys': 8.69.0
 
-  '@typescript-eslint/tsconfig-utils@8.69.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.69.0(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.69.0(eslint@9.39.5)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.69.0(eslint@9.39.5)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.69.0
-      '@typescript-eslint/typescript-estree': 8.69.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.69.0(eslint@9.39.5)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.69.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.69.0(eslint@9.39.5)(typescript@6.0.3)
       debug: 4.4.3
       eslint: 9.39.5
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.69.0': {}
 
-  '@typescript-eslint/typescript-estree@8.69.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.69.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.69.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.69.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.69.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.69.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.69.0
       '@typescript-eslint/visitor-keys': 8.69.0
       debug: 4.4.3
       minimatch: 10.2.6
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.69.0(eslint@9.39.5)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.69.0(eslint@9.39.5)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5)
       '@typescript-eslint/scope-manager': 8.69.0
       '@typescript-eslint/types': 8.69.0
-      '@typescript-eslint/typescript-estree': 8.69.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.69.0(typescript@6.0.3)
       eslint: 9.39.5
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6644,13 +6644,13 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  ts-api-utils@2.5.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  ts-essentials@10.2.1(typescript@5.9.3):
+  ts-essentials@10.2.1(typescript@6.0.3):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   tslib@2.8.1: {}
 
@@ -6658,16 +6658,16 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typedoc@0.28.20(typescript@5.9.3):
+  typedoc@0.28.20(typescript@6.0.3):
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9
       markdown-it: 14.3.1
       minimatch: 10.2.6
-      typescript: 5.9.3
+      typescript: 6.0.3
       yaml: 2.9.0
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
 
@@ -6745,10 +6745,10 @@ snapshots:
       terser: 5.36.0
       yaml: 2.9.0
 
-  vitest-mock-extended@3.1.1(typescript@5.9.3)(vitest@3.2.7(@types/node@26.4.1)(happy-dom@20.14.0)(terser@5.36.0)(yaml@2.9.0)):
+  vitest-mock-extended@3.1.1(typescript@6.0.3)(vitest@3.2.7(@types/node@26.4.1)(happy-dom@20.14.0)(terser@5.36.0)(yaml@2.9.0)):
     dependencies:
-      ts-essentials: 10.2.1(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-essentials: 10.2.1(typescript@6.0.3)
+      typescript: 6.0.3
       vitest: 3.2.7(@types/node@26.4.1)(happy-dom@20.14.0)(terser@5.36.0)(yaml@2.9.0)
 
   vitest@3.2.7(@types/node@26.4.1)(happy-dom@20.14.0)(terser@5.36.0)(yaml@2.9.0):

--- a/test/mockStage.ts
+++ b/test/mockStage.ts
@@ -39,6 +39,24 @@ export interface MockStageDimensions {
 }
 
 /**
+ * The implementation argument accepted by `mock<T>()`, i.e. `DeepPartial<T>`.
+ *
+ * `DeepPartial` recurses structurally through every nested type, and `Stage`
+ * transitively reaches the DOM lib via `renderer.canvas`. TypeScript 5.x gave
+ * up on that comparison early and treated it as assignable; TypeScript 6 walks
+ * far enough to surface mismatches deep inside the DOM types (e.g.
+ * `StylePropertyMapReadOnly` vs `ReadonlyMap`), so concrete values are rejected
+ * as incompatible with their own deep-partial form.
+ *
+ * The defaults below are deliberately concrete, so the argument is cast as a
+ * whole. This is purely a type-level escape hatch — the object is still handed
+ * to `mock()` unchanged, which matters because `mock()` recursively wraps
+ * nested objects in proxies. Building the mock and assigning afterwards would
+ * silently drop that behaviour.
+ */
+type MockImpl<T> = Parameters<typeof mock<T>>[0];
+
+/**
  * Build a `mock<Stage>` pre-populated with the scaffolding required to
  * construct core nodes.
  *
@@ -65,7 +83,7 @@ export function makeMockStage(
     } as unknown as Stage['interactiveNodes'],
     renderer: mock<CoreRenderer>() as CoreRenderer,
     ...overrides,
-  });
+  } as unknown as MockImpl<Stage>);
 }
 
 /**


### PR DESCRIPTION
Supersedes #889.

## Why #889 fails

CI reports only `Command failed with exit code 2: pnpm build:renderer` because the visual-regression runner swallows child stdout. The real failure is `tsc --build` producing three errors, all in `test/mockStage.ts`:

```
test/mockStage.ts(55,3):  error TS2740: Type '_MockProxy<T>' is missing the following
                          properties from type 'Stage': animationManager, txManager, ...
test/mockStage.ts(61,5):  error TS2322: Type 'Set<CoreNode>' is not assignable to
                          type 'Set<{ readonly children?: ... }>'
test/mockStage.ts(66,5):  error TS2322: Type 'CoreRenderer' is not assignable to
                          type '{ mode?: "webgl" | "canvas" | undefined; ... }'
```

Only two are real. I probed each argument in isolation and the TS2740 on the return type is a **cascade** — when the implementation argument fails to match, inference for `T` bails and the return collapses to `_MockProxy<T>`. Fix the argument and it clears on its own.

### Root cause

`vitest-mock-extended` types `mock()`'s implementation argument as `DeepPartial<T>` (from `ts-essentials`):

```ts
declare const mock: <T, MockedReturn extends MockProxy<T> & T = MockProxy<T> & T>(
  mockImplementation?: DeepPartial<T>, opts?: MockOpts
) => MockedReturn;
```

`DeepPartial` recurses structurally through every nested type, and `Stage` transitively reaches the entire DOM lib via `renderer.canvas`. The full error elaboration walks ~20 levels: `HTMLCanvasElement` → `offsetParent` → `attributes` → `ownerDocument` → `anchors` → `shadowRoot` → `childNodes` → `parentElement` → `assignedSlot` → `attributeStyleMap`, bottoming out at `StylePropertyMapReadOnly` not being assignable to `ReadonlyMap`.

TypeScript 5.x gave up on that comparison early and treated it as assignable. TypeScript 6 walks far enough to surface the mismatch, so concrete values are now rejected as incompatible with their own deep-partial form.

This is not a `vitest-mock-extended` incompatibility — it declares `typescript: "3.x || 4.x || 5.x || 6.x"` and the peer resolves cleanly.

## The fix

Cast the implementation argument as a whole, with a comment explaining why.

I deliberately did **not** restructure the helper into `mock<Stage>()` + `Object.assign`, which looks cleaner but is wrong. `overrideMockImp` recursively wraps nested plain objects in proxies:

```js
const overrideMockImp = (obj, opts) => {
  const proxy = new Proxy(obj, handler(opts));
  for (const name of Object.keys(obj)) {
    if (typeof obj[name] === 'object' && obj[name] !== null) {
      proxy[name] = overrideMockImp(obj[name], opts);   // <- recursive
    } ...
```

Assigning after construction would leave `defaultTexture` as a plain object, so unknown property access would return `undefined` instead of an auto-created mock fn — a silent behavioural change in the test scaffolding. The cast keeps the object flowing into `mock()` untouched.

## Verification

The important one for a published library: **`dist/` is byte-identical between 5.9.3 and 6.0.3** across all 360 files (`diff -rq` reports zero differences). Consumers see no change in emitted JS or `.d.ts`.

- `pnpm build` (`tsc --build`) — clean, no new deprecation warnings
- `pnpm test` — 292 passed (17 files)
- `visual-regression` `tsc --noEmit` — clean
- `pnpm test:visual --filter "alpha-blending*"` — exit 0
- `pnpm lint:eslint` — 932 warnings / 0 errors, **identical to main**; no typescript-eslint unsupported-version warning
- `prettier --check` clean on changed files

## One thing worth deciding separately

TypeScript's `latest` dist-tag is already **7.0.2** — 6.0 is a transitional release ahead of the Go-native port. This PR takes the incremental step to 6.0.3 (matching what Dependabot proposed) since it's verifiably output-neutral. Whether to go to 7 is a bigger question worth its own evaluation, and I'd suggest not folding it in here.
